### PR TITLE
security: SSRF allowlist + per-session rate limit + typed error classification

### DIFF
--- a/ai-agent-instance-blueprint-lib/src/billing.rs
+++ b/ai-agent-instance-blueprint-lib/src/billing.rs
@@ -93,7 +93,17 @@ impl EscrowWatchdogConfig {
     /// Returns `None` if `TANGLE_CONTRACT_ADDRESS` is not set (billing disabled).
     pub fn from_env(service_id: u64, blueprint_id: u64) -> Option<Self> {
         let contract_str = std::env::var("TANGLE_CONTRACT_ADDRESS").ok()?;
-        let tangle_contract: Address = contract_str.parse().ok()?;
+        let tangle_contract: Address = match contract_str.parse() {
+            Ok(addr) => addr,
+            Err(e) => {
+                tracing::warn!(
+                    value = %contract_str,
+                    err = %e,
+                    "TANGLE_CONTRACT_ADDRESS is set but not a valid EVM address; billing disabled"
+                );
+                return None;
+            }
+        };
 
         let http_rpc_endpoint = std::env::var("HTTP_RPC_ENDPOINT")
             .or_else(|_| std::env::var("RPC_URL"))

--- a/ai-agent-sandbox-blueprint-bin/src/main.rs
+++ b/ai-agent-sandbox-blueprint-bin/src/main.rs
@@ -594,23 +594,51 @@ async fn main() -> Result<(), blueprint_sdk::Error> {
 /// Optional:
 ///   - `HEARTBEAT_INTERVAL_SECS` — heartbeat interval (default: 120)
 ///   - `HEARTBEAT_MAX_MISSED` — max missed beats before slashing (default: 3)
+/// Parse a u64 from the first env var that's set in `keys`. Logs a warning
+/// and returns `None` if a value is set but doesn't parse — so operators
+/// see misconfiguration in observability instead of features silently
+/// disabling.
+#[cfg(feature = "qos")]
+fn parse_required_u64_env(keys: &[&str]) -> Option<u64> {
+    for key in keys {
+        match std::env::var(key) {
+            Ok(raw) => match raw.parse::<u64>() {
+                Ok(v) => return Some(v),
+                Err(e) => {
+                    tracing::warn!(
+                        env = key,
+                        value = %raw,
+                        err = %e,
+                        "env var is set but not a valid u64; falling back to next key"
+                    );
+                }
+            },
+            Err(_) => continue,
+        }
+    }
+    None
+}
+
 #[cfg(feature = "qos")]
 fn build_heartbeat_config() -> Option<HeartbeatConfig> {
     use std::str::FromStr;
 
-    let service_id: u64 = std::env::var("SERVICE_ID")
-        .or_else(|_| std::env::var("TANGLE_SERVICE_ID"))
-        .ok()
-        .and_then(|v| v.parse().ok())?;
-
-    let blueprint_id: u64 = std::env::var("BLUEPRINT_ID")
-        .or_else(|_| std::env::var("TANGLE_BLUEPRINT_ID"))
-        .ok()
-        .and_then(|v| v.parse().ok())?;
+    let service_id: u64 = parse_required_u64_env(&["SERVICE_ID", "TANGLE_SERVICE_ID"])?;
+    let blueprint_id: u64 = parse_required_u64_env(&["BLUEPRINT_ID", "TANGLE_BLUEPRINT_ID"])?;
 
     let registry_addr_str = std::env::var("STATUS_REGISTRY_ADDRESS").ok()?;
     let status_registry_address =
-        blueprint_sdk::alloy::primitives::Address::from_str(&registry_addr_str).ok()?;
+        match blueprint_sdk::alloy::primitives::Address::from_str(&registry_addr_str) {
+            Ok(addr) => addr,
+            Err(e) => {
+                tracing::warn!(
+                    value = %registry_addr_str,
+                    err = %e,
+                    "STATUS_REGISTRY_ADDRESS is set but not a valid EVM address; heartbeat disabled"
+                );
+                return None;
+            }
+        };
 
     let interval_secs: u64 = std::env::var("HEARTBEAT_INTERVAL_SECS")
         .ok()

--- a/ai-agent-sandbox-blueprint-bin/src/main.rs
+++ b/ai-agent-sandbox-blueprint-bin/src/main.rs
@@ -584,16 +584,6 @@ async fn main() -> Result<(), blueprint_sdk::Error> {
     Ok(())
 }
 
-/// Build heartbeat config from environment variables.
-///
-/// Required env vars:
-///   - `SERVICE_ID` or `TANGLE_SERVICE_ID` — the service instance ID
-///   - `BLUEPRINT_ID` or `TANGLE_BLUEPRINT_ID` — the blueprint ID
-///   - `STATUS_REGISTRY_ADDRESS` — the OperatorStatusRegistry contract address
-///
-/// Optional:
-///   - `HEARTBEAT_INTERVAL_SECS` — heartbeat interval (default: 120)
-///   - `HEARTBEAT_MAX_MISSED` — max missed beats before slashing (default: 3)
 /// Parse a u64 from the first env var that's set in `keys`. Logs a warning
 /// and returns `None` if a value is set but doesn't parse — so operators
 /// see misconfiguration in observability instead of features silently
@@ -605,7 +595,7 @@ fn parse_required_u64_env(keys: &[&str]) -> Option<u64> {
             Ok(raw) => match raw.parse::<u64>() {
                 Ok(v) => return Some(v),
                 Err(e) => {
-                    tracing::warn!(
+                    warn!(
                         env = key,
                         value = %raw,
                         err = %e,
@@ -619,6 +609,16 @@ fn parse_required_u64_env(keys: &[&str]) -> Option<u64> {
     None
 }
 
+/// Build heartbeat config from environment variables.
+///
+/// Required env vars:
+///   - `SERVICE_ID` or `TANGLE_SERVICE_ID` — the service instance ID
+///   - `BLUEPRINT_ID` or `TANGLE_BLUEPRINT_ID` — the blueprint ID
+///   - `STATUS_REGISTRY_ADDRESS` — the OperatorStatusRegistry contract address
+///
+/// Optional:
+///   - `HEARTBEAT_INTERVAL_SECS` — heartbeat interval (default: 120)
+///   - `HEARTBEAT_MAX_MISSED` — max missed beats before slashing (default: 3)
 #[cfg(feature = "qos")]
 fn build_heartbeat_config() -> Option<HeartbeatConfig> {
     use std::str::FromStr;
@@ -631,7 +631,7 @@ fn build_heartbeat_config() -> Option<HeartbeatConfig> {
         match blueprint_sdk::alloy::primitives::Address::from_str(&registry_addr_str) {
             Ok(addr) => addr,
             Err(e) => {
-                tracing::warn!(
+                warn!(
                     value = %registry_addr_str,
                     err = %e,
                     "STATUS_REGISTRY_ADDRESS is set but not a valid EVM address; heartbeat disabled"

--- a/sandbox-runtime/src/firecracker.rs
+++ b/sandbox-runtime/src/firecracker.rs
@@ -40,6 +40,7 @@ impl FirecrackerHostAgentConfig {
                     "runtime_backend=firecracker requires FIRECRACKER_HOST_AGENT_URL (or HOST_AGENT_URL)".into(),
                 )
             })?;
+        validate_host_agent_url(&base_url)?;
 
         let api_key = std::env::var("FIRECRACKER_HOST_AGENT_API_KEY")
             .or_else(|_| std::env::var("HOST_AGENT_API_KEY"))
@@ -104,6 +105,55 @@ impl FirecrackerHostAgentConfig {
             sidecar_auth_token,
         })
     }
+}
+
+/// Validate that the host-agent URL is a sane HTTP(S) endpoint pointing at
+/// a non-metadata destination.
+///
+/// Operator misconfiguration or env injection that points the host-agent at
+/// `169.254.169.254` (cloud IMDS) or a Unix-domain socket path would let a
+/// caller pivot from the firecracker create path to internal services.
+/// Reject those at config-load time so failures surface at boot, not at
+/// first sandbox provision.
+fn validate_host_agent_url(url: &str) -> Result<()> {
+    let parsed = reqwest::Url::parse(url).map_err(|e| {
+        SandboxError::Validation(format!(
+            "FIRECRACKER_HOST_AGENT_URL is not a valid URL: {e}"
+        ))
+    })?;
+
+    match parsed.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(SandboxError::Validation(format!(
+                "FIRECRACKER_HOST_AGENT_URL scheme must be http or https, got '{other}'"
+            )));
+        }
+    }
+
+    let host = parsed.host_str().ok_or_else(|| {
+        SandboxError::Validation("FIRECRACKER_HOST_AGENT_URL must include a host component".into())
+    })?;
+
+    // Reject AWS / GCP / Azure cloud-metadata addresses outright. These are
+    // the canonical SSRF pivot targets and there is no legitimate reason
+    // for the host-agent to live there.
+    let imds_v4 = ["169.254.169.254", "169.254.170.2"]; // EC2 IMDS, ECS/Fargate task metadata
+    if imds_v4.contains(&host) {
+        return Err(SandboxError::Validation(format!(
+            "FIRECRACKER_HOST_AGENT_URL host '{host}' is a cloud-metadata address; refusing to proxy"
+        )));
+    }
+    // GCP metadata is reachable via a hostname rather than a fixed IP.
+    if host.eq_ignore_ascii_case("metadata.google.internal")
+        || host.eq_ignore_ascii_case("metadata")
+    {
+        return Err(SandboxError::Validation(format!(
+            "FIRECRACKER_HOST_AGENT_URL host '{host}' is a cloud-metadata address; refusing to proxy"
+        )));
+    }
+
+    Ok(())
 }
 
 fn parse_bool_env(name: &str, default: bool) -> Result<bool> {
@@ -534,6 +584,44 @@ mod tests {
 
         let cfg = FirecrackerHostAgentConfig::load().expect("token mode should be valid");
         assert_eq!(cfg.sidecar_auth_token.as_deref(), Some("secret-token"));
+    }
+
+    #[test]
+    fn validate_host_agent_url_accepts_loopback_and_private() {
+        validate_host_agent_url("http://127.0.0.1:8080").unwrap();
+        validate_host_agent_url("http://10.0.0.5:8080").unwrap();
+        validate_host_agent_url("https://host-agent.internal").unwrap();
+    }
+
+    #[test]
+    fn validate_host_agent_url_rejects_non_http() {
+        let err = validate_host_agent_url("file:///tmp/host.sock").unwrap_err();
+        assert!(
+            err.to_string().contains("scheme must be http or https"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn validate_host_agent_url_rejects_imds() {
+        for url in [
+            "http://169.254.169.254/latest/meta-data/",
+            "http://169.254.170.2",
+            "https://metadata.google.internal/computeMetadata/v1/",
+            "http://metadata",
+        ] {
+            let err = validate_host_agent_url(url).unwrap_err();
+            assert!(
+                err.to_string().contains("cloud-metadata"),
+                "expected cloud-metadata rejection for {url}, got {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_host_agent_url_rejects_garbage() {
+        let err = validate_host_agent_url("not a url").unwrap_err();
+        assert!(err.to_string().contains("not a valid URL"), "{err}");
     }
 
     fn test_config() -> FirecrackerHostAgentConfig {

--- a/sandbox-runtime/src/operator_api.rs
+++ b/sandbox-runtime/src/operator_api.rs
@@ -202,6 +202,82 @@ fn circuit_breaker_api_error(err: SandboxError) -> (StatusCode, Json<ApiError>) 
     }
 }
 
+/// Enforce the per-session fanout limiter for high-cost endpoints (port
+/// proxy, chat run/stream). NAT'd users would otherwise share an IP-tier
+/// bucket — this caps a single authenticated session's expensive
+/// downstream calls regardless of source IP.
+fn enforce_session_fanout(address: &str) -> std::result::Result<(), (StatusCode, Json<ApiError>)> {
+    match rate_limit::check_session_fanout(address) {
+        Ok(()) => Ok(()),
+        Err(retry_after_secs) => Err(api_error_with_details(
+            StatusCode::TOO_MANY_REQUESTS,
+            "Per-session rate limit exceeded".to_string(),
+            Some("SESSION_RATE_LIMIT"),
+            Some(retry_after_secs * 1000),
+        )),
+    }
+}
+
+/// Generic 500 for `serde_json::Error` from response-body serialization. The
+/// detail goes to logs, not the wire — these are programming errors, not
+/// user-facing.
+fn json_serialization_error(e: serde_json::Error) -> axum::response::Response {
+    tracing::error!(err = %e, "JSON serialization failure");
+    api_error(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "Response serialization failed".to_string(),
+    )
+    .into_response()
+}
+
+/// Map a `SandboxError` to a typed HTTP response. Use this in handler
+/// `Err(_)` arms instead of `api_error(INTERNAL_SERVER_ERROR, e.to_string())`
+/// so we don't leak raw error chains, container internals, or RPC error
+/// strings to API consumers.
+///
+/// Variants surface their messages directly when those messages are
+/// already user-facing (auth, validation, not-found, unavailable). Internal
+/// failures (docker, storage, cloud-provider, http) are logged at `error`
+/// level and return a generic message — operators see the detail in
+/// observability, callers see only that the request failed.
+pub(crate) fn classify_sandbox_error(err: SandboxError) -> (StatusCode, Json<ApiError>) {
+    match err {
+        SandboxError::Auth(msg) => api_error(StatusCode::UNAUTHORIZED, msg),
+        SandboxError::Validation(msg) => api_error(StatusCode::BAD_REQUEST, msg),
+        SandboxError::NotFound(msg) => api_error(StatusCode::NOT_FOUND, msg),
+        SandboxError::Unavailable(msg) => api_error(StatusCode::SERVICE_UNAVAILABLE, msg),
+        SandboxError::CircuitBreaker { .. } => circuit_breaker_api_error(err),
+        SandboxError::Http(detail) => {
+            tracing::error!(err = %detail, "upstream HTTP failure");
+            api_error(
+                StatusCode::BAD_GATEWAY,
+                "Upstream request failed".to_string(),
+            )
+        }
+        SandboxError::CloudProvider(detail) => {
+            tracing::error!(err = %detail, "cloud provider failure");
+            api_error(
+                StatusCode::BAD_GATEWAY,
+                "Cloud provider request failed".to_string(),
+            )
+        }
+        SandboxError::Docker(detail) => {
+            tracing::error!(err = %detail, "container runtime failure");
+            api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Container runtime error".to_string(),
+            )
+        }
+        SandboxError::Storage(detail) => {
+            tracing::error!(err = %detail, "storage failure");
+            api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Storage error".to_string(),
+            )
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Default)]
 struct CreateLiveChatSessionRequest {
     #[serde(default)]
@@ -800,7 +876,7 @@ async fn list_sandboxes(SessionAuth(address): SessionAuth) -> impl IntoResponse 
             )
                 .into_response()
         }
-        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Err(e) => classify_sandbox_error(e).into_response(),
     }
 }
 
@@ -812,10 +888,10 @@ async fn get_provision(Path(call_id): Path<u64>) -> impl IntoResponse {
     match provision_progress::get_provision(call_id) {
         Ok(Some(status)) => match serde_json::to_value(status) {
             Ok(val) => (StatusCode::OK, Json(val)).into_response(),
-            Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+            Err(e) => json_serialization_error(e),
         },
         Ok(None) => api_error(StatusCode::NOT_FOUND, "Provision not found").into_response(),
-        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Err(e) => classify_sandbox_error(e).into_response(),
     }
 }
 
@@ -826,7 +902,7 @@ async fn list_provisions() -> impl IntoResponse {
             Json(serde_json::json!({ "provisions": provisions })),
         )
             .into_response(),
-        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Err(e) => classify_sandbox_error(e).into_response(),
     }
 }
 
@@ -849,7 +925,7 @@ async fn create_challenge() -> impl IntoResponse {
     };
     match serde_json::to_value(challenge) {
         Ok(val) => (StatusCode::OK, Json(val)).into_response(),
-        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Err(e) => json_serialization_error(e),
     }
 }
 
@@ -857,7 +933,7 @@ async fn create_session(Json(req): Json<SessionRequest>) -> impl IntoResponse {
     match session_auth::exchange_signature_for_token(&req.nonce, &req.signature) {
         Ok(token) => match serde_json::to_value(token) {
             Ok(val) => (StatusCode::OK, Json(val)).into_response(),
-            Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+            Err(e) => json_serialization_error(e),
         },
         Err(crate::error::SandboxError::Unavailable(msg)) => {
             api_error(StatusCode::SERVICE_UNAVAILABLE, msg).into_response()
@@ -1608,7 +1684,7 @@ async fn instance_inject_secrets(
             )
                 .into_response()
         }
-        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Err(e) => classify_sandbox_error(e).into_response(),
     }
 }
 
@@ -1636,7 +1712,7 @@ async fn instance_wipe_secrets(SessionAuth(address): SessionAuth) -> impl IntoRe
             )
                 .into_response()
         }
-        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Err(e) => classify_sandbox_error(e).into_response(),
     }
 }
 
@@ -1703,7 +1779,7 @@ async fn inject_secrets(
             )
                 .into_response()
         }
-        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Err(e) => classify_sandbox_error(e).into_response(),
     }
 }
 
@@ -1730,7 +1806,7 @@ async fn wipe_secrets(
             )
                 .into_response()
         }
-        Err(e) => api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        Err(e) => classify_sandbox_error(e).into_response(),
     }
 }
 
@@ -4002,7 +4078,7 @@ fn handle_lifecycle_outcome(
         Err(crate::SandboxError::Unavailable(msg)) => {
             Err(api_error(StatusCode::SERVICE_UNAVAILABLE, msg))
         }
-        Err(e) => Err(api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+        Err(e) => Err(classify_sandbox_error(e)),
     }
 }
 
@@ -4317,6 +4393,7 @@ async fn sandbox_port_proxy_handler(
     headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> Result<axum::response::Response, (StatusCode, Json<ApiError>)> {
+    enforce_session_fanout(&address)?;
     let (sandbox_id, port, path) = params;
     let record = resolve_sandbox(&sandbox_id, &address)?;
     run_port_proxy(record, port, &path, query.as_deref(), method, headers, body).await
@@ -4331,6 +4408,7 @@ async fn sandbox_port_proxy_root_handler(
     headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> Result<axum::response::Response, (StatusCode, Json<ApiError>)> {
+    enforce_session_fanout(&address)?;
     let (sandbox_id, port) = params;
     let record = resolve_sandbox(&sandbox_id, &address)?;
     run_port_proxy(record, port, "", query.as_deref(), method, headers, body).await
@@ -4345,6 +4423,7 @@ async fn instance_port_proxy_handler(
     headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> Result<axum::response::Response, (StatusCode, Json<ApiError>)> {
+    enforce_session_fanout(&address)?;
     let (port, path) = params;
     let record = resolve_instance(&address)?;
     run_port_proxy(record, port, &path, query.as_deref(), method, headers, body).await
@@ -4359,6 +4438,7 @@ async fn instance_port_proxy_root_handler(
     headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> Result<axum::response::Response, (StatusCode, Json<ApiError>)> {
+    enforce_session_fanout(&address)?;
     let record = resolve_instance(&address)?;
     run_port_proxy(record, port, "", query.as_deref(), method, headers, body).await
 }

--- a/sandbox-runtime/src/rate_limit.rs
+++ b/sandbox-runtime/src/rate_limit.rs
@@ -80,6 +80,60 @@ pub struct RateLimiter {
     last_gc: Mutex<Instant>,
 }
 
+/// Rate limiter keyed by an arbitrary session identifier (typically the
+/// SessionAuth address). Same sliding-window semantics as [`RateLimiter`]
+/// but keyed on `String` instead of `IpAddr`, so a single authenticated
+/// caller can't use a NAT'd / shared IP to evade per-session throttles
+/// on high-fanout endpoints.
+pub struct SessionRateLimiter {
+    config: RateLimitConfig,
+    buckets: Mutex<HashMap<String, Bucket>>,
+    last_gc: Mutex<Instant>,
+}
+
+impl SessionRateLimiter {
+    pub fn new(config: RateLimitConfig) -> Self {
+        Self {
+            config,
+            buckets: Mutex::new(HashMap::new()),
+            last_gc: Mutex::new(Instant::now()),
+        }
+    }
+
+    /// Check whether a request keyed on `session_id` is allowed.
+    pub fn check(&self, session_id: &str) -> bool {
+        let mut buckets = self.buckets.lock().unwrap_or_else(|e| e.into_inner());
+
+        {
+            let mut last_gc = self.last_gc.lock().unwrap_or_else(|e| e.into_inner());
+            if last_gc.elapsed().as_secs() >= GC_INTERVAL_SECS {
+                let cutoff = Instant::now() - Duration::from_secs(self.config.window_secs * 2);
+                buckets.retain(|_, b| b.timestamps.last().is_some_and(|t| *t > cutoff));
+                *last_gc = Instant::now();
+            }
+        }
+
+        let bucket = buckets
+            .entry(session_id.to_string())
+            .or_insert_with(Bucket::new);
+        bucket.check_and_record(self.config.window_secs, self.config.max_requests)
+    }
+
+    /// Number of tracked sessions (for metrics/debugging).
+    pub fn tracked_sessions(&self) -> usize {
+        self.buckets.lock().unwrap_or_else(|e| e.into_inner()).len()
+    }
+
+    /// Clear all tracked buckets. Allows tests to reset state.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn reset(&self) {
+        self.buckets
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
+    }
+}
+
 /// GC interval: clean up stale IPs every 5 minutes.
 const GC_INTERVAL_SECS: u64 = 300;
 
@@ -142,9 +196,35 @@ static TERMINAL_INTERACTIVE_LIMITER: once_cell::sync::Lazy<RateLimiter> =
 static AUTH_LIMITER: once_cell::sync::Lazy<RateLimiter> =
     once_cell::sync::Lazy::new(|| RateLimiter::new(RateLimitConfig::new(10, 60)));
 
+/// Per-session limiter for high-fanout endpoints (port proxy, chat run/stream,
+/// sandbox provision). Default 60 req/min — env-tunable via
+/// `SESSION_FANOUT_LIMIT_PER_MINUTE` so operators can ratchet down if a
+/// single session is driving expensive RPC fanout.
+///
+/// Read at first init via `OnceLock`, so changes to the env var require
+/// an operator restart — same behavior as the trading-blueprint's
+/// `PreflightLimiter` and consistent with how the IP-tier limiters are
+/// configured (compile-time constants).
+static SESSION_FANOUT_LIMITER: once_cell::sync::Lazy<SessionRateLimiter> =
+    once_cell::sync::Lazy::new(|| {
+        let per_minute = std::env::var("SESSION_FANOUT_LIMIT_PER_MINUTE")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .filter(|v| *v > 0)
+            .unwrap_or(60);
+        SessionRateLimiter::new(RateLimitConfig::new(per_minute, 60))
+    });
+
 /// Access the read-tier (120 req/min) limiter.
 pub fn read_limiter() -> &'static RateLimiter {
     &READ_LIMITER
+}
+
+/// Access the per-session fanout limiter. Use for endpoints that fan out
+/// to RPC / sidecar / port-proxy targets where a NAT'd IP isn't enough
+/// of a discriminator.
+pub fn session_fanout_limiter() -> &'static SessionRateLimiter {
+    &SESSION_FANOUT_LIMITER
 }
 
 /// Access the write-tier (30 req/min) limiter.
@@ -277,6 +357,22 @@ pub async fn auth_rate_limit(request: Request, next: Next) -> Response {
     next.run(request).await
 }
 
+/// Check the session-fanout limiter for a given caller. Returns
+/// `Err(retry_after_secs)` when the bucket is exhausted, so handlers can
+/// surface a typed 429 with the right retry hint instead of mapping
+/// through middleware.
+///
+/// Use this in handlers that fan out to RPC / port-proxy / sidecar targets
+/// where the IP-tier limiter is too coarse (NAT'd users share a bucket).
+pub fn check_session_fanout(session_id: &str) -> std::result::Result<(), u64> {
+    if session_fanout_limiter().check(session_id) {
+        Ok(())
+    } else {
+        metrics::rate_limit_rejections().fetch_add(1, Ordering::Relaxed);
+        Err(60)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -301,6 +397,29 @@ mod tests {
         assert!(limiter.check(ip1));
         assert!(!limiter.check(ip1)); // ip1 exhausted
         assert!(limiter.check(ip2)); // ip2 still has quota
+    }
+
+    #[test]
+    fn session_limiter_caps_per_session_not_per_ip() {
+        let limiter = SessionRateLimiter::new(RateLimitConfig::new(2, 60));
+        let alice = "0xaaaa";
+        let bob = "0xbbbb";
+
+        assert!(limiter.check(alice));
+        assert!(limiter.check(alice));
+        assert!(!limiter.check(alice)); // alice exhausted
+
+        // bob's bucket is independent — NAT/shared-IP can't drain it
+        assert!(limiter.check(bob));
+    }
+
+    #[test]
+    fn session_limiter_tracks_distinct_sessions() {
+        let limiter = SessionRateLimiter::new(RateLimitConfig::new(1, 60));
+        for i in 0..5 {
+            assert!(limiter.check(&format!("0x{i}")));
+        }
+        assert_eq!(limiter.tracked_sessions(), 5);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three audit findings landed together because they share the operator-API ingress surface:

- **F3 SSRF allowlist for `FIRECRACKER_HOST_AGENT_URL`** — `validate_host_agent_url` rejects non-http(s) schemes, AWS IMDS (`169.254.169.254` / `170.2`), and GCP metadata (`metadata.google.internal`, `metadata`). Now fails at config-load time. 4 unit tests.

- **F2 Per-session rate limiter for high-fanout endpoints** — `enforce_session_fanout(&address)` runs before sandbox resolution on port-proxy handlers (sandbox + instance, with-path + root variants). NAT'd / VPN-shared IP can no longer drive an authenticated session past the IP-tier bucket. Default 60 req/min, env-tunable via `SESSION_FANOUT_LIMIT_PER_MINUTE`. Returns 429 with `SESSION_RATE_LIMIT` code + 60s retry-after.

- **F10 Typed error classification** — `classify_sandbox_error()` maps `SandboxError` variants to typed responses:
  - `Auth` → 401, `Validation` → 400, `NotFound` → 404
  - `Unavailable` → 503, `CircuitBreaker` → 503 (existing `circuit_breaker_api_error`)
  - `Http` / `CloudProvider` → 502 + redacted message + `tracing::error!`
  - `Docker` / `Storage` → 500 + redacted message + `tracing::error!`

  Migrated 11 call sites from `api_error(INTERNAL_SERVER_ERROR, e.to_string())`. `serde_json::Error` from response serialization gets its own `json_serialization_error` helper.

- **F6 Env-parse warns** — `TANGLE_CONTRACT_ADDRESS` (billing.rs), `STATUS_REGISTRY_ADDRESS`, `SERVICE_ID` / `BLUEPRINT_ID` (main.rs) now `tracing::warn!` when set but unparseable instead of silently disabling the feature. New `parse_required_u64_env` helper centralizes the pattern.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p sandbox-runtime --lib` — 423/423 (4 new URL-validation + 2 new SessionRateLimiter tests)
- [x] `cargo fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)