### PR TITLE
chore(agent-ui): add npm publish workflow and package boundary policy

### DIFF
--- a/.github/workflows/publish-agent-ui.yml
+++ b/.github/workflows/publish-agent-ui.yml
@@ -44,7 +44,7 @@ jobs:
           TAG_VERSION="${GITHUB_REF_NAME#agent-ui-v}"
           PKG_VERSION="$(node -p "require('./packages/agent-ui/package.json').version")"
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match @tangle/agent-ui version ($PKG_VERSION)"
+            echo "Tag version ($TAG_VERSION) does not match @tangle-network/agent-ui version ($PKG_VERSION)"
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ The UI uses two shared packages. Keep responsibilities strict to avoid copy/past
   - Blueprint and chain infrastructure (`publicClient`, chain/address helpers, ABI exports)
   - Job/provisioning/quote utilities, infra/session/tx stores
   - Reusable cross-blueprint UI primitives and layout components
-- `@tangle/agent-ui`:
+- `@tangle-network/agent-ui`:
   - Agent chat/session rendering, run/tool timeline UI, markdown/tool previews
   - Sidecar auth/session hooks and PTY terminal integration
-  - Shared lightweight UI utilities in `@tangle/agent-ui/primitives`
+  - Shared lightweight UI utilities in `@tangle-network/agent-ui/primitives`
   - Published from this repo via `.github/workflows/publish-agent-ui.yml`
 - App-local (`ui/src/**`):
   - Sandbox-specific routes, workflows, feature copy, and product behavior

--- a/packages/agent-ui/CLAUDE.md
+++ b/packages/agent-ui/CLAUDE.md
@@ -1,7 +1,7 @@
 # Project Instructions
 
 ## Mission
-`@tangle/agent-ui` is a shared package for agent-facing UX primitives and flows. Treat it as a reusable library, not an app.
+`@tangle-network/agent-ui` is a shared package for agent-facing UX primitives and flows. Treat it as a reusable library, not an app.
 
 ## Scope
 Include:

--- a/packages/agent-ui/README.md
+++ b/packages/agent-ui/README.md
@@ -1,14 +1,14 @@
-# @tangle/agent-ui
+# @tangle-network/agent-ui
 
 Shared agent-facing UI package for Tangle apps.
 
 ## Scope
 
-Put code in `@tangle/agent-ui` when it is:
+Put code in `@tangle-network/agent-ui` when it is:
 - Agent chat/session UX (`ChatContainer`, run timeline, tool previews)
 - Agent markdown rendering and tool/result presentation
 - Sidecar auth/session orchestration and PTY terminal integration
-- Reusable agent-focused primitives/hooks (`@tangle/agent-ui/primitives`)
+- Reusable agent-focused primitives/hooks (`@tangle-network/agent-ui/primitives`)
 
 Do not put code here when it is:
 - Chain/contract/provisioning infra (belongs in `@tangle/blueprint-ui`)
@@ -18,21 +18,21 @@ Do not put code here when it is:
 ## Public API
 
 Entrypoints:
-- `@tangle/agent-ui`: main agent components/hooks/types
-- `@tangle/agent-ui/primitives`: small shared helpers/hooks for consumer UIs
-- `@tangle/agent-ui/terminal`: lazy terminal view entry
-- `@tangle/agent-ui/styles`: package stylesheet
+- `@tangle-network/agent-ui`: main agent components/hooks/types
+- `@tangle-network/agent-ui/primitives`: small shared helpers/hooks for consumer UIs
+- `@tangle-network/agent-ui/terminal`: lazy terminal view entry
+- `@tangle-network/agent-ui/styles`: package stylesheet
 
 Treat exported symbols as stable contract; prefer additive changes over breaking renames/removals.
 
 ## Usage
 
 ```tsx
-import { ChatContainer, useWagmiSidecarAuth } from '@tangle/agent-ui';
-import { copyText, timeAgo } from '@tangle/agent-ui/primitives';
+import { ChatContainer, useWagmiSidecarAuth } from '@tangle-network/agent-ui';
+import { copyText, timeAgo } from '@tangle-network/agent-ui/primitives';
 
 const TerminalView = React.lazy(() =>
-  import('@tangle/agent-ui/terminal').then((m) => ({ default: m.TerminalView })),
+  import('@tangle-network/agent-ui/terminal').then((m) => ({ default: m.TerminalView })),
 );
 ```
 
@@ -42,13 +42,13 @@ If Sandbox and Arena share substantial agent-facing code (roughly 20+ lines), ex
 
 ## Release
 
-- Publish target: npm package `@tangle/agent-ui`
+- Publish target: npm package `@tangle-network/agent-ui`
 - Workflow: `.github/workflows/publish-agent-ui.yml`
 - Tag format: `agent-ui-vX.Y.Z` (must match `packages/agent-ui/package.json` version)
 
 ## Repo Strategy
 
-`@tangle/agent-ui` is a cross-product package for shared agent experience building blocks.
+`@tangle-network/agent-ui` is a cross-product package for shared agent experience building blocks.
 
 Keep it in this repo while:
 1. Most API changes are driven by sandbox-runtime sidecar integration work.
@@ -63,6 +63,6 @@ Split to its own repo when:
 
 Before merging changes that touch agent UX:
 1. Check if the same pattern exists in both UIs.
-2. If yes and app-agnostic, move it into `@tangle/agent-ui`.
+2. If yes and app-agnostic, move it into `@tangle-network/agent-ui`.
 3. Keep exports explicit in `src/index.ts` or `src/primitives.ts`.
 4. Verify both consumers still typecheck/build after the change.

--- a/packages/agent-ui/package.json
+++ b/packages/agent-ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tangle/agent-ui",
+  "name": "@tangle-network/agent-ui",
   "version": "0.2.0",
   "description": "Shared agent UI components and sidecar integration hooks for Tangle blueprints",
   "type": "module",
@@ -38,11 +38,21 @@
     "wagmi": "^3.0.0"
   },
   "peerDependenciesMeta": {
-    "@tanstack/react-query": { "optional": true },
-    "@xterm/xterm": { "optional": true },
-    "@xterm/addon-fit": { "optional": true },
-    "@xterm/addon-web-links": { "optional": true },
-    "wagmi": { "optional": true }
+    "@tanstack/react-query": {
+      "optional": true
+    },
+    "@xterm/xterm": {
+      "optional": true
+    },
+    "@xterm/addon-fit": {
+      "optional": true
+    },
+    "@xterm/addon-web-links": {
+      "optional": true
+    },
+    "wagmi": {
+      "optional": true
+    }
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/packages/agent-ui/src/index.ts
+++ b/packages/agent-ui/src/index.ts
@@ -1,5 +1,5 @@
 // ---------------------------------------------------------------------------
-// @tangle/agent-ui — shared components for agentic chat UIs
+// @tangle-network/agent-ui — shared components for agentic chat UIs
 // ---------------------------------------------------------------------------
 
 // Types

--- a/packages/agent-ui/src/terminal.ts
+++ b/packages/agent-ui/src/terminal.ts
@@ -1,12 +1,12 @@
 // ---------------------------------------------------------------------------
-// @tangle/agent-ui/terminal — xterm.js terminal component (lazy-loadable)
+// @tangle-network/agent-ui/terminal — xterm.js terminal component (lazy-loadable)
 //
 // Separated from the main entry to avoid bundling xterm.js (~334KB) for
 // consumers who only need chat components.
 //
 // Usage:
 //   const TerminalView = lazy(() =>
-//     import('@tangle/agent-ui/terminal').then(m => ({ default: m.TerminalView }))
+//     import('@tangle-network/agent-ui/terminal').then(m => ({ default: m.TerminalView }))
 //   );
 // ---------------------------------------------------------------------------
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,7 +108,7 @@ importers:
       '@react-router/node':
         specifier: ^7.13.0
         version: 7.13.0(react-router@7.13.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.9.3)
-      '@tangle/agent-ui':
+      '@tangle-network/agent-ui':
         specifier: workspace:*
         version: link:../packages/agent-ui
       '@tangle/blueprint-ui':

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,7 +23,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-router/node": "^7.13.0",
-    "@tangle/agent-ui": "workspace:*",
+    "@tangle-network/agent-ui": "workspace:*",
     "@tangle/blueprint-ui": "link:../../blueprint-ui",
     "@tanstack/react-query": "^5.90.16",
     "@xterm/addon-fit": "^0.11.0",

--- a/ui/src/components/layout/TxDropdown.tsx
+++ b/ui/src/components/layout/TxDropdown.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react';
 import { txListStore, pendingCount, clearTxs, type TrackedTx } from '@tangle/blueprint-ui';
-import { timeAgo, useDropdownMenu } from '@tangle/agent-ui/primitives';
+import { timeAgo, useDropdownMenu } from '@tangle-network/agent-ui/primitives';
 
 function StatusIcon({ status }: { status: TrackedTx['status'] }) {
   if (status === 'pending') return <div className="w-4 h-4 rounded-full border-2 border-violet-500/40 border-t-violet-400 animate-spin shrink-0" />;

--- a/ui/src/components/layout/WalletButton.tsx
+++ b/ui/src/components/layout/WalletButton.tsx
@@ -13,7 +13,7 @@ import {
   truncateAddress,
   useDropdownMenu,
   useWalletEthBalance,
-} from '@tangle/agent-ui/primitives';
+} from '@tangle-network/agent-ui/primitives';
 import { toast } from 'sonner';
 
 /**

--- a/ui/src/components/shared/SessionSidebar.tsx
+++ b/ui/src/components/shared/SessionSidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useStore } from '@nanostores/react';
-import { ChatContainer, type AgentBranding } from '@tangle/agent-ui';
+import { ChatContainer, type AgentBranding } from '@tangle-network/agent-ui';
 import type { SandboxClient } from '~/lib/api/sandboxClient';
 import {
   chatSessionsStore,

--- a/ui/src/lib/hooks/useSandboxSession.ts
+++ b/ui/src/lib/hooks/useSandboxSession.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
-import type { SessionMessage, SessionPart, TextPart, ToolPart } from '@tangle/agent-ui';
+import type { SessionMessage, SessionPart, TextPart, ToolPart } from '@tangle-network/agent-ui';
 import type { SandboxClient } from '~/lib/api/sandboxClient';
 import {
   appendMessage,

--- a/ui/src/lib/hooks/useWagmiSidecarAuth.ts
+++ b/ui/src/lib/hooks/useWagmiSidecarAuth.ts
@@ -1,1 +1,1 @@
-export { useWagmiSidecarAuth } from '@tangle/agent-ui';
+export { useWagmiSidecarAuth } from '@tangle-network/agent-ui';

--- a/ui/src/lib/stores/chatSessions.test.ts
+++ b/ui/src/lib/stores/chatSessions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import type { SessionMessage, SessionPart } from '@tangle/agent-ui';
+import type { SessionMessage, SessionPart } from '@tangle-network/agent-ui';
 import {
   chatSessionsStore,
   createSession,

--- a/ui/src/lib/stores/chatSessions.ts
+++ b/ui/src/lib/stores/chatSessions.ts
@@ -1,5 +1,5 @@
 import { atom } from 'nanostores';
-import type { SessionMessage, SessionPart } from '@tangle/agent-ui';
+import type { SessionMessage, SessionPart } from '@tangle-network/agent-ui';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/ui/src/routes/instances.$id.tsx
+++ b/ui/src/routes/instances.$id.tsx
@@ -24,7 +24,7 @@ import { INSTANCE_OPERATOR_API_URL, OPERATOR_API_URL } from '~/lib/config';
 import { cn } from '@tangle/blueprint-ui';
 
 const TerminalView = lazy(() =>
-  import('@tangle/agent-ui/terminal').then((m) => ({ default: m.TerminalView })),
+  import('@tangle-network/agent-ui/terminal').then((m) => ({ default: m.TerminalView })),
 );
 
 type ActionTab = 'overview' | 'terminal' | 'chat' | 'attestation';

--- a/ui/src/routes/sandboxes.$id.tsx
+++ b/ui/src/routes/sandboxes.$id.tsx
@@ -32,7 +32,7 @@ import { cn } from '@tangle/blueprint-ui';
 import { ConfirmDialog } from '~/components/shared/ConfirmDialog';
 
 const TerminalView = lazy(() =>
-  import('@tangle/agent-ui/terminal').then((m) => ({ default: m.TerminalView }))
+  import('@tangle-network/agent-ui/terminal').then((m) => ({ default: m.TerminalView }))
 );
 
 type ActionTab = 'overview' | 'terminal' | 'chat' | 'ssh' | 'secrets' | 'attestation';

--- a/ui/src/test/stubs/agent-ui.ts
+++ b/ui/src/test/stubs/agent-ui.ts
@@ -1,3 +1,3 @@
-// Stub for @tangle/agent-ui — optional peer dep of @tangle/blueprint-ui.
+// Stub for @tangle-network/agent-ui — optional peer dep of @tangle/blueprint-ui.
 // Only needed during vitest pre-bundling; the real package is available at runtime.
 export const useSidecarAuth = () => ({ token: null, isLoading: false });

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -124,7 +124,7 @@ export default defineConfig({
     // Force Vite to bundle workspace-linked packages during SSR module
     // evaluation instead of trying to resolve them via Node.
     noExternal: [
-      '@tangle/agent-ui',
+      '@tangle-network/agent-ui',
       '@tangle/blueprint-ui',
     ],
   },
@@ -142,7 +142,7 @@ export default defineConfig({
       '@radix-ui/react-separator',
       '@radix-ui/react-slot',
       '@radix-ui/react-tabs',
-      '@tangle/agent-ui',
+      '@tangle-network/agent-ui',
       'blo',
       'class-variance-authority',
       'clsx',

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -5,9 +5,9 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   resolve: {
     alias: {
-      // @tangle/agent-ui is an optional peer dep of blueprint-ui — stub it
+      // @tangle-network/agent-ui is an optional peer dep of blueprint-ui — stub it
       // so the optimizer doesn't fail when pre-bundling blueprint-ui.
-      '@tangle/agent-ui': new URL('./src/test/stubs/agent-ui.ts', import.meta.url).pathname,
+      '@tangle-network/agent-ui': new URL('./src/test/stubs/agent-ui.ts', import.meta.url).pathname,
     },
     dedupe: [
       'class-variance-authority',
@@ -30,7 +30,7 @@ export default defineConfig({
       optimizer: {
         web: {
           include: ['@tangle/blueprint-ui'],
-          exclude: ['@tangle/agent-ui'],
+          exclude: ['@tangle-network/agent-ui'],
         },
       },
     },


### PR DESCRIPTION
## Summary
- add a dedicated npm publish workflow for `@tangle-network/agent-ui`
- publish on `agent-ui-v*` tags (with a version/tag guard) and manual dispatch
- migrate package scope/imports from `@tangle/agent-ui` to `@tangle-network/agent-ui`
- document package ownership boundaries and repo split criteria
- remove `sandbox-ui` naming reference from docs

## Validation
- `pnpm -C packages/agent-ui typecheck`
- `pnpm -C packages/agent-ui build`
- `pnpm -C ui exec tsc --noEmit`
- `pnpm -C ui test`
- `cargo check --workspace`