### PR TITLE
chore(deps): bump tnt-core 0.10.x -> 0.13.0

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -13,7 +13,7 @@ remappings_location = "txt"
 remappings_version = false
 
 [dependencies]
-tnt-core = "0.10.9"
+tnt-core = "0.13.0"
 forge-std = "1.9.6"
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,4 @@
-@openzeppelin/contracts-upgradeable/=dependencies/tnt-core-0.10.9/dependencies/@openzeppelin-contracts-upgradeable-5.1.0/
-@openzeppelin/contracts/=dependencies/tnt-core-0.10.9/dependencies/@openzeppelin-contracts-5.1.0/
+@openzeppelin/contracts-upgradeable/=dependencies/tnt-core-0.13.0/dependencies/@openzeppelin-contracts-upgradeable-5.1.0/
+@openzeppelin/contracts/=dependencies/tnt-core-0.13.0/dependencies/@openzeppelin-contracts-5.1.0/
 forge-std/=dependencies/forge-std-1.9.6/src/
-tnt-core/=dependencies/tnt-core-0.10.9/src/
+tnt-core/=dependencies/tnt-core-0.13.0/src/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -7,7 +7,7 @@ integrity = "e9ecdc364d152157431e5df5aa041ffddbe9bb1c1ad81634b1e72df9e23814e8"
 
 [[dependencies]]
 name = "tnt-core"
-version = "0.10.9"
-url = "https://soldeer-revisions.s3.amazonaws.com/tnt-core/0_10_9_24-04-2026_03:56:11_tnt-core.zip"
-checksum = "d7a5b2c0dd620a2801d300680d599535fab9128e3c30ca9c8f43b8dfdf2b5c0c"
-integrity = "02bb7d7371ce17f6c82141cb62589d598e3f3db92a632336c11e4c4207a1aa76"
+version = "0.13.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/tnt-core/0_13_0_08-05-2026_21:58:28_tnt-core.zip"
+checksum = "b800ed4ca62ef85a7db2cbfcbfb0649459c5dfe714851581ef3069cccb595391"
+integrity = "f3a9b91524f1d24b5a3a48e47cf8576d9d965b4ac79edba67870e3f2ea9d550a"


### PR DESCRIPTION
## Summary

- Bumps the soldeer-vendored `tnt-core` dependency from **0.10.9** to **0.13.0** (released to soldeer 2026-05-08).
- Removes stale `dependencies/tnt-core-0.10.1/` vendor directory.
- Refreshes `soldeer.lock` and `remappings.txt`.

## What's in tnt-core 0.13.0

Pulls in the round-1 + round-2 audit hardening from:

- tangle-network/tnt-core#124 — multi-subsystem hardening + bindings 0.12.0 (services lifecycle, slashing, payments, staking, indexer fixes).
- tangle-network/tnt-core#125 — round-2 red-team fixes + bindings 0.13.0 (beacon SSZ endianness, JobQuoteDetails requester, slash dispute window symmetry, SLASH_ADMIN self-dispute gate, L2 slash CEI, L2 setMessenger/setSlasher timelocks, MBSM grace-period pinning, `forceRemoveAllowsBelowMin` BSM hook, ServiceRequest layout reorder).

## Impact on this repo

The in-repo BSMs that inherit `BlueprintServiceManagerBase` (e.g. `AgentSandboxBlueprint`, `OperatorSelection`) automatically pick up the new `forceRemoveAllowsBelowMin(serviceId)` default — returns `false`, which preserves the safe `minOperators` floor for `forceRemoveOperator`. No source change required here.

## Test plan

- [x] `forge build` clean
- [x] `forge test` — 168/168 pass