### PR TITLE
ci(agent-ui): hard enforce tokenless OIDC publish

### DIFF
--- a/.github/workflows/publish-agent-ui.yml
+++ b/.github/workflows/publish-agent-ui.yml
@@ -23,6 +23,8 @@ jobs:
   publish:
     if: github.repository == 'tangle-network/ai-agent-sandbox-blueprint'
     runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ''
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,7 +39,6 @@ jobs:
         with:
           node-version: '22'
           cache: pnpm
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- set job-level NODE_AUTH_TOKEN to empty to prevent token-based npm auth
- remove setup-node registry-url auth path

This enforces OIDC-only publish even if org/repo secrets still define npm tokens.