### PR TITLE
fix(agent-ui): add package repository metadata for npm provenance

### DIFF
--- a/packages/agent-ui/package.json
+++ b/packages/agent-ui/package.json
@@ -2,6 +2,15 @@
   "name": "@tangle-network/agent-ui",
   "version": "0.2.0",
   "description": "Shared agent UI components and sidecar integration hooks for Tangle blueprints",
+  "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tangle-network/ai-agent-sandbox-blueprint"
+  },
+  "homepage": "https://github.com/tangle-network/ai-agent-sandbox-blueprint",
+  "bugs": {
+    "url": "https://github.com/tangle-network/ai-agent-sandbox-blueprint/issues"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- add `license`, `repository`, `homepage`, and `bugs` metadata to `packages/agent-ui/package.json`

## Why
- npm provenance publish was failing with E422 because `repository.url` was empty and did not match the GitHub repo in provenance metadata

## Validation
- pnpm -C packages/agent-ui typecheck
- pnpm -C packages/agent-ui build
