### PR TITLE
docs: point shared UI package docs to npm install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,13 @@ The UI uses two shared packages. Keep responsibilities strict to avoid copy/past
   - Blueprint and chain infrastructure (`publicClient`, chain/address helpers, ABI exports)
   - Job/provisioning/quote utilities, infra/session/tx stores
   - Reusable cross-blueprint UI primitives and layout components
+  - npm: https://www.npmjs.com/package/@tangle-network/blueprint-ui
 - `@tangle-network/agent-ui`:
   - Agent chat/session rendering, run/tool timeline UI, markdown/tool previews
   - Sidecar auth/session hooks and PTY terminal integration
   - Shared lightweight UI utilities in `@tangle-network/agent-ui/primitives`
   - Published from this repo via `.github/workflows/publish-agent-ui.yml`
+  - npm: https://www.npmjs.com/package/@tangle-network/agent-ui
 - App-local (`ui/src/**`):
   - Sandbox-specific routes, workflows, feature copy, and product behavior
   - Sandbox-only shell/layout styling concerns

--- a/packages/agent-ui/README.md
+++ b/packages/agent-ui/README.md
@@ -25,6 +25,14 @@ Entrypoints:
 
 Treat exported symbols as stable contract; prefer additive changes over breaking renames/removals.
 
+## Installation
+
+```bash
+npm install @tangle-network/agent-ui
+# or
+pnpm add @tangle-network/agent-ui
+```
+
 ## Usage
 
 ```tsx


### PR DESCRIPTION
## Summary
- add npm package links for shared UI packages in root README
- add install section for @tangle-network/agent-ui in package README

No runtime code changes.