### PR TITLE
feat(metadata): iframe contract + chain grants

### DIFF
--- a/metadata/blueprint-metadata.json
+++ b/metadata/blueprint-metadata.json
@@ -42,11 +42,27 @@
       "label": "Open Agent Sandbox",
       "iframe": {
         "appId": "agent-sandbox",
-        "allowedChainIds": [],
-        "contracts": [],
-        "messages": [],
+        "allowedChainIds": [31337, 84532],
+        "contracts": [
+          {
+            "chainId": 31337,
+            "address": "0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9"
+          },
+          {
+            "chainId": 84532,
+            "address": "0x1be58d12620ecc8ba9d780feec2596510d75a933"
+          }
+        ],
+        "messages": [
+          {
+            "chainId": 31337
+          },
+          {
+            "chainId": 84532
+          }
+        ],
         "allowReadAccount": true,
-        "allowChainSwitch": false,
+        "allowChainSwitch": true,
         "allowPopups": false
       }
     }


### PR DESCRIPTION
Adds `iframe.allowedChainIds` + `iframe.contracts` grants so the dapp's iframe bridge actually permits this app's wallet calls.

- 31337 (local anvil): 0xcf7ed3acca5a467e9e704c703e8d87f634fb0fc9
- 84532 (Base Sepolia): 0x1be58d12620ecc8ba9d780feec2596510d75a933

Other Tangle chains skipped — still 0x0 in dapp-config. Selectors omitted; narrow once the job surface is stable.