### PR TITLE
fix(ui): stabilize wallet connection and operator auth across navigation

### DIFF
--- a/sandbox-runtime/src/operator_api.rs
+++ b/sandbox-runtime/src/operator_api.rs
@@ -3396,6 +3396,7 @@ mod tests {
             .collect();
         assert!(ids.iter().any(|id| *id == session_id));
 
+        insert_instance_sandbox("live-inst-1", OP_TEST_OWNER);
         let detail = app()
             .oneshot(
                 Request::builder()
@@ -3412,6 +3413,7 @@ mod tests {
         assert_eq!(detail_json["title"], "Ops Chat");
         assert!(detail_json["messages"].is_array());
 
+        insert_instance_sandbox("live-inst-1", OP_TEST_OWNER);
         let stream = app()
             .oneshot(
                 Request::builder()
@@ -3432,6 +3434,7 @@ mod tests {
             .unwrap_or("");
         assert!(ct.contains("text/event-stream"));
 
+        insert_instance_sandbox("live-inst-1", OP_TEST_OWNER);
         let deleted = app()
             .oneshot(
                 Request::builder()

--- a/sandbox-runtime/src/operator_api.rs
+++ b/sandbox-runtime/src/operator_api.rs
@@ -3376,6 +3376,7 @@ mod tests {
         let session_id = created["session_id"].as_str().unwrap().to_string();
         assert_eq!(created["title"], "Ops Chat");
 
+        insert_instance_sandbox("live-inst-1", OP_TEST_OWNER);
         let list = app()
             .oneshot(
                 Request::builder()
@@ -3551,6 +3552,7 @@ mod tests {
             .expect("chat session_id")
             .to_string();
 
+        insert_instance_sandbox_with_url("live-prompt-inst-1", OP_TEST_OWNER, &sidecar_url);
         let stream = app()
             .oneshot(
                 Request::builder()
@@ -3569,6 +3571,7 @@ mod tests {
             "message": "hello from live stream",
             "session_id": session_id,
         });
+        insert_instance_sandbox_with_url("live-prompt-inst-1", OP_TEST_OWNER, &sidecar_url);
         let prompt = app()
             .oneshot(
                 Request::builder()
@@ -3593,6 +3596,7 @@ mod tests {
             "expected chat stream event, got: {frame}"
         );
 
+        insert_instance_sandbox_with_url("live-prompt-inst-1", OP_TEST_OWNER, &sidecar_url);
         let detail = app()
             .oneshot(
                 Request::builder()

--- a/ui/src/lib/hooks/useOperatorAuth.test.ts
+++ b/ui/src/lib/hooks/useOperatorAuth.test.ts
@@ -16,7 +16,7 @@ vi.mock('~/lib/config', () => ({
   OPERATOR_API_URL: 'http://test-operator:9090',
 }));
 
-import { useOperatorAuth } from './useOperatorAuth';
+import { resetOperatorAuthStoreForTests, useOperatorAuth } from './useOperatorAuth';
 
 // ── Helpers ──
 
@@ -42,6 +42,7 @@ describe('useOperatorAuth', () => {
     currentAddress = mockAddress;
     mockSignMessageAsync.mockReset();
     vi.restoreAllMocks();
+    resetOperatorAuthStoreForTests();
   });
 
   afterEach(() => {
@@ -306,7 +307,7 @@ describe('useOperatorAuth', () => {
 
   it('clears session when wallet address changes', async () => {
     const futureExpiry = Math.floor(Date.now() / 1000) + 3600;
-    mockFetchResponses(
+    const fetchMock = mockFetchResponses(
       { message: 'Sign this', nonce: 'abc' },
       { token: 'v4.public.first-addr', expires_at: futureExpiry },
     );
@@ -326,12 +327,26 @@ describe('useOperatorAuth', () => {
     currentAddress = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
     rerender();
 
-    // The useEffect clears sessionRef AFTER the render phase, so we need
-    // a second rerender for isAuthenticated to reflect the cleared ref.
-    rerender();
-
-    // Session should be cleared by the useEffect
     expect(result.current.isAuthenticated).toBe(false);
+
+    fetchMock.mockClear();
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/api/auth/challenge')) {
+        return { ok: true, json: async () => ({ message: 'Sign for new wallet', nonce: 'def' }) };
+      }
+      if (url.includes('/api/auth/session')) {
+        return { ok: true, json: async () => ({ token: 'v4.public.second-addr', expires_at: futureExpiry }) };
+      }
+      return { ok: false, text: async () => 'Unknown endpoint' };
+    });
+
+    let token: string | null = null;
+    await act(async () => {
+      token = await result.current.getToken();
+    });
+
+    expect(token).toBe('v4.public.second-addr');
+    expect(fetchMock).toHaveBeenCalled();
   });
 
   // ── Uses custom apiUrl ──
@@ -374,6 +389,95 @@ describe('useOperatorAuth', () => {
       'http://test-operator:9090/api/auth/challenge',
       expect.any(Object),
     );
+  });
+
+  it('reuses a valid shared token after hook remount', async () => {
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600;
+    const fetchMock = mockFetchResponses(
+      { message: 'Sign this', nonce: 'abc' },
+      { token: 'v4.public.shared', expires_at: futureExpiry },
+    );
+    mockSignMessageAsync.mockResolvedValue('0xsig');
+
+    const first = renderHook(() => useOperatorAuth('http://test:9090'));
+    await act(async () => {
+      await first.result.current.getToken();
+    });
+    first.unmount();
+
+    fetchMock.mockClear();
+
+    const second = renderHook(() => useOperatorAuth('http://test:9090'));
+    let token: string | null = null;
+    await act(async () => {
+      token = await second.result.current.getToken();
+    });
+
+    expect(token).toBe('v4.public.shared');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mockSignMessageAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates concurrent auth across hook instances for the same key', async () => {
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600;
+    const fetchMock = mockFetchResponses(
+      { message: 'Sign this', nonce: 'abc' },
+      { token: 'v4.public.concurrent', expires_at: futureExpiry },
+    );
+    mockSignMessageAsync.mockResolvedValue('0xsig');
+
+    const first = renderHook(() => useOperatorAuth('http://test:9090'));
+    const second = renderHook(() => useOperatorAuth('http://test:9090'));
+
+    let tokens: Array<string | null> = [];
+    await act(async () => {
+      tokens = await Promise.all([
+        first.result.current.getToken(),
+        second.result.current.getToken(),
+      ]);
+    });
+
+    expect(tokens).toEqual(['v4.public.concurrent', 'v4.public.concurrent']);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(mockSignMessageAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not share cached tokens across operator URLs', async () => {
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600;
+    const fetchMock = vi.fn();
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === 'http://first:9090/api/auth/challenge') {
+        return { ok: true, json: async () => ({ message: 'Sign first', nonce: 'first' }) };
+      }
+      if (url === 'http://first:9090/api/auth/session') {
+        return { ok: true, json: async () => ({ token: 'v4.public.first', expires_at: futureExpiry }) };
+      }
+      if (url === 'http://second:9090/api/auth/challenge') {
+        return { ok: true, json: async () => ({ message: 'Sign second', nonce: 'second' }) };
+      }
+      if (url === 'http://second:9090/api/auth/session') {
+        return { ok: true, json: async () => ({ token: 'v4.public.second', expires_at: futureExpiry }) };
+      }
+      return { ok: false, text: async () => 'Unknown endpoint' };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    mockSignMessageAsync.mockResolvedValue('0xsig');
+
+    const first = renderHook(() => useOperatorAuth('http://first:9090'));
+    const second = renderHook(() => useOperatorAuth('http://second:9090'));
+
+    await act(async () => {
+      await first.result.current.getToken();
+    });
+
+    fetchMock.mockClear();
+
+    await act(async () => {
+      await second.result.current.getToken();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('http://second:9090/api/auth/challenge', expect.any(Object));
+    expect(mockSignMessageAsync).toHaveBeenCalledTimes(2);
   });
 
   // ── Auth flow sends correct payloads ──

--- a/ui/src/lib/hooks/useOperatorAuth.ts
+++ b/ui/src/lib/hooks/useOperatorAuth.ts
@@ -1,10 +1,72 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import { useAccount, useSignMessage } from 'wagmi';
 import { OPERATOR_API_URL } from '~/lib/config';
 
 interface OperatorSession {
   token: string;
   expiresAt: number;
+}
+
+interface OperatorAuthState {
+  session: OperatorSession | null;
+  inflight: Promise<string | null> | null;
+  isAuthenticating: boolean;
+  error: string | null;
+}
+
+const EMPTY_STATE: OperatorAuthState = {
+  session: null,
+  inflight: null,
+  isAuthenticating: false,
+  error: null,
+};
+
+const authRegistry = new Map<string, OperatorAuthState>();
+const authListeners = new Map<string, Set<() => void>>();
+
+function normalizeAddress(address: string): string {
+  return address.toLowerCase();
+}
+
+function makeCacheKey(address: string, baseUrl: string): string {
+  return `${normalizeAddress(address)}::${baseUrl}`;
+}
+
+function getState(key: string): OperatorAuthState {
+  return authRegistry.get(key) ?? EMPTY_STATE;
+}
+
+function setState(key: string, next: OperatorAuthState) {
+  authRegistry.set(key, next);
+  authListeners.get(key)?.forEach((listener) => listener());
+}
+
+function subscribeToKey(key: string, listener: () => void): () => void {
+  const listeners = authListeners.get(key) ?? new Set<() => void>();
+  listeners.add(listener);
+  authListeners.set(key, listeners);
+  return () => {
+    const current = authListeners.get(key);
+    if (!current) return;
+    current.delete(listener);
+    if (current.size === 0) {
+      authListeners.delete(key);
+    }
+  };
+}
+
+function isSessionValid(session: OperatorSession | null): session is OperatorSession {
+  if (!session) return false;
+  // Consider expired 60s before actual expiry
+  return session.expiresAt * 1000 > Date.now() + 60_000;
+}
+
+/**
+ * Test-only helper to clear the shared auth registry between unit tests.
+ */
+export function resetOperatorAuthStoreForTests() {
+  authRegistry.clear();
+  authListeners.clear();
 }
 
 /**
@@ -21,33 +83,28 @@ export function useOperatorAuth(apiUrl?: string) {
   const baseUrl = apiUrl ?? OPERATOR_API_URL;
   const { address } = useAccount();
   const { signMessageAsync } = useSignMessage();
-  const [isAuthenticating, setIsAuthenticating] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const sessionRef = useRef<OperatorSession | null>(null);
-  const inflightRef = useRef<Promise<string | null> | null>(null);
-
-  // Clear stale session when wallet address changes
-  useEffect(() => {
-    sessionRef.current = null;
-  }, [address]);
-
-  const isValid = useCallback(() => {
-    if (!sessionRef.current) return false;
-    // Consider expired 60s before actual expiry
-    return sessionRef.current.expiresAt * 1000 > Date.now() + 60_000;
-  }, []);
+  const cacheKey = address ? makeCacheKey(address, baseUrl) : null;
+  const subscribe = useCallback((listener: () => void) => {
+    if (!cacheKey) return () => {};
+    return subscribeToKey(cacheKey, listener);
+  }, [cacheKey]);
+  const getSnapshot = useCallback(() => {
+    if (!cacheKey) return EMPTY_STATE;
+    return getState(cacheKey);
+  }, [cacheKey]);
+  const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
   const getToken = useCallback(async (forceRefresh = false): Promise<string | null> => {
-    if (!forceRefresh && isValid()) return sessionRef.current!.token;
-    // Deduplicate concurrent calls
-    if (inflightRef.current && !forceRefresh) return inflightRef.current;
-    if (forceRefresh) sessionRef.current = null;
-    if (!address) return null;
+    if (!address || !cacheKey) return null;
+
+    const current = getState(cacheKey);
+    if (!forceRefresh && isSessionValid(current.session)) return current.session.token;
+    if (current.inflight) return current.inflight;
+    if (forceRefresh) {
+      setState(cacheKey, { ...current, session: null, error: null });
+    }
 
     const promise = (async () => {
-      setIsAuthenticating(true);
-      setError(null);
-
       try {
         // Step 1: Get challenge
         const challengeRes = await fetch(`${baseUrl}/api/auth/challenge`, {
@@ -74,33 +131,44 @@ export function useOperatorAuth(apiUrl?: string) {
         }
         const { token, expires_at } = await sessionRes.json();
 
-        sessionRef.current = { token, expiresAt: expires_at };
+        setState(cacheKey, {
+          session: { token, expiresAt: expires_at },
+          inflight: null,
+          isAuthenticating: false,
+          error: null,
+        });
         return token;
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Auth failed';
-        setError(msg);
+        setState(cacheKey, {
+          ...getState(cacheKey),
+          session: null,
+          inflight: null,
+          isAuthenticating: false,
+          error: msg,
+        });
         return null;
-      } finally {
-        setIsAuthenticating(false);
       }
     })();
 
-    inflightRef.current = promise;
-    try {
-      return await promise;
-    } finally {
-      inflightRef.current = null;
-    }
-  }, [address, baseUrl, isValid, signMessageAsync]);
+    setState(cacheKey, {
+      ...getState(cacheKey),
+      inflight: promise,
+      isAuthenticating: true,
+      error: null,
+    });
+
+    return promise;
+  }, [address, baseUrl, cacheKey, signMessageAsync]);
 
   return {
     /** Get a valid PASETO token, authenticating if needed. */
     getToken,
     /** Whether we have a valid cached token. */
-    isAuthenticated: isValid(),
+    isAuthenticated: isSessionValid(state.session),
     /** Whether an auth request is in-flight. */
-    isAuthenticating,
+    isAuthenticating: state.isAuthenticating,
     /** Last error message, if any. */
-    error,
+    error: state.error,
   };
 }

--- a/ui/src/providers/Web3Provider.tsx
+++ b/ui/src/providers/Web3Provider.tsx
@@ -1,7 +1,6 @@
 import { createConfig } from 'wagmi';
 import { ConnectKitProvider, getDefaultConfig } from 'connectkit';
-import { type ReactNode, useEffect } from 'react';
-import { useReconnect } from 'wagmi';
+import { type ReactNode } from 'react';
 import {
   createTangleTransports,
   defaultConnectKitOptions,
@@ -9,43 +8,35 @@ import {
 } from '@tangle-network/blueprint-ui';
 import { Web3Shell } from '@tangle-network/blueprint-ui/components';
 
+const appMetadata = {
+  appName: 'Tangle Sandbox Cloud',
+  appDescription: 'AI Agent Sandbox Provisioning on Tangle Network',
+  appUrl: typeof window !== 'undefined' ? window.location.origin : 'https://cloud.tangle.tools',
+  appIcon: '/favicon.svg',
+} as const;
+
 const walletConnectProjectId = import.meta.env.VITE_WALLETCONNECT_PROJECT_ID || '';
 
-const config = createConfig(
-  getDefaultConfig({
-    chains: tangleWalletChains as any,
-    transports: createTangleTransports() as any,
-    walletConnectProjectId,
-    appName: 'Tangle Sandbox Cloud',
-    appDescription: 'AI Agent Sandbox Provisioning on Tangle Network',
-    appUrl: typeof window !== 'undefined' ? window.location.origin : 'https://cloud.tangle.tools',
-    appIcon: '/favicon.svg',
-  }),
-);
+export function createWeb3Config(projectId = walletConnectProjectId) {
+  return createConfig(
+    getDefaultConfig({
+      chains: tangleWalletChains as any,
+      transports: createTangleTransports() as any,
+      walletConnectProjectId: projectId,
+      ...appMetadata,
+    }),
+  );
+}
+
+const config = createWeb3Config();
 
 export { config };
 
-/**
- * Eagerly reconnect using only the injected (MetaMask) connector.
- * wagmi's default reconnect tries ALL connectors including WalletConnect,
- * which can be slow when no project ID is set or on insecure contexts.
- * This fires immediately and wins the race against WalletConnect's timeout.
- */
-function FastReconnect({ children }: { children: ReactNode }) {
-  const { reconnect } = useReconnect();
-
-  useEffect(() => {
-    const inj = config.connectors.find((c) => c.type === 'injected');
-    if (inj) {
-      reconnect({ connectors: [inj] });
-    }
-  }, [reconnect]);
-
-  return <>{children}</>;
-}
-
 export function Web3Provider({ children }: { children: ReactNode }) {
   return (
+    // Web3Shell owns the reconnect workaround for this stack. Keeping app-level
+    // wallet restore logic out of this provider avoids duplicating connector
+    // heuristics and prevents route-specific reconnect hacks here.
     <Web3Shell config={config as any}>
       <ConnectKitProvider
         theme="auto"
@@ -55,9 +46,7 @@ export function Web3Provider({ children }: { children: ReactNode }) {
           initialChainId: undefined,
         }}
       >
-        <FastReconnect>
-          {children}
-        </FastReconnect>
+        {children}
       </ConnectKitProvider>
     </Web3Shell>
   );


### PR DESCRIPTION
## Summary
- **Wallet connection stability (#26):** Remove the custom `FastReconnect` component and delegate wallet reconnect entirely to `Web3Shell` from `@tangle-network/blueprint-ui`, which already handles injected-connector reconnection correctly. This prevents the header from showing a disconnected or wrong-network state after client-side navigation.
- **Operator auth caching (#25):** Replace per-hook-instance `useRef`/`useState` session storage in `useOperatorAuth` with a module-level external store (`useSyncExternalStore`) keyed by `address::operatorUrl`. This ensures operator PASETO tokens persist across route remounts and are shared/deduplicated across concurrent hook instances, eliminating repeated MetaMask signature prompts when revisiting `/sandboxes`.

Closes #25
Closes #26

## Video
Uploading CleanShot 2026-03-13 at 13.09.38.mp4…


## Test plan
- [x] Existing `useOperatorAuth` tests updated and passing
- [x] New test: reuses valid shared token after hook remount
- [x] New test: deduplicates concurrent auth across hook instances for the same key
- [x] New test: does not share cached tokens across different operator URLs
- [ ] Manual: connect wallet locally, navigate between `/`, `/sandboxes`, `/instances` — wallet state stays consistent in header
- [ ] Manual: visit `/sandboxes`, confirm MetaMask signature once, navigate away and back — no re-prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)