### PR TITLE
fix(tee): bind Nitro attestations to caller nonce

### DIFF
--- a/sandbox-runtime/src/tee/aws_nitro.rs
+++ b/sandbox-runtime/src/tee/aws_nitro.rs
@@ -273,9 +273,15 @@ impl TeeBackend for NitroBackend {
         )
         .await?;
 
-        // Fetch attestation from the sidecar.
-        let attestation =
-            super::fetch_sidecar_attestation(&sidecar_url, &params.sidecar_token).await?;
+        // Fetch attestation from the sidecar. When the caller supplied a
+        // challenge, the sidecar must embed it in the signed NSM document.
+        let attestation = super::fetch_sidecar_attestation_with_report_data(
+            &sidecar_url,
+            &params.sidecar_token,
+            params.attestation_report_data,
+        )
+        .await?;
+        super::validate_attestation_report(&attestation, &TeeType::Nitro)?;
 
         let metadata = serde_json::json!({
             "ec2_instance_id": instance_id,
@@ -301,10 +307,14 @@ impl TeeBackend for NitroBackend {
     async fn attestation(
         &self,
         deployment_id: &str,
-        _report_data: Option<[u8; 64]>,
+        report_data: Option<[u8; 64]>,
     ) -> Result<AttestationReport> {
         let (sidecar_url, token) = super::sidecar_info_for_deployment(deployment_id)?;
-        super::fetch_sidecar_attestation(&sidecar_url, &token).await
+        let attestation =
+            super::fetch_sidecar_attestation_with_report_data(&sidecar_url, &token, report_data)
+                .await?;
+        super::validate_attestation_report(&attestation, &TeeType::Nitro)?;
+        Ok(attestation)
     }
 
     async fn stop(&self, deployment_id: &str) -> Result<()> {
@@ -333,6 +343,10 @@ impl TeeBackend for NitroBackend {
         TeeType::Nitro
     }
 
+    fn supports_attestation_report_data(&self) -> bool {
+        true
+    }
+
     async fn derive_public_key(&self, deployment_id: &str) -> Result<TeePublicKey> {
         super::sidecar_derive_public_key(deployment_id).await
     }
@@ -352,4 +366,26 @@ fn require_env(name: &str) -> Result<String> {
             "AWS Nitro backend requires {name} environment variable"
         ))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_backend() -> NitroBackend {
+        NitroBackend::new(NitroConfig {
+            region: "us-east-1".into(),
+            subnet_id: "subnet-test".into(),
+            security_group_id: "sg-test".into(),
+            ami_id: "ami-test".into(),
+            instance_type: "c5.xlarge".into(),
+            kms_key_id: None,
+            iam_instance_profile: None,
+        })
+    }
+
+    #[test]
+    fn nitro_supports_nonce_bound_attestation() {
+        assert!(test_backend().supports_attestation_report_data());
+    }
 }

--- a/sandbox-runtime/src/tee/mod.rs
+++ b/sandbox-runtime/src/tee/mod.rs
@@ -362,12 +362,30 @@ pub(crate) async fn fetch_sidecar_attestation(
     sidecar_url: &str,
     token: &str,
 ) -> crate::error::Result<AttestationReport> {
+    fetch_sidecar_attestation_with_report_data(sidecar_url, token, None).await
+}
+
+/// Fetch fresh attestation from a running sidecar, optionally bound to caller report data.
+#[allow(dead_code)] // Used by TEE backends
+pub(crate) async fn fetch_sidecar_attestation_with_report_data(
+    sidecar_url: &str,
+    token: &str,
+    report_data: Option<[u8; 64]>,
+) -> crate::error::Result<AttestationReport> {
     let url = crate::http::build_url(sidecar_url, "/tee/attestation")?;
     let headers = crate::http::auth_headers(token)?;
-    let (_status, body) = crate::http::send_json(reqwest::Method::GET, url, None, headers).await?;
-    let report: AttestationReport = serde_json::from_str(&body).map_err(|e| {
-        crate::error::SandboxError::Http(format!("Invalid attestation response: {e}"))
-    })?;
+    let method = if report_data.is_some() {
+        reqwest::Method::POST
+    } else {
+        reqwest::Method::GET
+    };
+    let body = report_data.map(|data| {
+        serde_json::json!({
+            "attestation_nonce": hex::encode(data),
+        })
+    });
+    let (_status, body) = crate::http::send_json(method, url, body, headers).await?;
+    let report = parse_sidecar_attestation_response(&body)?;
 
     // Basic sanity check — callers should also validate the TEE type matches.
     if report.evidence.is_empty() {
@@ -382,6 +400,15 @@ pub(crate) async fn fetch_sidecar_attestation(
     }
 
     Ok(report)
+}
+
+fn parse_sidecar_attestation_response(body: &str) -> crate::error::Result<AttestationReport> {
+    let value: serde_json::Value = serde_json::from_str(body).map_err(|e| {
+        crate::error::SandboxError::Http(format!("Invalid attestation response: {e}"))
+    })?;
+    let report_value = value.get("attestation").cloned().unwrap_or(value);
+    serde_json::from_value(report_value)
+        .map_err(|e| crate::error::SandboxError::Http(format!("Invalid attestation response: {e}")))
 }
 
 /// Validate an attestation report for completeness and type correctness.
@@ -656,6 +683,43 @@ mod tests {
         assert_eq!(decoded.evidence, vec![0xDE, 0xAD, 0xBE, 0xEF]);
         assert_eq!(decoded.measurement, vec![0x01, 0x02, 0x03]);
         assert_eq!(decoded.timestamp, 1_700_000_000);
+    }
+
+    #[test]
+    fn sidecar_attestation_response_accepts_raw_report() {
+        let body = serde_json::to_string(&AttestationReport {
+            tee_type: TeeType::Nitro,
+            evidence: vec![1, 2, 3],
+            measurement: vec![4, 5, 6],
+            timestamp: 1_700_000_000,
+        })
+        .unwrap();
+
+        let decoded = parse_sidecar_attestation_response(&body).unwrap();
+
+        assert_eq!(decoded.tee_type, TeeType::Nitro);
+        assert_eq!(decoded.evidence, vec![1, 2, 3]);
+        assert_eq!(decoded.measurement, vec![4, 5, 6]);
+    }
+
+    #[test]
+    fn sidecar_attestation_response_accepts_wrapped_report() {
+        let body = serde_json::json!({
+            "sandbox_id": "sb-1",
+            "attestation": {
+                "tee_type": "Sev",
+                "evidence": [7, 8, 9],
+                "measurement": [10, 11, 12],
+                "timestamp": 1_700_000_000u64,
+            }
+        })
+        .to_string();
+
+        let decoded = parse_sidecar_attestation_response(&body).unwrap();
+
+        assert_eq!(decoded.tee_type, TeeType::Sev);
+        assert_eq!(decoded.evidence, vec![7, 8, 9]);
+        assert_eq!(decoded.measurement, vec![10, 11, 12]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- send caller report data to the enclave sidecar with POST /tee/attestation for nonce-bound attestations
- mark AWS Nitro as supporting caller-supplied attestation report data
- validate Nitro sidecar responses against the expected TEE type
- accept both raw sidecar attestation responses and wrapped { attestation } responses

## Verification
- cargo test -p sandbox-runtime tee --lib --tests
- cargo test -p sandbox-runtime --features tee-aws-nitro nitro --lib
- cargo test -p sandbox-runtime --features tee-all tee --lib
- cargo test -p ai-agent-sandbox-blueprint-lib tee_config --lib --tests

## Note
This still requires the Nitro enclave sidecar image to implement POST /tee/attestation and embed the supplied 64-byte attestation_nonce in the NSM document. If the sidecar does not do that, the deployment/refresh fails closed instead of returning an unverifiable freshness claim.