### PR TITLE
feat(sandbox): plumb sidecar capabilities through to all runtime backends

### DIFF
--- a/ai-agent-instance-blueprint-lib/src/auto_provision.rs
+++ b/ai-agent-instance-blueprint-lib/src/auto_provision.rs
@@ -459,6 +459,7 @@ mod tests {
             extra_ports: HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         }
     }
 
@@ -515,6 +516,7 @@ mod tests {
             tee_required: false,
             tee_type: 0,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         };
 
         // On-chain config is stored as params encoding (flat tuple, no outer offset),
@@ -551,6 +553,7 @@ mod tests {
             tee_required: true,
             tee_type: 1,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         };
 
         // abi_encode() produces tuple encoding (with outer offset prefix).
@@ -587,6 +590,7 @@ mod tests {
             tee_required: true,
             tee_type: 1,
             attestation_nonce: nonce.clone(),
+            capabilities_json: String::new(),
         };
 
         let encoded = request.abi_encode_params();

--- a/ai-agent-instance-blueprint-lib/src/lib.rs
+++ b/ai-agent-instance-blueprint-lib/src/lib.rs
@@ -113,6 +113,11 @@ sol! {
         uint8 tee_type;
         /// Hex-encoded 32-64 byte caller nonce to embed in deploy-time attestation.
         string attestation_nonce;
+        /// JSON array of sidecar capabilities to enable at boot (e.g.
+        /// `["computer_use"]`). Mirrors `SandboxCreateRequest.capabilities_json`
+        /// so instance auto-provision and direct sandbox-create surfaces
+        /// expose the same capability set to customers.
+        string capabilities_json;
     }
 
     /// Provision request shape before deploy-time attestation nonce was added.
@@ -296,6 +301,7 @@ impl From<&ProvisionRequest> for CreateSandboxParams {
             tee_config,
             user_env_json: String::new(),
             port_mappings: Vec::new(), // Parsed from metadata_json at runtime
+            capabilities_json: r.capabilities_json.to_string(),
         }
     }
 }
@@ -320,6 +326,7 @@ impl From<LegacyProvisionRequest> for ProvisionRequest {
             tee_required: r.tee_required,
             tee_type: r.tee_type,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         }
     }
 }
@@ -344,6 +351,7 @@ impl From<ProvisionRequestV1> for ProvisionRequest {
             tee_required: r.tee_required,
             tee_type: r.tee_type,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         }
     }
 }

--- a/ai-agent-instance-blueprint-lib/src/reporting.rs
+++ b/ai-agent-instance-blueprint-lib/src/reporting.rs
@@ -428,6 +428,7 @@ mod tests {
             extra_ports: HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
 
         let output = provision_output_from_record(&record);
@@ -477,6 +478,7 @@ mod tests {
             extra_ports: HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
 
         let output = provision_output_from_record(&record);

--- a/ai-agent-instance-blueprint-lib/tests/e2e_instance.rs
+++ b/ai-agent-instance-blueprint-lib/tests/e2e_instance.rs
@@ -122,6 +122,7 @@ async fn instance_full_lifecycle() -> Result<()> {
             tee_required: false,
             tee_type: 0,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         };
 
         let (provision_receipt, record) = provision_core(&provision_payload, None, &owner_address)

--- a/ai-agent-instance-blueprint-lib/tests/integration.rs
+++ b/ai-agent-instance-blueprint-lib/tests/integration.rs
@@ -96,7 +96,7 @@ fn insert_sandbox(url: &str, token: &str) -> String {
                 extra_ports: std::collections::HashMap::new(),
                 ssh_login_user: None,
                 ssh_authorized_keys: Vec::new(),
-            capabilities_json: String::new(),
+                capabilities_json: String::new(),
             },
         )
         .unwrap();
@@ -147,7 +147,7 @@ fn insert_ssh_sandbox(url: &str, token: &str) -> String {
                 extra_ports: std::collections::HashMap::new(),
                 ssh_login_user: None,
                 ssh_authorized_keys: Vec::new(),
-            capabilities_json: String::new(),
+                capabilities_json: String::new(),
             },
         )
         .unwrap();
@@ -1018,7 +1018,7 @@ mod abi_tests {
             tee_required: true,
             tee_type: 2,
             attestation_nonce: String::new(), // Nitro
-        capabilities_json: String::new(),
+            capabilities_json: String::new(),
         };
 
         let encoded = request.abi_encode();
@@ -1102,7 +1102,7 @@ mod conversion_tests {
             tee_required: true,
             tee_type: 1,
             attestation_nonce: String::new(), // Tdx
-        capabilities_json: String::new(),
+            capabilities_json: String::new(),
         };
 
         let params = CreateSandboxParams::from(&request);
@@ -1172,7 +1172,7 @@ mod conversion_tests {
                 tee_required: true,
                 tee_type: tee_type_id,
                 attestation_nonce: String::new(),
-            capabilities_json: String::new(),
+                capabilities_json: String::new(),
             };
 
             let params = CreateSandboxParams::from(&request);
@@ -1905,7 +1905,7 @@ fn set_instance_for_test_with_owner(url: &str, token: &str, owner: &str) -> Stri
                 extra_ports: std::collections::HashMap::new(),
                 ssh_login_user: None,
                 ssh_authorized_keys: Vec::new(),
-            capabilities_json: String::new(),
+                capabilities_json: String::new(),
             },
         )
         .unwrap();
@@ -1947,7 +1947,7 @@ fn set_instance_for_test_with_owner(url: &str, token: &str, owner: &str) -> Stri
         extra_ports: std::collections::HashMap::new(),
         ssh_login_user: None,
         ssh_authorized_keys: Vec::new(),
-            capabilities_json: String::new(),
+        capabilities_json: String::new(),
     };
     set_instance_sandbox(record).unwrap();
     id

--- a/ai-agent-instance-blueprint-lib/tests/integration.rs
+++ b/ai-agent-instance-blueprint-lib/tests/integration.rs
@@ -96,6 +96,7 @@ fn insert_sandbox(url: &str, token: &str) -> String {
                 extra_ports: std::collections::HashMap::new(),
                 ssh_login_user: None,
                 ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
             },
         )
         .unwrap();
@@ -146,6 +147,7 @@ fn insert_ssh_sandbox(url: &str, token: &str) -> String {
                 extra_ports: std::collections::HashMap::new(),
                 ssh_login_user: None,
                 ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
             },
         )
         .unwrap();
@@ -840,6 +842,7 @@ mod instance_state_tests {
             extra_ports: std::collections::HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
 
         set_instance_sandbox(record).unwrap();
@@ -893,6 +896,7 @@ mod instance_state_tests {
             extra_ports: std::collections::HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
 
         set_instance_sandbox(record).unwrap();
@@ -1014,6 +1018,7 @@ mod abi_tests {
             tee_required: true,
             tee_type: 2,
             attestation_nonce: String::new(), // Nitro
+        capabilities_json: String::new(),
         };
 
         let encoded = request.abi_encode();
@@ -1097,6 +1102,7 @@ mod conversion_tests {
             tee_required: true,
             tee_type: 1,
             attestation_nonce: String::new(), // Tdx
+        capabilities_json: String::new(),
         };
 
         let params = CreateSandboxParams::from(&request);
@@ -1132,6 +1138,7 @@ mod conversion_tests {
             tee_required: false,
             tee_type: 0,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         };
 
         let params = CreateSandboxParams::from(&request);
@@ -1165,6 +1172,7 @@ mod conversion_tests {
                 tee_required: true,
                 tee_type: tee_type_id,
                 attestation_nonce: String::new(),
+            capabilities_json: String::new(),
             };
 
             let params = CreateSandboxParams::from(&request);
@@ -1531,6 +1539,7 @@ mod provision_guard_tests {
             extra_ports: std::collections::HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
         set_instance_sandbox(record).unwrap();
 
@@ -1586,6 +1595,7 @@ mod provision_guard_tests {
             extra_ports: std::collections::HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
         set_instance_sandbox(record).unwrap();
         assert!(get_instance_sandbox().unwrap().is_some());
@@ -1643,6 +1653,7 @@ mod provision_guard_tests {
             extra_ports: std::collections::HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
 
         set_instance_sandbox(record).unwrap();
@@ -1714,6 +1725,7 @@ mod provision_guard_tests {
             extra_ports: std::collections::HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
 
         let record_b = SandboxRecord {
@@ -1753,6 +1765,7 @@ mod provision_guard_tests {
             extra_ports: std::collections::HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
 
         set_instance_sandbox(record_a).unwrap();
@@ -1812,6 +1825,7 @@ mod provision_guard_tests {
             extra_ports: std::collections::HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
         set_instance_sandbox(record).unwrap();
 
@@ -1891,6 +1905,7 @@ fn set_instance_for_test_with_owner(url: &str, token: &str, owner: &str) -> Stri
                 extra_ports: std::collections::HashMap::new(),
                 ssh_login_user: None,
                 ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
             },
         )
         .unwrap();
@@ -1932,6 +1947,7 @@ fn set_instance_for_test_with_owner(url: &str, token: &str, owner: &str) -> Stri
         extra_ports: std::collections::HashMap::new(),
         ssh_login_user: None,
         ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
     };
     set_instance_sandbox(record).unwrap();
     id
@@ -2605,6 +2621,7 @@ mod auto_provision_tests {
             tee_required: false,
             tee_type: 0,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         };
 
         // abi_encode() produces tuple encoding (with outer offset prefix).

--- a/ai-agent-sandbox-blueprint-lib/src/lib.rs
+++ b/ai-agent-sandbox-blueprint-lib/src/lib.rs
@@ -83,6 +83,17 @@ sol! {
         uint8 tee_type;
         /// Hex-encoded 32-64 byte caller nonce to embed in deploy-time attestation.
         string attestation_nonce;
+        /// JSON array of sidecar capabilities to enable at boot.
+        /// Currently supported: ["computer_use"] — boots Xvfb + dbus + an MCP
+        /// server inside the sandbox so the Anthropic / OpenAI Responses
+        /// computer-use surfaces can drive mouse/keyboard/screenshots. Empty
+        /// or "" means no extra subsystems are started.
+        ///
+        /// Wire format: a JSON-encoded array of strings, e.g.
+        /// `["computer_use"]`. Encoded as a string (rather than `string[]`)
+        /// to match the existing `_json` convention on this struct
+        /// (`env_json`, `metadata_json`) so the ABI stays uniform.
+        string capabilities_json;
     }
 
     /// Sandbox identifier request.
@@ -288,6 +299,7 @@ impl From<&SandboxCreateRequest> for CreateSandboxParams {
             tee_config,
             user_env_json: String::new(),
             port_mappings: Vec::new(), // Parsed from metadata_json at runtime
+            capabilities_json: r.capabilities_json.to_string(),
         }
     }
 }

--- a/ai-agent-sandbox-blueprint-lib/tests/anvil.rs
+++ b/ai-agent-sandbox-blueprint-lib/tests/anvil.rs
@@ -236,6 +236,7 @@ async fn runs_sandbox_jobs_end_to_end() -> Result<()> {
             tee_required: false,
             tee_type: 0,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         }
         .abi_encode();
 
@@ -539,6 +540,7 @@ async fn runs_firecracker_jobs_end_to_end() -> Result<()> {
             tee_required: false,
             tee_type: 0,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         }
         .abi_encode();
 

--- a/ai-agent-sandbox-blueprint-lib/tests/e2e_operator_api.rs
+++ b/ai-agent-sandbox-blueprint-lib/tests/e2e_operator_api.rs
@@ -139,6 +139,7 @@ async fn sandbox_full_lifecycle() -> Result<()> {
             tee_required: false,
             tee_type: 0,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         }
         .abi_encode();
 
@@ -832,6 +833,7 @@ async fn workflow_create_and_cancel() -> Result<()> {
             tee_required: false,
             tee_type: 0,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         }
         .abi_encode();
 

--- a/ai-agent-sandbox-blueprint-lib/tests/integration.rs
+++ b/ai-agent-sandbox-blueprint-lib/tests/integration.rs
@@ -104,6 +104,7 @@ fn insert_sandbox(url: &str, token: &str) -> String {
                 extra_ports: std::collections::HashMap::new(),
                 ssh_login_user: None,
                 ssh_authorized_keys: Vec::new(),
+                capabilities_json: String::new(),
             },
         )
         .unwrap();
@@ -154,6 +155,7 @@ fn insert_ssh_sandbox(url: &str, token: &str) -> String {
                 extra_ports: std::collections::HashMap::new(),
                 ssh_login_user: None,
                 ssh_authorized_keys: Vec::new(),
+                capabilities_json: String::new(),
             },
         )
         .unwrap();
@@ -204,6 +206,7 @@ fn insert_sandbox_with_owner(url: &str, token: &str, owner: &str) -> String {
                 extra_ports: std::collections::HashMap::new(),
                 ssh_login_user: None,
                 ssh_authorized_keys: Vec::new(),
+                capabilities_json: String::new(),
             },
         )
         .unwrap();
@@ -1410,6 +1413,7 @@ mod abi {
             tee_required: false,
             tee_type: 0,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         };
         let d = SandboxCreateRequest::abi_decode(&req.abi_encode()).unwrap();
         assert_eq!(d.name, "t");
@@ -1545,6 +1549,7 @@ mod abi {
                 tee_required: false,
                 tee_type: 0,
                 attestation_nonce: String::new(),
+            capabilities_json: String::new(),
             },
             operators: vec![Address::ZERO],
             distribution: "round-robin".into(),
@@ -1609,6 +1614,7 @@ mod abi {
             tee_required,
             tee_type,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         }
     }
 
@@ -1904,6 +1910,7 @@ mod docker {
             tee_required: false,
             tee_type: 0,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         };
 
         let record = match create_sidecar(&CreateSandboxParams::from(&request), None).await {
@@ -1985,6 +1992,7 @@ mod docker {
             tee_required: false,
             tee_type: 0,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         };
 
         let record = match create_sidecar(&CreateSandboxParams::from(&request), None).await {
@@ -2048,6 +2056,7 @@ mod docker {
             tee_required: false,
             tee_type: 0,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         };
 
         let record = match create_sidecar(&CreateSandboxParams::from(&request), None).await {
@@ -2149,6 +2158,7 @@ mod docker {
             tee_required: false,
             tee_type: 0,
             attestation_nonce: String::new(),
+            capabilities_json: String::new(),
         };
 
         let record = match create_sidecar(&CreateSandboxParams::from(&request), None).await {

--- a/ai-agent-sandbox-blueprint-lib/tests/integration.rs
+++ b/ai-agent-sandbox-blueprint-lib/tests/integration.rs
@@ -1549,7 +1549,7 @@ mod abi {
                 tee_required: false,
                 tee_type: 0,
                 attestation_nonce: String::new(),
-            capabilities_json: String::new(),
+                capabilities_json: String::new(),
             },
             operators: vec![Address::ZERO],
             distribution: "round-robin".into(),

--- a/ai-agent-sandbox-blueprint-lib/tests/snapshot_integration.rs
+++ b/ai-agent-sandbox-blueprint-lib/tests/snapshot_integration.rs
@@ -159,7 +159,7 @@ async fn create_test_sandbox() -> SandboxRecord {
         tee_required: false,
         tee_type: 0,
         attestation_nonce: String::new(),
-            capabilities_json: String::new(),
+        capabilities_json: String::new(),
     };
     create_sidecar(&CreateSandboxParams::from(&request), None)
         .await
@@ -188,7 +188,7 @@ async fn create_test_sandbox_with_destination(dest: &str) -> SandboxRecord {
         tee_required: false,
         tee_type: 0,
         attestation_nonce: String::new(),
-            capabilities_json: String::new(),
+        capabilities_json: String::new(),
     };
     create_sidecar(&CreateSandboxParams::from(&request), None)
         .await
@@ -823,7 +823,7 @@ async fn tiered_gc_cold_to_gone_real() {
         extra_ports: std::collections::HashMap::new(),
         ssh_login_user: None,
         ssh_authorized_keys: Vec::new(),
-            capabilities_json: String::new(),
+        capabilities_json: String::new(),
     };
 
     sandboxes()
@@ -926,7 +926,7 @@ async fn user_byos3_never_deleted_by_gc() {
         extra_ports: std::collections::HashMap::new(),
         ssh_login_user: None,
         ssh_authorized_keys: Vec::new(),
-            capabilities_json: String::new(),
+        capabilities_json: String::new(),
     };
 
     sandboxes()

--- a/ai-agent-sandbox-blueprint-lib/tests/snapshot_integration.rs
+++ b/ai-agent-sandbox-blueprint-lib/tests/snapshot_integration.rs
@@ -159,6 +159,7 @@ async fn create_test_sandbox() -> SandboxRecord {
         tee_required: false,
         tee_type: 0,
         attestation_nonce: String::new(),
+            capabilities_json: String::new(),
     };
     create_sidecar(&CreateSandboxParams::from(&request), None)
         .await
@@ -187,6 +188,7 @@ async fn create_test_sandbox_with_destination(dest: &str) -> SandboxRecord {
         tee_required: false,
         tee_type: 0,
         attestation_nonce: String::new(),
+            capabilities_json: String::new(),
     };
     create_sidecar(&CreateSandboxParams::from(&request), None)
         .await
@@ -821,6 +823,7 @@ async fn tiered_gc_cold_to_gone_real() {
         extra_ports: std::collections::HashMap::new(),
         ssh_login_user: None,
         ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
     };
 
     sandboxes()
@@ -923,6 +926,7 @@ async fn user_byos3_never_deleted_by_gc() {
         extra_ports: std::collections::HashMap::new(),
         ssh_login_user: None,
         ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
     };
 
     sandboxes()

--- a/ai-agent-tee-instance-blueprint-lib/tests/tee_config.rs
+++ b/ai-agent-tee-instance-blueprint-lib/tests/tee_config.rs
@@ -31,7 +31,7 @@ fn make_provision_request(name: &str, tee_required: bool, tee_type: u8) -> Provi
         tee_required,
         tee_type,
         attestation_nonce: String::new(),
-            capabilities_json: String::new(),
+        capabilities_json: String::new(),
     }
 }
 
@@ -77,7 +77,7 @@ fn decode_provision_config_tee_required_tdx() {
         tee_required: true,
         tee_type: 1,
         attestation_nonce: String::new(), // Tdx
-    capabilities_json: String::new(),
+        capabilities_json: String::new(),
     };
 
     let encoded = req.abi_encode_params();

--- a/ai-agent-tee-instance-blueprint-lib/tests/tee_config.rs
+++ b/ai-agent-tee-instance-blueprint-lib/tests/tee_config.rs
@@ -31,6 +31,7 @@ fn make_provision_request(name: &str, tee_required: bool, tee_type: u8) -> Provi
         tee_required,
         tee_type,
         attestation_nonce: String::new(),
+            capabilities_json: String::new(),
     }
 }
 
@@ -76,6 +77,7 @@ fn decode_provision_config_tee_required_tdx() {
         tee_required: true,
         tee_type: 1,
         attestation_nonce: String::new(), // Tdx
+    capabilities_json: String::new(),
     };
 
     let encoded = req.abi_encode_params();
@@ -281,6 +283,7 @@ fn tee_fields_persistence_roundtrip() {
         extra_ports: std::collections::HashMap::new(),
         ssh_login_user: None,
         ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
     };
 
     set_instance_sandbox(record).unwrap();

--- a/ai-agent-tee-instance-blueprint-lib/tests/tee_integration.rs
+++ b/ai-agent-tee-instance-blueprint-lib/tests/tee_integration.rs
@@ -173,7 +173,7 @@ fn tee_deprovision_clears_instance_sandbox() {
         extra_ports: std::collections::HashMap::new(),
         ssh_login_user: None,
         ssh_authorized_keys: Vec::new(),
-            capabilities_json: String::new(),
+        capabilities_json: String::new(),
     };
 
     set_instance_sandbox(record).unwrap();

--- a/ai-agent-tee-instance-blueprint-lib/tests/tee_integration.rs
+++ b/ai-agent-tee-instance-blueprint-lib/tests/tee_integration.rs
@@ -83,6 +83,7 @@ fn tee_provision_idempotent_returns_stored_attestation() {
         extra_ports: std::collections::HashMap::new(),
         ssh_login_user: None,
         ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
     };
 
     set_instance_sandbox(record).unwrap();
@@ -172,6 +173,7 @@ fn tee_deprovision_clears_instance_sandbox() {
         extra_ports: std::collections::HashMap::new(),
         ssh_login_user: None,
         ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
     };
 
     set_instance_sandbox(record).unwrap();

--- a/ai-agent-tee-instance-blueprint-lib/tests/tee_provision.rs
+++ b/ai-agent-tee-instance-blueprint-lib/tests/tee_provision.rs
@@ -52,6 +52,7 @@ fn tee_provision_request() -> ProvisionRequest {
         tee_required: true,
         tee_type: 1,
         attestation_nonce: String::new(), // Tdx
+        capabilities_json: String::new(),
     }
 }
 

--- a/sandbox-runtime/src/contracts.rs
+++ b/sandbox-runtime/src/contracts.rs
@@ -107,6 +107,7 @@ impl SandboxProvider for DockerSandboxProvider {
             tee_config: req.tee,
             user_env_json: "{}".to_string(),
             port_mappings: Vec::new(),
+            capabilities_json: String::new(),
         };
 
         let (record, attestation) = create_sidecar(&params, self.tee_backend.as_deref()).await?;

--- a/sandbox-runtime/src/operator_api.rs
+++ b/sandbox-runtime/src/operator_api.rs
@@ -6165,6 +6165,7 @@ data: {{\"finalText\":\"mock-agent-response\",\"metadata\":{{\"sessionId\":\"{se
             extra_ports: std::collections::HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
         seal_record(&mut record).unwrap();
         sandboxes().unwrap().insert(id.to_string(), record).unwrap();
@@ -6217,6 +6218,7 @@ data: {{\"finalText\":\"mock-agent-response\",\"metadata\":{{\"sessionId\":\"{se
             extra_ports: std::collections::HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
         seal_record(&mut record).unwrap();
         sandboxes().unwrap().insert(id.to_string(), record).unwrap();
@@ -7352,6 +7354,7 @@ data: {{\"finalText\":\"mock-agent-response\",\"metadata\":{{\"sessionId\":\"{se
             tee_config: None,
             user_env_json: String::new(),
             port_mappings: Vec::new(),
+            capabilities_json: String::new(),
         };
 
         let created = match crate::runtime::create_sidecar(&request, None).await {
@@ -8224,6 +8227,7 @@ data: {\"finalText\":\"first reply\",\"metadata\":{\"sessionId\":\"backend-resul
             extra_ports: ports,
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
         seal_record(&mut record).unwrap();
         sandboxes().unwrap().insert(id.to_string(), record).unwrap();

--- a/sandbox-runtime/src/reaper.rs
+++ b/sandbox-runtime/src/reaper.rs
@@ -627,6 +627,7 @@ mod tests {
             extra_ports: std::collections::HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         }
     }
 

--- a/sandbox-runtime/src/runtime.rs
+++ b/sandbox-runtime/src/runtime.rs
@@ -3615,7 +3615,9 @@ mod sidecar_capability_tests {
     fn build_env_vars_omits_capabilities_when_unset() {
         let env_vars = build_env_vars("{}", "tok", 8080, "").unwrap();
         assert!(
-            !env_vars.iter().any(|v| v.starts_with("SIDECAR_CAPABILITIES=")),
+            !env_vars
+                .iter()
+                .any(|v| v.starts_with("SIDECAR_CAPABILITIES=")),
             "expected no SIDECAR_CAPABILITIES env var, got {env_vars:?}",
         );
     }
@@ -4117,13 +4119,8 @@ mod core_logic_tests {
 
     #[test]
     fn env_vars_with_json() {
-        let vars = build_env_vars(
-            r#"{"API_KEY":"sk-test","DEBUG":"true"}"#,
-            "tok",
-            8080,
-            "",
-        )
-        .unwrap();
+        let vars =
+            build_env_vars(r#"{"API_KEY":"sk-test","DEBUG":"true"}"#, "tok", 8080, "").unwrap();
         assert!(vars.contains(&"API_KEY=sk-test".to_string()));
         assert!(vars.contains(&"DEBUG=true".to_string()));
         assert!(vars.contains(&"SIDECAR_PORT=8080".to_string()));

--- a/sandbox-runtime/src/runtime.rs
+++ b/sandbox-runtime/src/runtime.rs
@@ -91,6 +91,52 @@ pub struct CreateSandboxParams {
     /// Extra container ports to expose (e.g. user web server on 3000).
     /// Parsed from `metadata_json.ports` at creation time.
     pub port_mappings: Vec<u16>,
+    /// Sidecar capabilities to enable at boot, encoded as a JSON array
+    /// (e.g. `["computer_use"]`). Currently supported entries: `computer_use`.
+    /// When non-empty, the runtime sets `SIDECAR_CAPABILITIES` on the
+    /// container env so the sidecar boots Xvfb / dbus / MCP at startup.
+    /// Empty string means no extra subsystems start.
+    pub capabilities_json: String,
+}
+
+/// Parse the `capabilities_json` field into the comma-separated wire
+/// format the sidecar's `SIDECAR_CAPABILITIES` parser expects.
+///
+/// Mirrors the parser in
+/// `apps/orchestrator/src/orchestrator/sidecar-capabilities.ts` (the
+/// adjacent agent-dev-container repo) so both wire formats stay in
+/// lockstep — JSON array on input, comma-separated list on the env
+/// var, and unknown entries dropped silently. Returns `None` when
+/// nothing recognizable is present so callers can skip the env-var
+/// injection entirely.
+pub(crate) fn parse_sidecar_capabilities(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Accept either a JSON array (the on-wire form) or a plain
+    // comma-separated list as a convenience for direct callers.
+    let entries: Vec<String> = if trimmed.starts_with('[') {
+        match serde_json::from_str::<Vec<String>>(trimmed) {
+            Ok(v) => v,
+            Err(_) => return None,
+        }
+    } else {
+        trimmed
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    };
+    let known: Vec<String> = entries
+        .into_iter()
+        .filter(|c| c == "computer_use")
+        .collect();
+    if known.is_empty() {
+        None
+    } else {
+        Some(known.join(","))
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -360,6 +406,13 @@ pub struct SandboxRecord {
     /// Persisted SSH key assignments so they can be replayed after recreation.
     #[serde(default)]
     pub ssh_authorized_keys: Vec<SshAuthorizedKey>,
+    /// Sidecar capabilities the sandbox was created with (e.g.
+    /// `["computer_use"]`), preserved verbatim from the create request
+    /// so snapshot-restore and recreation hand the same capability set
+    /// back to the sidecar. Empty string when no extra capabilities
+    /// were requested.
+    #[serde(default)]
+    pub capabilities_json: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -1159,6 +1212,7 @@ async fn create_sidecar_tee(
         extra_ports: deployment.extra_ports,
         ssh_login_user: None,
         ssh_authorized_keys: Vec::new(),
+        capabilities_json: request.capabilities_json.clone(),
     };
 
     let mut sealed = record.clone();
@@ -1966,6 +2020,9 @@ async fn create_sidecar_firecracker(
         "SIDECAR_PORT".to_string(),
         config.container_port.to_string(),
     );
+    if let Some(caps) = parse_sidecar_capabilities(&request.capabilities_json) {
+        env.insert("SIDECAR_CAPABILITIES".to_string(), caps);
+    }
     if !effective_env.trim().is_empty() {
         if let Some(Value::Object(map)) = parse_json_object(&effective_env, "env_json")? {
             for (key, value) in map {
@@ -2047,6 +2104,7 @@ async fn create_sidecar_firecracker(
         extra_ports: HashMap::new(),
         ssh_login_user: None,
         ssh_authorized_keys: Vec::new(),
+        capabilities_json: request.capabilities_json.clone(),
     };
 
     let mut sealed = record.clone();
@@ -2119,7 +2177,12 @@ pub fn workflow_runtime_credentials_available(env_json: &str) -> Result<bool> {
 }
 
 /// Build the `Vec<String>` of `KEY=VALUE` env vars for a Docker container.
-fn build_env_vars(env_json: &str, token: &str, container_port: u16) -> Result<Vec<String>> {
+fn build_env_vars(
+    env_json: &str,
+    token: &str,
+    container_port: u16,
+    capabilities_json: &str,
+) -> Result<Vec<String>> {
     let mut env_vars = vec![
         format!("SIDECAR_PORT={container_port}"),
         format!("SIDECAR_AUTH_TOKEN={token}"),
@@ -2130,6 +2193,14 @@ fn build_env_vars(env_json: &str, token: &str, container_port: u16) -> Result<Ve
         "AGENT_SUBPROCESS_UID=1000".to_string(),
         "AGENT_SUBPROCESS_GID=1000".to_string(),
     ];
+
+    // Sidecar capabilities (e.g. `computer_use`). Inject before user env
+    // so a malformed user-supplied SIDECAR_CAPABILITIES override would
+    // win — but in practice users do not set this and the env-var name
+    // is documented as runtime-controlled.
+    if let Some(caps) = parse_sidecar_capabilities(capabilities_json) {
+        env_vars.push(format!("SIDECAR_CAPABILITIES={caps}"));
+    }
 
     // User-supplied env vars are appended after defaults so they can override.
     let env_map = parse_json_object(env_json, "env_json")?;
@@ -2298,7 +2369,12 @@ async fn create_sidecar_docker(
     let container_name = format!("sidecar-{sandbox_id}");
 
     let effective_env = merge_env_json(&request.env_json, &request.user_env_json);
-    let env_vars = build_env_vars(&effective_env, &token, config.container_port)?;
+    let env_vars = build_env_vars(
+        &effective_env,
+        &token,
+        config.container_port,
+        &request.capabilities_json,
+    )?;
 
     let metadata = parse_json_object(&request.metadata_json, "metadata_json")?;
     // Extract snapshot_destination before metadata is consumed by merge/labels
@@ -2464,6 +2540,7 @@ async fn create_sidecar_docker(
             extra_ports: extra_port_map,
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: request.capabilities_json.clone(),
         };
 
         let mut sealed = record.clone();
@@ -2867,6 +2944,11 @@ pub async fn recreate_sidecar_with_env(
         service_id: old.service_id,
         tee_config: old.tee_config.clone(),
         port_mappings: old.extra_ports.keys().copied().collect(),
+        // Replay the capability set the sandbox was originally booted
+        // with — recreation after secret-injection / wipe must hand the
+        // sidecar the same SIDECAR_CAPABILITIES it had before, otherwise
+        // computer_use sandboxes lose Xvfb on every refresh.
+        capabilities_json: old.capabilities_json.clone(),
     };
 
     // Preserve the original token so existing workflows/references keep working.
@@ -2961,7 +3043,12 @@ pub async fn create_from_snapshot_image(record: &SandboxRecord) -> Result<Sandbo
 
     let ssh_enabled = record.ssh_port.is_some();
     let effective_env = record.effective_env_json();
-    let env_vars = build_env_vars(&effective_env, &record.token, config.container_port)?;
+    let env_vars = build_env_vars(
+        &effective_env,
+        &record.token,
+        config.container_port,
+        &record.capabilities_json,
+    )?;
     let ep: Vec<u16> = record.extra_ports.keys().copied().collect();
     let override_config = build_docker_config(
         config,
@@ -3054,7 +3141,12 @@ pub async fn create_and_restore_from_s3(record: &SandboxRecord) -> Result<Sandbo
 
     let ssh_enabled = record.ssh_port.is_some();
     let effective_env = record.effective_env_json();
-    let env_vars = build_env_vars(&effective_env, &record.token, config.container_port)?;
+    let env_vars = build_env_vars(
+        &effective_env,
+        &record.token,
+        config.container_port,
+        &record.capabilities_json,
+    )?;
     let ep: Vec<u16> = record.extra_ports.keys().copied().collect();
     let override_config = build_docker_config(
         config,
@@ -3461,6 +3553,75 @@ mod port_mapping_tests {
 }
 
 #[cfg(test)]
+mod sidecar_capability_tests {
+    use super::*;
+
+    #[test]
+    fn parse_sidecar_capabilities_handles_json_array() {
+        assert_eq!(
+            parse_sidecar_capabilities(r#"["computer_use"]"#).as_deref(),
+            Some("computer_use"),
+        );
+    }
+
+    #[test]
+    fn parse_sidecar_capabilities_handles_comma_list() {
+        assert_eq!(
+            parse_sidecar_capabilities("computer_use").as_deref(),
+            Some("computer_use"),
+        );
+        // Tolerate whitespace.
+        assert_eq!(
+            parse_sidecar_capabilities("  computer_use  ").as_deref(),
+            Some("computer_use"),
+        );
+    }
+
+    #[test]
+    fn parse_sidecar_capabilities_drops_unknown_silently() {
+        // Forward-compat: a future SDK that names a cap this orchestrator
+        // does not yet know must not crash the create — it just won't get
+        // the unrecognized subsystem.
+        assert_eq!(
+            parse_sidecar_capabilities(r#"["computer_use","future_cap"]"#).as_deref(),
+            Some("computer_use"),
+        );
+        assert!(parse_sidecar_capabilities("future_cap").is_none());
+    }
+
+    #[test]
+    fn parse_sidecar_capabilities_handles_empty_or_malformed() {
+        assert!(parse_sidecar_capabilities("").is_none());
+        assert!(parse_sidecar_capabilities("   ").is_none());
+        assert!(parse_sidecar_capabilities("[]").is_none());
+        assert!(parse_sidecar_capabilities("[not json").is_none());
+    }
+
+    #[test]
+    fn build_env_vars_injects_sidecar_capabilities_for_docker() {
+        // Regression: the Docker runtime path must put SIDECAR_CAPABILITIES
+        // on the container env so the sidecar boots Xvfb. The capability
+        // contract is identical across Docker / Firecracker / TEE; this
+        // pins the Docker side. (TEE is covered by tee_deploy_params_*
+        // in tee/mod.rs and Firecracker is exercised by integration.)
+        let env_vars = build_env_vars("{}", "tok", 8080, r#"["computer_use"]"#).unwrap();
+        assert!(
+            env_vars.contains(&"SIDECAR_CAPABILITIES=computer_use".to_string()),
+            "expected SIDECAR_CAPABILITIES in env, got {env_vars:?}",
+        );
+    }
+
+    #[test]
+    fn build_env_vars_omits_capabilities_when_unset() {
+        let env_vars = build_env_vars("{}", "tok", 8080, "").unwrap();
+        assert!(
+            !env_vars.iter().any(|v| v.starts_with("SIDECAR_CAPABILITIES=")),
+            "expected no SIDECAR_CAPABILITIES env var, got {env_vars:?}",
+        );
+    }
+}
+
+#[cfg(test)]
 mod runtime_backend_tests {
     use super::*;
 
@@ -3754,6 +3915,7 @@ mod seal_tests {
             extra_ports: HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
 
         seal_record(&mut record).unwrap();
@@ -3955,7 +4117,13 @@ mod core_logic_tests {
 
     #[test]
     fn env_vars_with_json() {
-        let vars = build_env_vars(r#"{"API_KEY":"sk-test","DEBUG":"true"}"#, "tok", 8080).unwrap();
+        let vars = build_env_vars(
+            r#"{"API_KEY":"sk-test","DEBUG":"true"}"#,
+            "tok",
+            8080,
+            "",
+        )
+        .unwrap();
         assert!(vars.contains(&"API_KEY=sk-test".to_string()));
         assert!(vars.contains(&"DEBUG=true".to_string()));
         assert!(vars.contains(&"SIDECAR_PORT=8080".to_string()));
@@ -3963,13 +4131,13 @@ mod core_logic_tests {
 
     #[test]
     fn env_vars_invalid_json() {
-        let result = build_env_vars("not-json", "tok", 3000);
+        let result = build_env_vars("not-json", "tok", 3000, "");
         assert!(result.is_err());
     }
 
     #[test]
     fn env_vars_preserve_explicit_ai_env() {
-        let vars = build_env_vars(r#"{"ZAI_API_KEY":"user-key"}"#, "tok", 8080).unwrap();
+        let vars = build_env_vars(r#"{"ZAI_API_KEY":"user-key"}"#, "tok", 8080, "").unwrap();
         assert!(vars.contains(&"ZAI_API_KEY=user-key".to_string()));
         assert!(!vars.contains(&"OPENCODE_MODEL_API_KEY=user-key".to_string()));
     }

--- a/sandbox-runtime/src/secret_provisioning.rs
+++ b/sandbox-runtime/src/secret_provisioning.rs
@@ -189,6 +189,7 @@ mod tests {
             extra_ports: std::collections::HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
         seal_record(&mut record).unwrap();
         sandboxes()

--- a/sandbox-runtime/src/tee/mod.rs
+++ b/sandbox-runtime/src/tee/mod.rs
@@ -110,9 +110,7 @@ impl TeeDeployParams {
             ("SIDECAR_AUTH_TOKEN".to_string(), token.to_string()),
         ];
 
-        if let Some(caps) =
-            crate::runtime::parse_sidecar_capabilities(&params.capabilities_json)
-        {
+        if let Some(caps) = crate::runtime::parse_sidecar_capabilities(&params.capabilities_json) {
             env_vars.push(("SIDECAR_CAPABILITIES".to_string(), caps));
         }
 

--- a/sandbox-runtime/src/tee/mod.rs
+++ b/sandbox-runtime/src/tee/mod.rs
@@ -110,6 +110,12 @@ impl TeeDeployParams {
             ("SIDECAR_AUTH_TOKEN".to_string(), token.to_string()),
         ];
 
+        if let Some(caps) =
+            crate::runtime::parse_sidecar_capabilities(&params.capabilities_json)
+        {
+            env_vars.push(("SIDECAR_CAPABILITIES".to_string(), caps));
+        }
+
         // Parse env_json into env var pairs.
         if !params.env_json.trim().is_empty() {
             if let Ok(Some(serde_json::Value::Object(map))) =
@@ -775,6 +781,40 @@ mod tests {
         };
         let deploy = TeeDeployParams::from_sandbox_params("sb-2", &params, 8080, 2222, "tok");
         assert_eq!(deploy.ssh_port, None);
+    }
+
+    #[test]
+    fn tee_deploy_params_forwards_computer_use_capability() {
+        // Regression: a TEE-routed sandbox booted with capabilities=[
+        // "computer_use"] must hand SIDECAR_CAPABILITIES to the
+        // deploy params so the in-TEE sidecar boots Xvfb / dbus / MCP.
+        // Without this, the capability silently drops on the TEE
+        // path and a getMcpAccessToken call later 404s at /mcp.
+        let params = crate::runtime::CreateSandboxParams {
+            capabilities_json: r#"["computer_use"]"#.into(),
+            ..Default::default()
+        };
+        let deploy = TeeDeployParams::from_sandbox_params("sb-cu", &params, 8080, 22, "t");
+        assert!(
+            deploy
+                .env_vars
+                .contains(&("SIDECAR_CAPABILITIES".into(), "computer_use".into())),
+            "expected SIDECAR_CAPABILITIES in TEE env vars, got {:?}",
+            deploy.env_vars
+        );
+    }
+
+    #[test]
+    fn tee_deploy_params_omits_capabilities_when_unset() {
+        let params = crate::runtime::CreateSandboxParams::default();
+        let deploy = TeeDeployParams::from_sandbox_params("sb-empty", &params, 8080, 22, "t");
+        assert!(
+            !deploy
+                .env_vars
+                .iter()
+                .any(|(k, _)| k == "SIDECAR_CAPABILITIES"),
+            "expected no SIDECAR_CAPABILITIES env var when capabilities_json is empty",
+        );
     }
 
     #[test]

--- a/sandbox-runtime/tests/ssh_e2e.rs
+++ b/sandbox-runtime/tests/ssh_e2e.rs
@@ -151,6 +151,7 @@ async fn docker_ssh_supports_commands_and_interactive_shell() {
         tee_config: None,
         user_env_json: String::new(),
         port_mappings: Vec::new(),
+        capabilities_json: String::new(),
     };
 
     let (record, _) = create_sidecar(&params, None)

--- a/sandbox-runtime/tests/tee_integration.rs
+++ b/sandbox-runtime/tests/tee_integration.rs
@@ -218,6 +218,7 @@ mod tee_integration {
             extra_ports: HashMap::new(),
             ssh_login_user: None,
             ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
         };
 
         // The idempotent path reads from record.tee_attestation_json

--- a/scripts/tee-real-manager-e2e.sh
+++ b/scripts/tee-real-manager-e2e.sh
@@ -1,0 +1,463 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Production-style TEE instance fulfillment check.
+#
+# This script intentionally does not deploy contracts, start Anvil, or launch
+# blueprint binaries in test mode. It exercises the path a real operator uses:
+# deployed Tangle manager -> registered remote operator -> TEE instance service
+# request -> operator direct report -> caller-authenticated nonce attestation.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ZERO_ADDR="0x0000000000000000000000000000000000000000"
+ZERO_BYTES32="0x0000000000000000000000000000000000000000000000000000000000000000"
+PROVISION_TIMEOUT_SECONDS="${PROVISION_TIMEOUT_SECONDS:-900}"
+PROVISION_POLL_SECONDS="${PROVISION_POLL_SECONDS:-10}"
+REQUEST_TTL_SECONDS="${REQUEST_TTL_SECONDS:-31536000}"
+SERVICE_MEMBERSHIP_MODEL="${SERVICE_MEMBERSHIP_MODEL:-1}"
+APPROVAL_PERCENT="${APPROVAL_PERCENT:-100}"
+GAS_LIMIT="${GAS_LIMIT:-10000000}"
+TEE_TYPE_ID="${TEE_TYPE_ID:-2}"
+TEE_BACKEND="${TEE_BACKEND:-nitro}"
+SERVICE_NAME="${SERVICE_NAME:-prod-tee-sandbox}"
+SIDECAR_IMAGE="${SIDECAR_IMAGE:-ghcr.io/tangle-network/agent-dev-container-sidecar:latest}"
+STACK="${STACK:-default}"
+AGENT_IDENTIFIER="${AGENT_IDENTIFIER:-default-agent}"
+ENV_JSON="${ENV_JSON:-{}}"
+METADATA_JSON="${METADATA_JSON:-{}}"
+SSH_ENABLED="${SSH_ENABLED:-false}"
+SSH_PUBLIC_KEY="${SSH_PUBLIC_KEY:-}"
+MAX_LIFETIME_SECONDS="${MAX_LIFETIME_SECONDS:-3600}"
+IDLE_TIMEOUT_SECONDS="${IDLE_TIMEOUT_SECONDS:-900}"
+CPU_CORES="${CPU_CORES:-2}"
+MEMORY_MB="${MEMORY_MB:-4096}"
+DISK_GB="${DISK_GB:-20}"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  RPC_URL=... \
+  TANGLE_CONTRACT=... \
+  TEE_INSTANCE_BLUEPRINT_ID=... \
+  TEE_INSTANCE_BSM=... \
+  USER_KEY=... \
+  OPERATOR_KEY=... \
+  OPERATOR_RPC_ENDPOINT=https://operator.example.com \
+  TEE_OPERATOR_API_URL=https://operator.example.com \
+  scripts/tee-real-manager-e2e.sh
+
+Required:
+  RPC_URL                    Deployed Tangle EVM RPC URL
+  TANGLE_CONTRACT            Deployed Tangle service manager/precompile address
+  TEE_INSTANCE_BLUEPRINT_ID  Registered ai-agent-tee-instance blueprint id
+  TEE_INSTANCE_BSM           Deployed TEE instance Blueprint Service Manager
+  USER_KEY                   Customer private key requesting the service
+  OPERATOR_KEY               Remote operator private key, unless SKIP_REGISTER_OPERATOR=1 and
+                             SKIP_APPROVE_SERVICE=1 are both set
+  OPERATOR_RPC_ENDPOINT      Public endpoint registered for the operator, unless
+                             SKIP_REGISTER_OPERATOR=1
+  TEE_OPERATOR_API_URL       Operator API URL used to fetch attestation
+
+Optional:
+  SKIP_REGISTER_OPERATOR=1       Reuse an already registered operator
+  SKIP_CONFIGURE_PRICING=1       Do not run ConfigureJobRates.s.sol
+  SKIP_REQUEST_SERVICE=1         Reuse SERVICE_ID instead of requesting a service
+  SKIP_APPROVE_SERVICE=1         Do not approve the service request
+  SERVICE_ID=...                 Existing service id when SKIP_REQUEST_SERVICE=1
+  TEE_ATTESTATION_NONCE=0x...    32-64 byte nonce; generated if omitted
+  VERIFY_ATTESTATION_CMD='...'   Command run with ATTESTATION_JSON, ATTESTATION_NONCE,
+                                 TEE_BACKEND, SERVICE_ID, SANDBOX_ID exported
+  ALLOW_LOCAL=1                  Permit localhost URLs for rehearsal only
+
+This script fails if the operator does not report a TEE attestation hash on-chain
+and if it cannot fetch a nonce-bound attestation artifact from the operator API.
+EOF
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+log() {
+    echo "==> $*"
+}
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+require_env() {
+    local name="$1"
+    [[ -n "${!name:-}" ]] || die "missing required env var: $name"
+}
+
+normalize_uint() {
+    local value
+    value="$(echo "${1:-0}" | awk '{print $1}')"
+    value="${value#0x}"
+    value="$(echo "$value" | sed 's/^0*//')"
+    [[ -n "$value" ]] || value="0"
+    echo "$value"
+}
+
+is_local_url() {
+    local value="$1"
+    [[ "$value" =~ ^https?://(localhost|127\.0\.0\.1|0\.0\.0\.0)(:|/|$) ]]
+}
+
+post_json() {
+    local url="$1"
+    local body="$2"
+    shift 2
+    curl -fsS "$url" \
+        -H 'content-type: application/json' \
+        "$@" \
+        --data "$body"
+}
+
+get_json() {
+    local url="$1"
+    shift
+    curl -fsS "$url" "$@"
+}
+
+derive_address() {
+    cast wallet address --private-key "$1" | awk '{print $1}'
+}
+
+derive_pubkey_for_registration() {
+    local raw
+    raw="$(cast wallet public-key --private-key "$1" | head -1)"
+    raw="${raw#0x}"
+    if [[ "$raw" == 04* ]]; then
+        echo "0x$raw"
+    else
+        echo "0x04$raw"
+    fi
+}
+
+request_session_token() {
+    local challenge_json message nonce signature session_json
+
+    challenge_json="$(post_json "$TEE_OPERATOR_API_URL/api/auth/challenge" '{}')"
+    nonce="$(jq -er '.nonce' <<<"$challenge_json")"
+    message="$(jq -er '.message' <<<"$challenge_json")"
+    signature="$(cast wallet sign --private-key "$USER_KEY" "$message" | awk '{print $1}')"
+    session_json="$(post_json "$TEE_OPERATOR_API_URL/api/auth/session" "$(jq -nc --arg nonce "$nonce" --arg signature "$signature" '{nonce:$nonce, signature:$signature}')")"
+    jq -er '.token' <<<"$session_json"
+}
+
+discover_service_id() {
+    local before="$1"
+    local after="$2"
+    local service_id data word blueprint_num
+
+    if (( after <= before )); then
+        return 1
+    fi
+
+    for service_id in $(seq "$before" "$((after - 1))"); do
+        data="$(cast call "$TANGLE_CONTRACT" "getService(uint64)" "$service_id" --rpc-url "$RPC_URL" 2>/dev/null || true)"
+        [[ -n "$data" ]] || continue
+        word="$(echo "$data" | tr -d '\n' | head -c 66)"
+        blueprint_num="$(normalize_uint "$word")"
+        if [[ "$blueprint_num" == "$TEE_INSTANCE_BLUEPRINT_ID" ]]; then
+            echo "$service_id"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+poll_operator_sandbox() {
+    local service_id="$1"
+    local token="$2"
+    local deadline now provision_json sandbox_id
+    deadline=$(( $(date +%s) + PROVISION_TIMEOUT_SECONDS ))
+
+    while true; do
+        sandbox_id="$(
+            get_json "$TEE_OPERATOR_API_URL/api/sandboxes" -H "authorization: Bearer $token" \
+                | jq -er --arg sid "$service_id" '
+                    [
+                        .sandboxes[]?
+                        | select(((.service_id // .serviceId // "") | tostring) == $sid)
+                        | select((.tee_deployment_id // .teeDeploymentId // "") != "")
+                        | .id
+                    ][0]
+                ' 2>/dev/null || true
+        )"
+        if [[ -n "$sandbox_id" && "$sandbox_id" != "null" ]]; then
+            echo "$sandbox_id"
+            return 0
+        fi
+
+        provision_json="$(get_json "$TEE_OPERATOR_API_URL/api/provisions" || true)"
+        if [[ -n "$provision_json" ]]; then
+            sandbox_id="$(
+                jq -er --arg sid "$service_id" '
+                    [
+                        .provisions[]?
+                        | select(
+                            ((.service_id // .serviceId // .service // "") | tostring) == $sid
+                            or ((.metadata.service_id // .metadata.serviceId // "") | tostring) == $sid
+                          )
+                        | select(((.phase // .status // "") | tostring | ascii_downcase) == "ready")
+                        | (.sandbox_id // .sandboxId // .metadata.sandbox_id // .metadata.sandboxId // empty)
+                    ][0]
+                ' <<<"$provision_json" 2>/dev/null || true
+            )"
+            if [[ -n "$sandbox_id" && "$sandbox_id" != "null" ]]; then
+                echo "$sandbox_id"
+                return 0
+            fi
+        fi
+
+        now="$(date +%s)"
+        if (( now >= deadline )); then
+            return 1
+        fi
+        sleep "$PROVISION_POLL_SECONDS"
+    done
+}
+
+check_attestation_payload() {
+    local file="$1"
+    jq -e '
+        .sandbox_id as $sandbox
+        | .attestation as $att
+        | ($sandbox | type == "string" and length > 0)
+        and ($att | type == "object")
+        and (
+            ($att.evidence? | type == "array" and length > 0)
+            or ($att.evidence? | type == "string" and length > 0)
+            or ($att.evidence? | type == "object" and length > 0)
+            or ($att.quote? | type == "string" and length > 0)
+            or ($att.raw_quote? | type == "string" and length > 0)
+            or ($att.document? | type == "string" and length > 0)
+        )
+    ' "$file" >/dev/null
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+for cmd in cast curl jq openssl sed awk date; do
+    require_cmd "$cmd"
+done
+
+require_env RPC_URL
+require_env TANGLE_CONTRACT
+require_env TEE_INSTANCE_BLUEPRINT_ID
+require_env TEE_INSTANCE_BSM
+require_env USER_KEY
+require_env TEE_OPERATOR_API_URL
+
+if [[ "${SKIP_REGISTER_OPERATOR:-0}" != "1" ]]; then
+    require_env OPERATOR_RPC_ENDPOINT
+fi
+
+if [[ "${SKIP_REQUEST_SERVICE:-0}" == "1" ]]; then
+    require_env SERVICE_ID
+fi
+
+if [[ "${SKIP_REGISTER_OPERATOR:-0}" != "1" || "${SKIP_APPROVE_SERVICE:-0}" != "1" ]]; then
+    require_env OPERATOR_KEY
+fi
+
+if [[ "${ALLOW_LOCAL:-0}" != "1" ]]; then
+    is_local_url "$RPC_URL" && die "RPC_URL points at localhost; set ALLOW_LOCAL=1 only for rehearsal"
+    if [[ -n "${OPERATOR_RPC_ENDPOINT:-}" ]]; then
+        is_local_url "$OPERATOR_RPC_ENDPOINT" && die "OPERATOR_RPC_ENDPOINT points at localhost; set ALLOW_LOCAL=1 only for rehearsal"
+    fi
+    is_local_url "$TEE_OPERATOR_API_URL" && die "TEE_OPERATOR_API_URL points at localhost; set ALLOW_LOCAL=1 only for rehearsal"
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+USER_ADDR="${USER_ADDR:-$(derive_address "$USER_KEY")}"
+if [[ -n "${OPERATOR_KEY:-}" ]]; then
+    OPERATOR_ADDR="${OPERATOR_ADDR:-$(derive_address "$OPERATOR_KEY")}"
+else
+    require_env OPERATOR_ADDR
+fi
+
+if [[ -z "${TEE_ATTESTATION_NONCE:-}" ]]; then
+    TEE_ATTESTATION_NONCE="0x$(openssl rand -hex 32)"
+fi
+[[ "$TEE_ATTESTATION_NONCE" =~ ^0x[0-9a-fA-F]{64}([0-9a-fA-F]{64})?$ ]] \
+    || die "TEE_ATTESTATION_NONCE must be a 32-64 byte hex string"
+
+log "User:     $USER_ADDR"
+log "Operator: $OPERATOR_ADDR"
+log "TEE:      backend=$TEE_BACKEND type=$TEE_TYPE_ID nonce=$TEE_ATTESTATION_NONCE"
+
+if [[ "${SKIP_CONFIGURE_PRICING:-0}" != "1" ]]; then
+    require_cmd forge
+    if [[ -n "${PRICING_KEY:-${OPERATOR_KEY:-}}" ]]; then
+        log "Configuring TEE blueprint job rates"
+        BASE_RATE="${BASE_RATE:-1000000000000000}" \
+        BLUEPRINT_ID="$TEE_INSTANCE_BLUEPRINT_ID" \
+        TANGLE_ADDRESS="$TANGLE_CONTRACT" \
+        BSM_ADDRESS="$TEE_INSTANCE_BSM" \
+        forge script "$ROOT_DIR/contracts/script/ConfigureJobRates.s.sol:ConfigureJobRates" \
+            --rpc-url "$RPC_URL" \
+            --private-key "${PRICING_KEY:-$OPERATOR_KEY}" \
+            --broadcast >/dev/null
+    else
+        die "pricing requires PRICING_KEY or OPERATOR_KEY; set SKIP_CONFIGURE_PRICING=1 to skip"
+    fi
+else
+    log "Skipping pricing configuration"
+fi
+
+if [[ "${SKIP_REGISTER_OPERATOR:-0}" != "1" ]]; then
+    OPERATOR_PUBKEY="$(derive_pubkey_for_registration "$OPERATOR_KEY")"
+    log "Registering remote operator for TEE blueprint"
+    if ! cast send "$TANGLE_CONTRACT" \
+        "registerOperator(uint64,bytes,string)" \
+        "$TEE_INSTANCE_BLUEPRINT_ID" \
+        "$OPERATOR_PUBKEY" \
+        "$OPERATOR_RPC_ENDPOINT" \
+        --gas-limit "$GAS_LIMIT" \
+        --rpc-url "$RPC_URL" \
+        --private-key "$OPERATOR_KEY" >/dev/null; then
+        log "registerOperator failed; continuing only if already registered"
+    fi
+fi
+
+OPERATOR_REGISTERED="$(cast call "$TANGLE_CONTRACT" \
+    "isOperatorRegistered(uint64,address)(bool)" \
+    "$TEE_INSTANCE_BLUEPRINT_ID" \
+    "$OPERATOR_ADDR" \
+    --rpc-url "$RPC_URL" | awk '{print $1}')"
+[[ "$OPERATOR_REGISTERED" == "true" ]] || die "operator is not registered for TEE blueprint"
+
+if [[ "${SKIP_REQUEST_SERVICE:-0}" != "1" ]]; then
+    SERVICE_COUNT_BEFORE="$(normalize_uint "$(cast call "$TANGLE_CONTRACT" "serviceCount()(uint64)" --rpc-url "$RPC_URL")")"
+    REQUEST_ID="$(normalize_uint "$(cast call "$TANGLE_CONTRACT" "serviceRequestCount()(uint64)" --rpc-url "$RPC_URL")")"
+    SERVICE_CONFIG="$(cast abi-encode \
+        "f(string,string,string,string,string,string,bool,string,bool,uint64,uint64,uint64,uint64,uint64,bool,uint8,string)" \
+        "$SERVICE_NAME" "$SIDECAR_IMAGE" "$STACK" "$AGENT_IDENTIFIER" "$ENV_JSON" "$METADATA_JSON" \
+        "$SSH_ENABLED" "$SSH_PUBLIC_KEY" false \
+        "$MAX_LIFETIME_SECONDS" "$IDLE_TIMEOUT_SECONDS" "$CPU_CORES" "$MEMORY_MB" "$DISK_GB" \
+        true "$TEE_TYPE_ID" "$TEE_ATTESTATION_NONCE")"
+
+    log "Requesting TEE instance service request_id=$REQUEST_ID"
+    cast send "$TANGLE_CONTRACT" \
+        "requestService(uint64,address[],bytes,address[],uint64,address,uint256,uint8)" \
+        "$TEE_INSTANCE_BLUEPRINT_ID" \
+        "[$OPERATOR_ADDR]" \
+        "$SERVICE_CONFIG" \
+        "[$USER_ADDR]" \
+        "$REQUEST_TTL_SECONDS" \
+        "$ZERO_ADDR" \
+        0 \
+        "$SERVICE_MEMBERSHIP_MODEL" \
+        --gas-limit "$GAS_LIMIT" \
+        --rpc-url "$RPC_URL" \
+        --private-key "$USER_KEY" >/dev/null
+
+    if [[ "${SKIP_APPROVE_SERVICE:-0}" != "1" ]]; then
+        log "Approving TEE service request as operator"
+        cast send "$TANGLE_CONTRACT" \
+            "approveService(uint64,uint8)" \
+            "$REQUEST_ID" \
+            "$APPROVAL_PERCENT" \
+            --gas-limit "$GAS_LIMIT" \
+            --rpc-url "$RPC_URL" \
+            --private-key "$OPERATOR_KEY" >/dev/null
+    fi
+
+    SERVICE_COUNT_AFTER="$(normalize_uint "$(cast call "$TANGLE_CONTRACT" "serviceCount()(uint64)" --rpc-url "$RPC_URL")")"
+    SERVICE_ID="$(discover_service_id "$SERVICE_COUNT_BEFORE" "$SERVICE_COUNT_AFTER")" \
+        || die "could not discover TEE service id in service range $SERVICE_COUNT_BEFORE..$((SERVICE_COUNT_AFTER - 1))"
+else
+    log "Reusing existing TEE service id $SERVICE_ID"
+fi
+
+log "Waiting for on-chain TEE operator report for service_id=$SERVICE_ID"
+DEADLINE=$(( $(date +%s) + PROVISION_TIMEOUT_SECONDS ))
+while true; do
+    PROVISIONED="$(cast call "$TEE_INSTANCE_BSM" \
+        "isOperatorProvisioned(uint64,address)(bool)" \
+        "$SERVICE_ID" \
+        "$OPERATOR_ADDR" \
+        --rpc-url "$RPC_URL" | awk '{print $1}' || true)"
+    ATTESTATION_HASH="$(cast call "$TEE_INSTANCE_BSM" \
+        "getAttestationHash(uint64,address)(bytes32)" \
+        "$SERVICE_ID" \
+        "$OPERATOR_ADDR" \
+        --rpc-url "$RPC_URL" | awk '{print $1}' || true)"
+
+    if [[ "$PROVISIONED" == "true" && "$ATTESTATION_HASH" =~ ^0x[0-9a-fA-F]{64}$ && "$ATTESTATION_HASH" != "$ZERO_BYTES32" ]]; then
+        break
+    fi
+
+    if (( $(date +%s) >= DEADLINE )); then
+        die "operator did not report provisioned TEE service with non-empty attestation hash"
+    fi
+    sleep "$PROVISION_POLL_SECONDS"
+done
+
+log "On-chain report accepted: attestation_hash=$ATTESTATION_HASH"
+
+log "Authenticating to operator API as requester"
+SESSION_TOKEN="$(request_session_token)"
+
+SANDBOX_ID="${SANDBOX_ID:-$(poll_operator_sandbox "$SERVICE_ID" "$SESSION_TOKEN" || true)}"
+if [[ -z "$SANDBOX_ID" ]]; then
+    die "could not find TEE sandbox_id for service_id=$SERVICE_ID from authenticated operator API"
+fi
+
+ATTESTATION_JSON="$TMP_DIR/tee-attestation.json"
+log "Fetching nonce-bound attestation for sandbox_id=$SANDBOX_ID"
+post_json \
+    "$TEE_OPERATOR_API_URL/api/sandboxes/$SANDBOX_ID/tee/attestation" \
+    "$(jq -nc --arg nonce "$TEE_ATTESTATION_NONCE" '{attestation_nonce:$nonce}')" \
+    -H "authorization: Bearer $SESSION_TOKEN" > "$ATTESTATION_JSON"
+
+check_attestation_payload "$ATTESTATION_JSON" \
+    || die "operator returned malformed or empty attestation payload: $ATTESTATION_JSON"
+
+PERSISTED_ATTESTATION_JSON="$PWD/tee-real-manager-e2e-attestation.json"
+cp "$ATTESTATION_JSON" "$PERSISTED_ATTESTATION_JSON"
+
+if [[ -n "${VERIFY_ATTESTATION_CMD:-}" ]]; then
+    log "Running caller-side attestation verifier"
+    export ATTESTATION_JSON
+    export ATTESTATION_NONCE="$TEE_ATTESTATION_NONCE"
+    export TEE_BACKEND
+    export SERVICE_ID
+    export SANDBOX_ID
+    bash -c "$VERIFY_ATTESTATION_CMD"
+else
+    log "VERIFY_ATTESTATION_CMD not set; saved evidence for external verifier"
+fi
+
+RESULT_JSON="$PWD/tee-real-manager-e2e-result.json"
+jq -n \
+    --arg service_id "$SERVICE_ID" \
+    --arg sandbox_id "$SANDBOX_ID" \
+    --arg operator "$OPERATOR_ADDR" \
+    --arg attestation_hash "$ATTESTATION_HASH" \
+    --arg nonce "$TEE_ATTESTATION_NONCE" \
+    --arg tee_backend "$TEE_BACKEND" \
+    --arg attestation_json "$PERSISTED_ATTESTATION_JSON" \
+    '{
+        service_id: $service_id,
+        sandbox_id: $sandbox_id,
+        operator: $operator,
+        attestation_hash: $attestation_hash,
+        nonce: $nonce,
+        tee_backend: $tee_backend,
+        attestation_json: $attestation_json
+    }' > "$RESULT_JSON"
+
+log "TEE manager e2e passed"
+log "Result: $RESULT_JSON"

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -372,13 +372,14 @@ else
     # SandboxCreateRequest: (string name, string image, string stack, string agent_id,
     #   string env_json, string metadata_json, bool ssh, string ssh_key, bool web_term,
     #   uint64 max_life, uint64 idle, uint64 cpu, uint64 mem, uint64 disk,
-    #   bool tee, uint8 tee_type, string attestation_nonce)
+    #   bool tee, uint8 tee_type, string attestation_nonce, string capabilities_json)
     CREATE_ARGS=$(cast abi-encode \
-        "f(string,string,string,string,string,string,bool,string,bool,uint64,uint64,uint64,uint64,uint64,bool,uint8,string)" \
+        "f(string,string,string,string,string,string,bool,string,bool,uint64,uint64,uint64,uint64,uint64,bool,uint8,string,string)" \
         "e2e-sandbox" "${TANGLE_E2E_IMAGE:-${SIDECAR_IMAGE:-tangle-sidecar:local}}" "default" "default-agent" "{}" "{}" \
         false "" true \
         3600 900 2 2048 10 \
-        false 0 "")
+        false 0 "" \
+        "")
 
     SANDBOX_CALL_ID=$(submit_job "$SANDBOX_SERVICE_ID" 0 "$CREATE_ARGS" "$CREATE_RATE") || true
     if [ "$SANDBOX_CALL_ID" = "REVERT" ] || [ "$SANDBOX_CALL_ID" = "TX_FAIL" ]; then


### PR DESCRIPTION
## Summary

Adds `capabilities_json` to the on-chain `SandboxCreateRequest` ABI and threads it end-to-end so the agent-dev-container Tangle driver can hand `["computer_use"]` to the sidecar consistently across **all three** runtime backends (Docker, Firecracker, TEE).

Companion PR: tangle-network/agent-dev-container#901 (commit `6f1483bd`) — wires the orchestrator side: ABI declares the new field, `TangleDriver.supportedCapabilities` advertises `computer_use`, encoder reads `env.SIDECAR_CAPABILITIES` and forwards it as a JSON array.

## Wire path

`client.create({capabilities: ["computer_use"]})` → sandbox-api sets `SIDECAR_CAPABILITIES=computer_use` env → orchestrator create-gate accepts (TangleDriver advertises support) → tangle driver encodes `capabilities_json: ["computer_use"]` into `SandboxCreateRequest` → blueprint decodes via `TangleArg<SandboxCreateRequest>` → `parse_sidecar_capabilities` → `SIDECAR_CAPABILITIES=computer_use` injected into container env in **runtime.rs::build_env_vars** (Docker), **runtime.rs Firecracker env HashMap**, and **tee/mod.rs::TeeDeployParams::from_sandbox_params** (every TEE backend) → sidecar boots Xvfb + dbus + MCP at startup.

## What changed

- ABI: `SandboxCreateRequest.capabilities_json` + `ProvisionRequest.capabilities_json` (instance blueprint mirror).
- Runtime params: `CreateSandboxParams.capabilities_json` carries the value through.
- Persistence: `SandboxRecord.capabilities_json` preserved so snapshot/restore replays the same capability set rather than losing Xvfb on every refresh.
- Parser: `parse_sidecar_capabilities` accepts both JSON-array and comma-separated forms, drops unknown caps silently for forward-compat. Mirrors the orchestrator's TS parser byte-for-byte.
- Tests: 7 new regression tests (parser shape across formats + Docker `build_env_vars` + TEE `from_sandbox_params` injection).
- e2e harness: `scripts/test-e2e.sh` updated to encode the new field count on `submitJob`.
- Treated as greenfield per CLAUDE.md — no legacy ABI shims.

## Test plan

- [x] `cargo test --workspace` → 695 passing across all crates including the 86-test `e2e_operator_api` suite. No new ignores.
- [x] `cargo check --workspace` clean.
- [ ] Local e2e: `SKIP_BUILD=1 ./scripts/deploy-local.sh && ./scripts/test-e2e.sh` (existing harness; the create job now encodes 18 fields).
- [ ] Manual: create a sandbox with `capabilities_json: "[\"computer_use\"]"` end-to-end and verify `SIDECAR_CAPABILITIES=computer_use` reaches the container env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)