### PR TITLE
security(secrets): zeroize secret material at env + key derivation boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8565,6 +8565,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "uuid 1.23.1",
+ "zeroize",
 ]
 
 [[package]]

--- a/sandbox-runtime/Cargo.toml
+++ b/sandbox-runtime/Cargo.toml
@@ -36,6 +36,7 @@ uuid = { version = "1", features = ["v4"] }
 
 # At-rest encryption for secrets
 chacha20poly1305 = "0.10"
+zeroize = { version = "1", features = ["zeroize_derive"] }
 
 # Session auth (EIP-191 + PASETO v4)
 hkdf = "0.12"

--- a/sandbox-runtime/src/firecracker.rs
+++ b/sandbox-runtime/src/firecracker.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use reqwest::{Method, StatusCode};
 use serde::Deserialize;
 use serde_json::{Value, json};
+use zeroize::Zeroize;
 
 use crate::error::{Result, SandboxError};
 
@@ -41,17 +42,23 @@ impl FirecrackerHostAgentConfig {
                 )
             })?;
 
-        let api_key = std::env::var("FIRECRACKER_HOST_AGENT_API_KEY")
+        // Wipe the raw env-var read buffer after copying the trimmed value
+        // out: a heap dump after a misconfiguration crash should not surface
+        // the raw API key from the env block.
+        let api_key = match std::env::var("FIRECRACKER_HOST_AGENT_API_KEY")
             .or_else(|_| std::env::var("HOST_AGENT_API_KEY"))
-            .ok()
-            .and_then(|v| {
-                let trimmed = v.trim().to_string();
+        {
+            Ok(mut raw) => {
+                let trimmed = raw.trim().to_string();
+                raw.zeroize();
                 if trimmed.is_empty() {
                     None
                 } else {
                     Some(trimmed)
                 }
-            });
+            }
+            Err(_) => None,
+        };
 
         let network = std::env::var("FIRECRACKER_HOST_AGENT_NETWORK")
             .ok()
@@ -73,14 +80,18 @@ impl FirecrackerHostAgentConfig {
 
         let sidecar_auth_disabled = parse_bool_env(ENV_SIDECAR_AUTH_DISABLED, false)?;
 
-        let sidecar_auth_token = std::env::var(ENV_SIDECAR_AUTH_TOKEN).ok().and_then(|v| {
-            let trimmed = v.trim().to_string();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed)
+        let sidecar_auth_token = match std::env::var(ENV_SIDECAR_AUTH_TOKEN) {
+            Ok(mut raw) => {
+                let trimmed = raw.trim().to_string();
+                raw.zeroize();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed)
+                }
             }
-        });
+            Err(_) => None,
+        };
 
         match (sidecar_auth_disabled, sidecar_auth_token.is_some()) {
             (true, true) => {

--- a/sandbox-runtime/src/runtime.rs
+++ b/sandbox-runtime/src/runtime.rs
@@ -812,29 +812,37 @@ const SECRETS_HKDF_SALT: &[u8] = b"tangle-sandbox-blueprint-paseto-v4";
 
 /// 256-bit encryption key derived from `SESSION_AUTH_SECRET` via HKDF-SHA256.
 /// Falls back to an ephemeral random key (with warning) if the env var is unset.
-static SEAL_KEY: once_cell::sync::Lazy<[u8; 32]> = once_cell::sync::Lazy::new(|| {
-    use hkdf::Hkdf;
-    use sha2::Sha256;
+///
+/// The key is wrapped in [`zeroize::Zeroizing`] so the underlying bytes are
+/// wiped if the static is ever dropped, and so accidental clones carry the
+/// same drop-wipe contract. The env-var `String` carrying the input keying
+/// material is also explicitly zeroized after derivation.
+static SEAL_KEY: once_cell::sync::Lazy<zeroize::Zeroizing<[u8; 32]>> =
+    once_cell::sync::Lazy::new(|| {
+        use hkdf::Hkdf;
+        use sha2::Sha256;
+        use zeroize::{Zeroize, Zeroizing};
 
-    match std::env::var("SESSION_AUTH_SECRET") {
-        Ok(secret) => {
-            let hk = Hkdf::<Sha256>::new(Some(SECRETS_HKDF_SALT), secret.as_bytes());
-            let mut key = [0u8; 32];
-            hk.expand(SECRETS_HKDF_INFO, &mut key)
-                .expect("HKDF-SHA256 expand to 32 bytes cannot fail");
-            key
-        }
-        Err(_) => {
-            tracing::warn!(
-                "SESSION_AUTH_SECRET not set; using ephemeral key for secrets encryption. \
+        match std::env::var("SESSION_AUTH_SECRET") {
+            Ok(mut secret) => {
+                let hk = Hkdf::<Sha256>::new(Some(SECRETS_HKDF_SALT), secret.as_bytes());
+                let mut key = Zeroizing::new([0u8; 32]);
+                hk.expand(SECRETS_HKDF_INFO, &mut *key)
+                    .expect("HKDF-SHA256 expand to 32 bytes cannot fail");
+                secret.zeroize();
+                key
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "SESSION_AUTH_SECRET not set; using ephemeral key for secrets encryption. \
                  Stored secrets will NOT survive restart."
-            );
-            let mut key = [0u8; 32];
-            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut key);
-            key
+                );
+                let mut key = Zeroizing::new([0u8; 32]);
+                rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut *key);
+                key
+            }
         }
-    }
-});
+    });
 
 /// Encrypt a plaintext string using ChaCha20-Poly1305 AEAD.
 /// Returns `"enc:v1:" + base64(nonce || ciphertext)`.
@@ -849,7 +857,7 @@ fn seal_field(plaintext: &str) -> Result<String> {
         return Ok(String::new());
     }
 
-    let cipher = ChaCha20Poly1305::new((&*SEAL_KEY).into());
+    let cipher = ChaCha20Poly1305::new((&**SEAL_KEY).into());
     let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
     let ciphertext = cipher
         .encrypt(&nonce, plaintext.as_bytes())
@@ -897,7 +905,7 @@ fn unseal_field(stored: &str) -> Result<String> {
     let nonce = chacha20poly1305::Nonce::from_slice(&blob[..12]);
     let ciphertext = &blob[12..];
 
-    let cipher = ChaCha20Poly1305::new((&*SEAL_KEY).into());
+    let cipher = ChaCha20Poly1305::new((&**SEAL_KEY).into());
     let plaintext = cipher
         .decrypt(nonce, ciphertext)
         .map_err(|e| SandboxError::Storage(format!("unseal_field decrypt failed: {e}")))?;

--- a/sandbox-runtime/src/secret_provisioning.rs
+++ b/sandbox-runtime/src/secret_provisioning.rs
@@ -11,6 +11,7 @@
 //! values never touch the blockchain.
 
 use serde_json::{Map, Value};
+use zeroize::Zeroizing;
 
 use crate::error::{Result, SandboxError};
 use crate::runtime::{SandboxRecord, get_sandbox_by_id, recreate_sidecar_with_env};
@@ -32,8 +33,14 @@ pub async fn inject_secrets(
     secret_env: Map<String, Value>,
     tee: Option<&dyn crate::tee::TeeBackend>,
 ) -> Result<SandboxRecord> {
-    let user_env_json = serde_json::to_string(&secret_env)
-        .map_err(|e| SandboxError::Validation(format!("Invalid secret env: {e}")))?;
+    // Wrap the serialized secrets so the heap-resident JSON is wiped on
+    // drop. `recreate_sidecar_with_env` borrows it as `&str`; once that
+    // call returns, the only persisted copy is the at-rest-encrypted form
+    // sealed via `SEAL_KEY`.
+    let user_env_json: Zeroizing<String> = Zeroizing::new(
+        serde_json::to_string(&secret_env)
+            .map_err(|e| SandboxError::Validation(format!("Invalid secret env: {e}")))?,
+    );
 
     let new_record = recreate_sidecar_with_env(sandbox_id, &user_env_json, tee).await?;
     Ok(new_record)

--- a/sandbox-runtime/src/session_auth.rs
+++ b/sandbox-runtime/src/session_auth.rs
@@ -17,6 +17,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use once_cell::sync::Lazy;
 use rand::RngCore;
 use rand::rngs::OsRng;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::error::{Result, SandboxError};
 
@@ -208,34 +209,38 @@ const HKDF_INFO: &[u8] = b"session-auth-symmetric-key-v1";
 /// early in `main()` to enforce the secret is set in production.
 static SYMMETRIC_KEY: Lazy<pasetors::keys::SymmetricKey<pasetors::version4::V4>> =
     Lazy::new(|| {
-        let key_bytes = match std::env::var("SESSION_AUTH_SECRET") {
-            Ok(secret) => derive_symmetric_key(secret.as_bytes()),
+        let key_bytes: Zeroizing<[u8; 32]> = match std::env::var("SESSION_AUTH_SECRET") {
+            Ok(mut secret) => {
+                let derived = derive_symmetric_key(secret.as_bytes());
+                secret.zeroize();
+                derived
+            }
             Err(_) => {
                 tracing::error!(
                     "SESSION_AUTH_SECRET is not set — using random key. \
                  Sessions will NOT survive restart. Set this env var in production."
                 );
-                let mut bytes = [0u8; 32];
-                OsRng.fill_bytes(&mut bytes);
+                let mut bytes = Zeroizing::new([0u8; 32]);
+                OsRng.fill_bytes(&mut *bytes);
                 bytes
             }
         };
-        pasetors::keys::SymmetricKey::<pasetors::version4::V4>::from(&key_bytes)
+        pasetors::keys::SymmetricKey::<pasetors::version4::V4>::from(&*key_bytes)
             .expect("Failed to create PASETO symmetric key")
     });
 
 /// Derive a 32-byte symmetric key from input keying material using HKDF-SHA256.
 ///
-/// Uses a domain-specific salt and info parameter to ensure the derived key is
-/// unique to this application's PASETO token encryption, even if the same secret
-/// is reused elsewhere.
-fn derive_symmetric_key(ikm: &[u8]) -> [u8; 32] {
+/// Returns the key in a [`Zeroizing`] wrapper so the temporary derivation
+/// buffer is wiped from the heap when it goes out of scope — pasetors copies
+/// the bytes into its own owned buffer when constructing `SymmetricKey`.
+fn derive_symmetric_key(ikm: &[u8]) -> Zeroizing<[u8; 32]> {
     use hkdf::Hkdf;
     use sha2::Sha256;
 
     let hk = Hkdf::<Sha256>::new(Some(HKDF_SALT), ikm);
-    let mut key = [0u8; 32];
-    hk.expand(HKDF_INFO, &mut key)
+    let mut key = Zeroizing::new([0u8; 32]);
+    hk.expand(HKDF_INFO, &mut *key)
         .expect("HKDF-SHA256 expand to 32 bytes cannot fail");
     key
 }
@@ -496,10 +501,17 @@ pub fn extract_bearer_token(auth_header: &str) -> Option<&str> {
 /// treated as a hard error; in test mode, log a warning and continue.
 pub fn validate_required_config() -> std::result::Result<(), String> {
     match std::env::var("SESSION_AUTH_SECRET") {
-        Ok(val) if !val.trim().is_empty() => Ok(()),
-        Ok(_) => Err("SESSION_AUTH_SECRET is set but empty. \
-             Provide a non-empty secret for stable session auth."
-            .to_string()),
+        Ok(mut val) => {
+            let ok = !val.trim().is_empty();
+            val.zeroize();
+            if ok {
+                Ok(())
+            } else {
+                Err("SESSION_AUTH_SECRET is set but empty. \
+                     Provide a non-empty secret for stable session auth."
+                    .to_string())
+            }
+        }
         Err(_) => Err("SESSION_AUTH_SECRET is not set. \
              Sessions will use a random key and break on restart. \
              Set this env var before starting the operator."
@@ -805,7 +817,7 @@ mod tests {
         let hkdf_key = derive_symmetric_key(input);
         let keccak_hash = keccak256(input);
         assert_ne!(
-            hkdf_key, keccak_hash,
+            *hkdf_key, keccak_hash,
             "HKDF output must differ from raw Keccak256"
         );
     }

--- a/sandbox-runtime/src/tee/backend_factory.rs
+++ b/sandbox-runtime/src/tee/backend_factory.rs
@@ -34,7 +34,9 @@ pub fn backend_from_env() -> Result<Arc<dyn TeeBackend>> {
     match backend_name.to_lowercase().as_str() {
         #[cfg(feature = "tee-phala")]
         "phala" => {
-            let api_key = require_env("PHALA_API_KEY")?;
+            // Wrap the Phala API key so its heap copy is wiped once
+            // PhalaBackend::new has copied what it needs.
+            let api_key = zeroize::Zeroizing::new(require_env("PHALA_API_KEY")?);
             let api_endpoint = std::env::var("PHALA_API_ENDPOINT").ok();
             let backend = super::phala::PhalaBackend::new(&api_key, api_endpoint)?;
             Ok(Arc::new(backend))


### PR DESCRIPTION
## Summary

Audit found zero `zeroize` adoption across the rust crates, including long-lived `SEAL_KEY` / `SYMMETRIC_KEY` and the operator-API plumbing in `firecracker.rs` / `runtime.rs`. This PR ports the trading-blueprint pattern to the secret-loading boundaries.

- **`session_auth.rs`** — `derive_symmetric_key` returns `Zeroizing<[u8; 32]>`; `SESSION_AUTH_SECRET` env-var `String` zeroized after HKDF expansion; `validate_required_config` wipes its read buffer.
- **`runtime.rs SEAL_KEY`** — wrapped in `Lazy<Zeroizing<[u8; 32]>>`; env-var read buffer zeroized after HKDF derivation.
- **`firecracker.rs`** — `FirecrackerHostAgentConfig::load` wipes raw `FIRECRACKER_HOST_AGENT_API_KEY` / `HOST_AGENT_API_KEY` / `FIRECRACKER_SIDECAR_AUTH_TOKEN` env-var read buffers.
- **`secret_provisioning.rs`** — `inject_secrets` wraps the serialized user-secret JSON in `Zeroizing<String>`; only the at-rest-encrypted form persists past the call.
- **`tee/backend_factory.rs`** — `PHALA_API_KEY` wrapped in `Zeroizing<String>`.

The intermediate heap copies the operator process owns are now wiped on drop. The kernel-held env block is still the secrets injector's responsibility — but a heap dump after a misconfiguration crash can no longer recover the raw secret from intermediate buffers.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p sandbox-runtime --lib` — 417/417 passing
- [x] `cargo fmt --all`

## Notes

- No public API changes; no behavior changes outside zero-on-drop ordering.
- The Docker env `Vec<String>` carrying user `ANTHROPIC_API_KEY` / `ZAI_API_KEY` etc. (`runtime.rs:2241`) is **out of scope here** — would require a refactor of how bollard consumes the env vec. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)