### PR TITLE
ci: pin Foundry to v1.5.1 (fixes nightly tag fetch 403)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.5.1
 
       - name: Verify Forge installation
         run: forge --version
@@ -90,7 +90,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.5.1
 
       - name: Verify Forge installation
         run: forge --version
@@ -164,6 +164,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.5.1
       - name: Install Solidity Dependencies
         run: forge soldeer update -d
       - name: Build
@@ -214,7 +216,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.5.1
 
       - name: Install Solidity Dependencies
         run: forge soldeer update -d
@@ -322,7 +324,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.5.1
 
       - name: Install Solidity Dependencies
         run: forge soldeer update -d
@@ -438,7 +440,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.5.1
 
       - name: Install Solidity Dependencies
         run: forge soldeer update -d


### PR DESCRIPTION
`foundry-rs/foundry-toolchain@v1` with `version: nightly` (or no version, which defaults to nightly) calls `api.github.com/repos/foundry-rs/foundry/releases` to resolve the latest nightly tag. That endpoint is unauthenticated and gets HTTP 403 rate-limited on busy CI windows, killing every Foundry-using job.

This pins all six call sites to `v1.5.1` — the same pin tnt-core uses successfully. No API call needed; the action downloads a known asset directly.