### PR TITLE
feat(ui): replace @tangle-network/agent-ui with @tangle-network/sandbox-ui

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -23,7 +23,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-router/node": "^7.13.0",
-    "@tangle-network/sandbox-ui": "^0.4.0",
+    "@tangle-network/sandbox-ui": "^0.5.0",
     "@tangle-network/blueprint-ui": "link:../../blueprint-ui",
     "@tanstack/react-query": "^5.90.16",
     "@xterm/addon-fit": "^0.11.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,7 +23,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-router/node": "^7.13.0",
-    "@tangle-network/agent-ui": "workspace:*",
+    "@tangle-network/sandbox-ui": "^0.4.0",
     "@tangle-network/blueprint-ui": "link:../../blueprint-ui",
     "@tanstack/react-query": "^5.90.16",
     "@xterm/addon-fit": "^0.11.0",

--- a/ui/src/components/layout/TxDropdown.tsx
+++ b/ui/src/components/layout/TxDropdown.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react';
 import { txListStore, pendingCount, clearTxs, type TrackedTx } from '@tangle-network/blueprint-ui';
-import { timeAgo, useDropdownMenu } from '@tangle-network/agent-ui/primitives';
+import { timeAgo, useDropdownMenu } from '@tangle-network/sandbox-ui';
 
 function StatusIcon({ status }: { status: TrackedTx['status'] }) {
   if (status === 'pending') return <div className="w-4 h-4 rounded-full border-2 border-violet-500/40 border-t-violet-400 animate-spin shrink-0" />;

--- a/ui/src/components/layout/WalletButton.tsx
+++ b/ui/src/components/layout/WalletButton.tsx
@@ -7,13 +7,10 @@ import { numberToHex } from 'viem';
 import { networks } from '~/lib/contracts/chains';
 import { publicClient, selectedChainIdStore } from '@tangle-network/blueprint-ui';
 import { Identicon } from '@tangle-network/blueprint-ui/components';
-import {
-  ConnectWalletCta,
-  copyText,
-  truncateAddress,
-  useDropdownMenu,
-  useWalletEthBalance,
-} from '@tangle-network/agent-ui/primitives';
+import { ConnectWalletCta } from '@tangle-network/blueprint-ui/components';
+import { copyText, useDropdownMenu } from '@tangle-network/sandbox-ui';
+import { useWalletEthBalance } from '@tangle-network/blueprint-ui';
+import { truncateAddress } from '~/lib/utils/truncate-address';
 import { toast } from 'sonner';
 import { expectedLocalRpcUrl, walletRpcMatchesAppRpc } from '~/lib/walletRpcSync';
 import { useOperatorAuth } from '~/lib/hooks/useOperatorAuth';

--- a/ui/src/components/shared/OnChainVerificationCard.tsx
+++ b/ui/src/components/shared/OnChainVerificationCard.tsx
@@ -8,7 +8,7 @@ import {
 import { cn } from '@tangle-network/blueprint-ui';
 import { useOnChainVerification } from '~/lib/hooks/useInstanceReads';
 import { CopyButton } from './CopyButton';
-import { truncateAddress } from '@tangle-network/agent-ui/primitives';
+import { truncateAddress } from '~/lib/utils/truncate-address';
 
 const BYTES32_ZERO = '0x0000000000000000000000000000000000000000000000000000000000000000';
 

--- a/ui/src/components/shared/SessionSidebar.tsx
+++ b/ui/src/components/shared/SessionSidebar.tsx
@@ -14,8 +14,8 @@ import {
   type SessionPart,
   type ToolPart,
   type ReasoningPart,
-} from '@tangle-network/agent-ui';
-import type { TextPart } from '@tangle-network/agent-ui';
+  type TextPart,
+} from '@tangle-network/sandbox-ui';
 import type { SandboxClient } from '~/lib/api/sandboxClient';
 import {
   chatSessionsStore,
@@ -97,7 +97,7 @@ function AgentRunGroup({
   onToggle,
   branding,
 }: {
-  run: import('@tangle-network/agent-ui').Run;
+  run: import('@tangle-network/sandbox-ui').Run;
   partMap: Record<string, SessionPart[]>;
   collapsed: boolean;
   onToggle: () => void;

--- a/ui/src/lib/hooks/useSandboxSession.ts
+++ b/ui/src/lib/hooks/useSandboxSession.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { SessionMessage, SessionPart } from '@tangle-network/agent-ui';
+import type { SessionMessage, SessionPart } from '@tangle-network/sandbox-ui';
 import type { SandboxClient } from '~/lib/api/sandboxClient';
 import {
   applyChatStreamEvent,

--- a/ui/src/lib/hooks/useWagmiSidecarAuth.ts
+++ b/ui/src/lib/hooks/useWagmiSidecarAuth.ts
@@ -1,1 +1,1 @@
-export { useWagmiSidecarAuth } from '@tangle-network/agent-ui';
+export { useWagmiSidecarAuth } from '@tangle-network/blueprint-ui';

--- a/ui/src/lib/stores/chatSessions.ts
+++ b/ui/src/lib/stores/chatSessions.ts
@@ -1,5 +1,5 @@
 import { atom } from 'nanostores';
-import type { SessionMessage, SessionPart, TextPart } from '@tangle-network/agent-ui';
+import type { SessionMessage, SessionPart, TextPart } from '@tangle-network/sandbox-ui';
 import type {
   ChatStreamEvent,
   ChatRunSummary,

--- a/ui/src/lib/utils/truncate-address.ts
+++ b/ui/src/lib/utils/truncate-address.ts
@@ -1,0 +1,5 @@
+export function truncateAddress(address: string | null | undefined): string {
+  if (!address) return ''
+  if (address.length <= 12) return address
+  return `${address.slice(0, 6)}...${address.slice(-4)}`
+}

--- a/ui/src/routes/instances.$id.test.tsx
+++ b/ui/src/routes/instances.$id.test.tsx
@@ -57,7 +57,7 @@ vi.mock('@tangle-network/blueprint-ui', () => ({
   cn: (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(' '),
 }));
 
-vi.mock('@tangle-network/agent-ui/primitives', () => ({
+vi.mock('~/lib/utils/truncate-address', () => ({
   truncateAddress: (value: string) => {
     if (!value || value.length <= 12) return value;
     return `${value.slice(0, 6)}...${value.slice(-4)}`;

--- a/ui/src/routes/instances.$id.tsx
+++ b/ui/src/routes/instances.$id.tsx
@@ -22,7 +22,7 @@ import { useInstanceHydration } from '~/lib/hooks/useInstanceHydration';
 import { createProxiedInstanceClient, type SandboxClient } from '~/lib/api/sandboxClient';
 import { INSTANCE_OPERATOR_API_URL, OPERATOR_API_URL } from '~/lib/config';
 import { cn } from '@tangle-network/blueprint-ui';
-import { truncateAddress } from '@tangle-network/agent-ui/primitives';
+import { truncateAddress } from '~/lib/utils/truncate-address';
 import { OperatorTerminalView } from '~/components/shared/OperatorTerminalView';
 import { ConfirmDialog } from '~/components/shared/ConfirmDialog';
 import { SnapshotDialog } from '~/components/shared/SnapshotDialog';

--- a/ui/src/routes/sandboxes.$id.tsx
+++ b/ui/src/routes/sandboxes.$id.tsx
@@ -33,7 +33,7 @@ import { useTeeAttestation } from '~/lib/hooks/useTeeAttestation';
 import { useSandboxHydration } from '~/lib/hooks/useSandboxHydration';
 import { createProxiedClient, type SandboxClient } from '~/lib/api/sandboxClient';
 import { cn } from '@tangle-network/blueprint-ui';
-import { truncateAddress } from '@tangle-network/agent-ui/primitives';
+import { truncateAddress } from '~/lib/utils/truncate-address';
 import { ConfirmDialog } from '~/components/shared/ConfirmDialog';
 import { SnapshotDialog } from '~/components/shared/SnapshotDialog';
 import { OperatorTerminalView } from '~/components/shared/OperatorTerminalView';

--- a/ui/src/test/stubs/agent-ui.ts
+++ b/ui/src/test/stubs/agent-ui.ts
@@ -1,3 +1,4 @@
-// Stub for @tangle-network/agent-ui — optional peer dep of @tangle-network/blueprint-ui.
-// Only needed during vitest pre-bundling; the real package is available at runtime.
+// @tangle-network/agent-ui has been replaced by @tangle-network/sandbox-ui.
+// This stub is retained for any legacy vi.mock references during transition.
+// Remove once all test mocks reference the new package.
 export const useSidecarAuth = () => ({ token: null, isLoading: false });


### PR DESCRIPTION
## Summary

`@tangle-network/agent-ui` is deprecated. This PR completes the migration to `@tangle-network/sandbox-ui` for general UI components/types and `@tangle-network/blueprint-ui` for web3/wagmi hooks.

**Import migration map:**

| Symbol(s) | From | To |
|-----------|------|----|
| `SessionMessage`, `SessionPart`, `TextPart`, `ToolPart`, `ReasoningPart`, `Run` | `agent-ui` | `sandbox-ui` |
| `AgentBranding`, `InlineToolItem`, `InlineThinkingItem`, `Markdown`, `UserMessage`, `RunGroup` | `agent-ui` | `sandbox-ui` |
| `useRunGroups`, `useRunCollapseState`, `useAutoScroll`, `useDropdownMenu`, `timeAgo`, `copyText` | `agent-ui` | `sandbox-ui` |
| `useWagmiSidecarAuth`, `useWalletEthBalance` | `agent-ui` | `blueprint-ui` |
| `ConnectWalletCta` | `agent-ui/primitives` | `blueprint-ui/components` |
| `truncateAddress` | `agent-ui/primitives` | `~/lib/utils/truncate-address` (local — ETH address util belongs at app level) |

**Files changed:** `ui/package.json`, 6 component/hook/store files, 3 route files, test mock update, stub comment update.

## Dependency note

`@tangle-network/sandbox-ui` is pinned at `^0.4.0` (current npm release). Bump to `^0.5.0` after [tangle-network/sandbox-ui#14](https://github.com/tangle-network/sandbox-ui/pull/14) merges and publishes — that PR adds the light theme, Storybook, and agent timeline redesign.

## Test plan

- [ ] `pnpm typecheck` in `ui/` passes
- [ ] `pnpm test` passes (updated `instances.$id.test.tsx` mock points to local util)
- [ ] `SessionSidebar` renders correctly in sandbox and instance detail pages
- [ ] `TxDropdown` dropdown still renders and `timeAgo` displays correctly
- [ ] `WalletButton` renders with connected/disconnected states; address truncates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)