### PR TITLE
fix(tee): make local blueprint dap flow current

### DIFF
--- a/TEE-GUIDE.md
+++ b/TEE-GUIDE.md
@@ -30,12 +30,8 @@ Choose a TEE backend based on your infrastructure:
 ## Building
 
 ```bash
-# All backends
-cargo build -p ai-agent-tee-instance-blueprint-bin --features tee-all
-
-# Specific backend
-cargo build -p ai-agent-tee-instance-blueprint-bin --features tee-phala
-cargo build -p ai-agent-tee-instance-blueprint-bin --features tee-direct
+# TEE instance blueprint. This binary already enables sandbox-runtime/tee-all.
+cargo build -p ai-agent-tee-instance-blueprint-bin
 ```
 
 ## Configuration
@@ -108,6 +104,12 @@ The host must have the corresponding device node available:
 | SEV-SNP | `/dev/sev-guest` |
 | Nitro | `/dev/nsm` |
 
+Direct TDX currently uses Linux `TDX_CMD_GET_REPORT0`, which returns a local
+TDREPORT. That is useful for in-guest binding, but it is not a remotely
+verifiable DCAP quote and cannot carry caller nonce challenges in this runtime.
+Use SEV-SNP, Nitro, Phala, GCP, or Azure for nonce-bound client verification
+until direct TDX DCAP quote generation is added.
+
 ## Contract Deployment
 
 Deploy with `teeRequired=true`:
@@ -141,7 +143,8 @@ User                     Contract                  Operator
   |                         |     tee_public_key_json) |
   |                         |                         |
   |                         | _handleProvisionResult: |
-  |                         |   verify tee_attestation |
+  |                         |   require non-empty      |
+  |                         |   tee_attestation_json   |
   |                         |   store attestation hash |
   |                         |                         |
   |<-- service ready -------|                         |
@@ -162,6 +165,18 @@ Fetch fresh attestation from a running TEE sandbox.
   "evidence": [/* raw bytes */],
   "measurement": [/* raw bytes */],
   "timestamp": 1700000000
+}
+```
+
+### `POST /api/sandboxes/{id}/tee/attestation`
+
+Fetch fresh attestation bound to caller-provided report data. The runtime
+rejects this request when the selected backend cannot bind report data.
+
+**Request:**
+```json
+{
+  "attestation_nonce": "64-to-128 hex chars"
 }
 ```
 
@@ -268,9 +283,10 @@ require(expected == stored, "Attestation mismatch");
 The evidence format depends on the TEE type:
 
 **Intel TDX:**
-- Parse the TDREPORT (1024 bytes)
-- Extract MRTD at offset 512 (48 bytes, SHA-384)
-- Compare MRTD against the expected sidecar image measurement
+- A raw 1024-byte TDREPORT from `/dev/tdx_guest` is not remotely verifiable.
+- For client trust, verify a DCAP quote through Intel PCS/Trust Authority or a
+  provider backend that returns remotely verifiable TDX evidence.
+- Reject nonce-bound direct TDX until DCAP quote support is implemented.
 
 **AWS Nitro:**
 - Parse the NSM attestation document (CBOR-encoded)
@@ -280,6 +296,8 @@ The evidence format depends on the TEE type:
 - Parse the ATTESTATION_REPORT
 - Extract LAUNCH_DIGEST at offset 0x90 (48 bytes, SHA-384)
 - Compare against expected VM image measurement
+- Verify the report signature against AMD KDS/VCEK roots and ensure the caller
+  nonce is present in `report_data`.
 
 **Phala:**
 - `tcb_info` and `app_certificates` are Phala-specific

--- a/ai-agent-tee-instance-blueprint-lib/README.md
+++ b/ai-agent-tee-instance-blueprint-lib/README.md
@@ -65,7 +65,7 @@ TEE_INTEGRATION=1 cargo test -p ai-agent-tee-instance-blueprint-lib -- tee_integ
 
 ```bash
 # Build
-cargo build -p ai-agent-tee-instance-blueprint-bin --features tee-all
+cargo build -p ai-agent-tee-instance-blueprint-bin
 
 # Deploy contract
 forge script contracts/script/DeployTeeInstance.s.sol:DeployTeeInstanceBlueprint \

--- a/contracts/script/RegisterBlueprint.s.sol
+++ b/contracts/script/RegisterBlueprint.s.sol
@@ -91,6 +91,7 @@ contract RegisterBlueprint is Script {
         returns (Types.BlueprintDefinition memory def)
     {
         def.metadataUri = "https://github.com/tangle-network/ai-agent-sandbox-blueprint";
+        def.metadataHash = keccak256(bytes(def.metadataUri));
         def.manager = manager;
         def.masterManagerRevision = 0;
         def.hasConfig = true;
@@ -153,6 +154,7 @@ contract RegisterBlueprint is Script {
         returns (Types.BlueprintDefinition memory def)
     {
         def.metadataUri = "https://github.com/tangle-network/ai-agent-sandbox-blueprint";
+        def.metadataHash = keccak256(bytes(def.metadataUri));
         def.manager = manager;
         def.masterManagerRevision = 0;
         def.hasConfig = true;
@@ -215,6 +217,7 @@ contract RegisterBlueprint is Script {
         returns (Types.BlueprintDefinition memory def)
     {
         def.metadataUri = "https://github.com/tangle-network/ai-agent-sandbox-blueprint";
+        def.metadataHash = keccak256(bytes(def.metadataUri));
         def.manager = manager;
         def.masterManagerRevision = 0;
         def.hasConfig = true;

--- a/foundry.toml
+++ b/foundry.toml
@@ -13,7 +13,7 @@ remappings_location = "txt"
 remappings_version = false
 
 [dependencies]
-tnt-core = "0.10.1"
+tnt-core = "0.10.9"
 forge-std = "1.9.6"
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,4 @@
-@openzeppelin/contracts-upgradeable/=dependencies/tnt-core-0.10.1/dependencies/@openzeppelin-contracts-upgradeable-5.1.0/
-@openzeppelin/contracts/=dependencies/tnt-core-0.10.1/dependencies/@openzeppelin-contracts-5.1.0/
+@openzeppelin/contracts-upgradeable/=dependencies/tnt-core-0.10.9/dependencies/@openzeppelin-contracts-upgradeable-5.1.0/
+@openzeppelin/contracts/=dependencies/tnt-core-0.10.9/dependencies/@openzeppelin-contracts-5.1.0/
 forge-std/=dependencies/forge-std-1.9.6/src/
-tnt-core/=dependencies/tnt-core-0.10.1/src/
+tnt-core/=dependencies/tnt-core-0.10.9/src/

--- a/sandbox-runtime/src/runtime.rs
+++ b/sandbox-runtime/src/runtime.rs
@@ -1437,7 +1437,7 @@ async fn docker_exec_as_user(
 fn build_docker_ssh_bootstrap_command(username: &str) -> String {
     let user_arg = shell_escape(username);
     format!(
-        r#"set -euo pipefail;
+        r#"set -eu;
 user={user_arg};
 shell="/bin/sh";
 [ -x "$shell" ] || shell="/bin/bash";
@@ -1505,7 +1505,7 @@ awk 'NR > 1 {{ split($2,a,":"); if (toupper(a[2]) == "0016" && $4 == "0A") found
 fn build_docker_ssh_user_home_bootstrap_command(username: &str) -> String {
     let user_arg = shell_escape(username);
     format!(
-        r#"set -euo pipefail;
+        r#"set -eu;
 user={user_arg};
 home=$(getent passwd "$user" | cut -d: -f6);
 if [ -z "$home" ]; then
@@ -1523,7 +1523,7 @@ fn build_ssh_key_install_command(username: &str, public_key: &str) -> String {
     let user_arg = shell_escape(username);
     let key_arg = shell_escape(public_key);
     format!(
-        r#"set -euo pipefail;
+        r#"set -eu;
 user={user_arg};
 key={key_arg};
 home=$(getent passwd "$user" | cut -d: -f6);
@@ -1545,7 +1545,7 @@ fn build_ssh_key_revoke_command(username: &str, public_key: &str) -> String {
     let user_arg = shell_escape(username);
     let key_arg = shell_escape(public_key);
     format!(
-        r#"set -euo pipefail;
+        r#"set -eu;
 user={user_arg};
 key={key_arg};
 home=$(getent passwd "$user" | cut -d: -f6);
@@ -1566,7 +1566,7 @@ fn build_sidecar_ssh_key_install_command(username: &str, public_key: &str) -> St
     let user_arg = shell_escape(username);
     let key_arg = shell_escape(public_key);
     format!(
-        "set -euo pipefail; user={user_arg}; \
+        "set -eu; user={user_arg}; \
 home=$(getent passwd \"${{user}}\" | cut -d: -f6); \
 if [ -z \"$home\" ]; then echo \"User ${{user}} does not exist\" >&2; exit 1; fi; \
 mkdir -p \"$home/.ssh\"; chmod 700 \"$home/.ssh\"; \
@@ -1580,7 +1580,7 @@ fn build_sidecar_ssh_key_revoke_command(username: &str, public_key: &str) -> Str
     let user_arg = shell_escape(username);
     let key_arg = shell_escape(public_key);
     format!(
-        "set -euo pipefail; user={user_arg}; \
+        "set -eu; user={user_arg}; \
 home=$(getent passwd \"${{user}}\" | cut -d: -f6); \
 if [ -z \"$home\" ]; then echo \"User ${{user}} does not exist\" >&2; exit 1; fi; \
 if [ -f \"$home/.ssh/authorized_keys\" ]; then \
@@ -3419,6 +3419,7 @@ mod port_mapping_tests {
         let command = build_docker_ssh_bootstrap_command("agent");
         assert!(command.contains("passwd -u \"$user\""));
         assert!(command.contains("AllowUsers agent"));
+        assert!(!command.contains("pipefail"));
     }
 
     #[test]

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -256,7 +256,7 @@ SVC_BEFORE=$(echo "$SVC_BEFORE" | sed 's/^0x//' | sed 's/^0*//' | sed 's/^$/0/')
 
 # Request sandbox service (Dynamic membership, EventDriven pricing → no payment)
 if ! cast send "$TANGLE" \
-    "requestService(uint64,address[],bytes,address[],uint64,address,uint256)" \
+    "requestService(uint64,address[],bytes,address[],uint64,address,uint256,uint8)" \
     "$SANDBOX_BLUEPRINT_ID" \
     "[$OPERATOR1_ADDR,$OPERATOR2_ADDR]" \
     "0x" \
@@ -264,6 +264,7 @@ if ! cast send "$TANGLE" \
     31536000 \
     "0x0000000000000000000000000000000000000000" \
     0 \
+    2 \
     --gas-limit 3000000 \
     --rpc-url "$RPC_URL" --private-key "$DEPLOYER_KEY" > /dev/null 2>&1; then
     echo "  ERROR: Sandbox requestService failed"
@@ -277,12 +278,12 @@ echo "  Sandbox service request #$SANDBOX_REQ_ID submitted"
 NEXT_REQ=$((NEXT_REQ + 1))
 INSTANCE_CONFIG=$(cast abi-encode \
     "f(string,string,string,string,string,string,bool,string,bool,uint64,uint64,uint64,uint64,uint64,bool,uint8,string)" \
-    "dev-sandbox" "agent-dev" "default" "default-agent" "{}" "{}" \
+    "dev-sandbox" "$SIDECAR_IMAGE" "default" "default-agent" "{}" "{}" \
     true "" false \
     3600 900 2 4096 20 \
     false 0 "")
 if ! cast send "$TANGLE" \
-    "requestService(uint64,address[],bytes,address[],uint64,address,uint256)" \
+    "requestService(uint64,address[],bytes,address[],uint64,address,uint256,uint8)" \
     "$INSTANCE_BLUEPRINT_ID" \
     "[$OPERATOR1_ADDR,$OPERATOR2_ADDR]" \
     "$INSTANCE_CONFIG" \
@@ -290,6 +291,7 @@ if ! cast send "$TANGLE" \
     31536000 \
     "0x0000000000000000000000000000000000000000" \
     0 \
+    2 \
     --gas-limit 3000000 \
     --rpc-url "$RPC_URL" --private-key "$DEPLOYER_KEY" > /dev/null 2>&1; then
     echo "  ERROR: Instance requestService failed"
@@ -308,12 +310,12 @@ if [[ "$ENABLE_TEE_OPERATOR" == "1" ]]; then
     NEXT_REQ=$((NEXT_REQ + 1))
     TEE_INSTANCE_CONFIG=$(cast abi-encode \
         "f(string,string,string,string,string,string,bool,string,bool,uint64,uint64,uint64,uint64,uint64,bool,uint8,string)" \
-        "dev-tee-sandbox" "agent-dev" "default" "default-agent" "{}" "{}" \
+        "dev-tee-sandbox" "$SIDECAR_IMAGE" "default" "default-agent" "{}" "{}" \
         true "" false \
         3600 900 2 4096 20 \
         true "$TEE_TYPE_ID" "${TEE_ATTESTATION_NONCE:-}")
     if ! cast send "$TANGLE" \
-        "requestService(uint64,address[],bytes,address[],uint64,address,uint256)" \
+        "requestService(uint64,address[],bytes,address[],uint64,address,uint256,uint8)" \
         "$TEE_INSTANCE_BLUEPRINT_ID" \
         "[$OPERATOR1_ADDR,$OPERATOR2_ADDR]" \
         "$TEE_INSTANCE_CONFIG" \
@@ -321,6 +323,7 @@ if [[ "$ENABLE_TEE_OPERATOR" == "1" ]]; then
         31536000 \
         "0x0000000000000000000000000000000000000000" \
         0 \
+        1 \
         --gas-limit 3000000 \
         --rpc-url "$RPC_URL" --private-key "$DEPLOYER_KEY" > /dev/null 2>&1; then
         echo "  ERROR: TEE instance requestService failed"

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -371,13 +371,14 @@ else
     # 4a: Create sandbox
     # SandboxCreateRequest: (string name, string image, string stack, string agent_id,
     #   string env_json, string metadata_json, bool ssh, string ssh_key, bool web_term,
-    #   uint64 max_life, uint64 idle, uint64 cpu, uint64 mem, uint64 disk, bool tee, uint8 tee_type)
+    #   uint64 max_life, uint64 idle, uint64 cpu, uint64 mem, uint64 disk,
+    #   bool tee, uint8 tee_type, string attestation_nonce)
     CREATE_ARGS=$(cast abi-encode \
-        "f(string,string,string,string,string,string,bool,string,bool,uint64,uint64,uint64,uint64,uint64,bool,uint8)" \
-        "e2e-sandbox" "agent-dev" "default" "default-agent" "{}" "{}" \
+        "f(string,string,string,string,string,string,bool,string,bool,uint64,uint64,uint64,uint64,uint64,bool,uint8,string)" \
+        "e2e-sandbox" "${TANGLE_E2E_IMAGE:-${SIDECAR_IMAGE:-tangle-sidecar:local}}" "default" "default-agent" "{}" "{}" \
         false "" true \
         3600 900 2 2048 10 \
-        false 0)
+        false 0 "")
 
     SANDBOX_CALL_ID=$(submit_job "$SANDBOX_SERVICE_ID" 0 "$CREATE_ARGS" "$CREATE_RATE") || true
     if [ "$SANDBOX_CALL_ID" = "REVERT" ] || [ "$SANDBOX_CALL_ID" = "TX_FAIL" ]; then

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -7,7 +7,7 @@ integrity = "e9ecdc364d152157431e5df5aa041ffddbe9bb1c1ad81634b1e72df9e23814e8"
 
 [[dependencies]]
 name = "tnt-core"
-version = "0.10.1"
-url = "https://soldeer-revisions.s3.amazonaws.com/tnt-core/0_10_1_11-02-2026_14:25:51_tnt-core.zip"
-checksum = "e4eb3b6264d42c5fc9a833ca6ba2b37122adc7988ad80aee88201baf76bc758e"
-integrity = "4a3bff58b9991114ef060df4a7b0c2330c76cc919a3a15f4c905421061202377"
+version = "0.10.9"
+url = "https://soldeer-revisions.s3.amazonaws.com/tnt-core/0_10_9_24-04-2026_03:56:11_tnt-core.zip"
+checksum = "d7a5b2c0dd620a2801d300680d599535fab9128e3c30ca9c8f43b8dfdf2b5c0c"
+integrity = "02bb7d7371ce17f6c82141cb62589d598e3f3db92a632336c11e4c4207a1aa76"


### PR DESCRIPTION
## Summary\n- update local blueprint registration to current TNT Core metadataHash ABI\n- update deploy-local service requests for confidentiality policy and local sidecar image\n- make Docker SSH bootstrap POSIX-sh compatible and fix e2e sandbox create calldata/image\n- correct TEE runbook claims around tee-all, direct TDX, and nonce-bound attestation\n\n## Verification\n- bash -n scripts/deploy-local.sh scripts/test-e2e.sh\n- forge build\n- cargo check -p ai-agent-tee-instance-blueprint-bin\n- cargo test -p sandbox-runtime tee --lib --tests\n- SKIP_BUILD=1 timeout 600s bash scripts/deploy-local.sh\n- timeout 300s bash scripts/test-e2e.sh (44 passed, 0 failed, 6 skipped)\n\n## Notes\nReal hardware attestation was not run on this host because /dev/sev-guest, /dev/tdx_guest, and /dev/nsm are absent. The local DAP path now validates standard sandbox and instance provisioning; TEE hardware validation still needs a SEV-SNP/Nitro/provider host.