### PR TITLE
ci(agent-ui): normalize publish surface and move to OIDC-only auth

### DIFF
--- a/.github/workflows/publish-agent-ui.yml
+++ b/.github/workflows/publish-agent-ui.yml
@@ -5,10 +5,19 @@ on:
     tags:
       - 'agent-ui-v*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Package version to publish (must match packages/agent-ui/package.json)'
+        required: true
+        type: string
 
 permissions:
   contents: read
   id-token: write
+
+concurrency:
+  group: npm-publish-${{ github.repository }}-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   publish:
@@ -21,12 +30,13 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
@@ -38,18 +48,34 @@ jobs:
       - name: Build package
         run: pnpm -C packages/agent-ui build
 
-      - name: Ensure tag matches package version
-        if: startsWith(github.ref, 'refs/tags/agent-ui-v')
+      - name: Validate publish target
+        id: validate
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#agent-ui-v}"
+          PKG_NAME="@tangle-network/agent-ui"
           PKG_VERSION="$(node -p "require('./packages/agent-ui/package.json').version")"
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match @tangle-network/agent-ui version ($PKG_VERSION)"
+          EXPECTED_VERSION=""
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            EXPECTED_VERSION="${{ github.event.inputs.version }}"
+          elif [ "${GITHUB_REF_TYPE}" = "tag" ] && [[ "${GITHUB_REF_NAME}" == agent-ui-v* ]]; then
+            EXPECTED_VERSION="${GITHUB_REF_NAME#agent-ui-v}"
+          else
+            echo "Unsupported trigger or tag format."
             exit 1
           fi
 
+          if [ "${EXPECTED_VERSION}" != "${PKG_VERSION}" ]; then
+            echo "Version mismatch: expected ${EXPECTED_VERSION}, package.json has ${PKG_VERSION}"
+            exit 1
+          fi
+
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "${PKG_NAME}@${PKG_VERSION} is already published."
+            exit 1
+          fi
+
+          echo "version=${PKG_VERSION}" >> "${GITHUB_OUTPUT}"
+
       - name: Publish package
         working-directory: packages/agent-ui
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public --provenance

--- a/packages/agent-ui/README.md
+++ b/packages/agent-ui/README.md
@@ -44,7 +44,10 @@ If Sandbox and Arena share substantial agent-facing code (roughly 20+ lines), ex
 
 - Publish target: npm package `@tangle-network/agent-ui`
 - Workflow: `.github/workflows/publish-agent-ui.yml`
-- Tag format: `agent-ui-vX.Y.Z` (must match `packages/agent-ui/package.json` version)
+- Triggers:
+  - Push tag `agent-ui-vX.Y.Z` (must match `packages/agent-ui/package.json` version)
+  - Manual `workflow_dispatch` with `version` input (must match package version)
+- Publish auth: npm Trusted Publishing (OIDC), no long-lived npm token required once configured
 
 ## Repo Strategy
 

--- a/packages/agent-ui/package.json
+++ b/packages/agent-ui/package.json
@@ -11,6 +11,9 @@
   "bugs": {
     "url": "https://github.com/tangle-network/ai-agent-sandbox-blueprint/issues"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- standardize agent-ui publish workflow to package-specific tag and manual version input
- add strict version validation for both tag and workflow_dispatch publishes
- add published-version guard to fail early if target version already exists
- switch workflow to OIDC-only publish (remove NODE_AUTH_TOKEN dependency)
- add publish concurrency control and align pnpm setup to v10
- add publish metadata consistency in package.json (publishConfig.access)
- update package README publish section to match workflow behavior

## Validation
- pnpm -C packages/agent-ui typecheck
- pnpm -C packages/agent-ui build
