### PR TITLE
security: hardening bundle (zeroize + static analysis + runbook + test guard + frontend + solidity)

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,75 @@
+name: Static Analysis
+
+# Supply-chain + Solidity lint gates that don't need a full build matrix.
+# Runs on every PR and on main pushes. Kept in a separate workflow from
+# `ci.yml` so a slow `cargo deny` advisory-db fetch doesn't block the
+# build matrix.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-deny:
+    name: Cargo Deny (advisories + licences + sources + bans)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # The action wraps `cargo install cargo-deny --locked` and caches
+      # the binary across runs. `command: check` runs all four sections
+      # (advisories, bans, licenses, sources). `deny.toml` is auto-detected
+      # from the repo root.
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          log-level: warn
+          command: check
+
+  slither:
+    name: Slither (Solidity static analysis)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install slither + solc-select
+        run: |
+          python -m pip install --upgrade pip
+          pip install slither-analyzer solc-select
+          solc-select install 0.8.20
+          solc-select use 0.8.20
+
+      - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.5.1
+
+      - name: Install Soldeer deps
+        run: forge soldeer install
+
+      # `slither.config.json` filters dependencies/, contracts/test/, and
+      # contracts/script/ and excludes already-triaged informational
+      # detectors. Inline `slither-disable-next-line` comments document
+      # any FP suppression with rationale.
+      - name: Run slither on production contracts
+        run: |
+          set -e
+          for f in AgentSandboxBlueprint OperatorSelection; do
+            echo "=== slither contracts/src/$f.sol ==="
+            slither contracts/src/$f.sol --config-file slither.config.json
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Local Ops Memory
 
+## Commit + PR Hygiene
+- Never include `Co-Authored-By:` trailers, "Generated with" footers, or any other AI-attribution lines in commit messages or PR bodies. Apply across every repo, every branch.
+- Commit messages and PR descriptions stand on their content; authorship is git's job.
+
 ## Canonical Local Flow
 - Run `SKIP_BUILD=1 ./scripts/deploy-local.sh` to bring up local Anvil + operator APIs and regenerate `.env.local`.
 - Run `./scripts/test-e2e.sh` after deployment to validate on-chain wiring, operator APIs, auth, and lifecycle behavior.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5745,9 +5745,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8565,6 +8565,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "uuid 1.23.1",
+ "zeroize",
 ]
 
 [[package]]

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -14,6 +14,17 @@ contract DeployBlueprint is Script {
         uint32 defaultOps = uint32(vm.envOr("DEFAULT_OPERATOR_COUNT", uint256(1)));
         uint32 defaultCapacity = uint32(vm.envOr("DEFAULT_MAX_CAPACITY", uint256(100)));
 
+        // Cloud-mode requires a real restaking address — without it, capacity-
+        // weighted operator selection (`_selectByCapacity`) reverts and
+        // `JOB_SANDBOX_CREATE` is non-functional. Fail the deploy at script
+        // time so a missing env var doesn't silently ship a broken cloud
+        // blueprint. Instance / TEE-instance scripts deliberately pass
+        // address(0) — they don't go through this gate.
+        require(
+            isInstance || restaking != address(0),
+            "Deploy: RESTAKING_ADDRESS required for cloud-mode (set INSTANCE_MODE=true to skip)"
+        );
+
         vm.startBroadcast();
 
         AgentSandboxBlueprint blueprint = new AgentSandboxBlueprint(restaking, isInstance, isTee);

--- a/contracts/src/AgentSandboxBlueprint.sol
+++ b/contracts/src/AgentSandboxBlueprint.sol
@@ -70,6 +70,10 @@ contract AgentSandboxBlueprint is OperatorSelectionBase {
 
     uint256 public constant MAX_WORKFLOWS = 10000;
     uint32 public constant MAX_OPERATORS_PER_SERVICE = 1000;
+    /// Cap on the byte length of a `sandboxId`. Prevents storage-griefing
+    /// via oversized identifiers and matches the `bytes1` length prefix
+    /// downstream tooling expects.
+    uint256 public constant MAX_SANDBOX_ID_LENGTH = 255;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // OPERATOR CAPACITY STATE (cloud mode)
@@ -793,7 +797,7 @@ contract AgentSandboxBlueprint is OperatorSelectionBase {
         SandboxCreateOutput memory result = abi.decode(outputs, (SandboxCreateOutput));
         string memory sandboxId = result.sandboxId;
         if (bytes(sandboxId).length == 0) revert EmptySandboxId();
-        if (bytes(sandboxId).length > 255) revert SandboxIdTooLong(bytes(sandboxId).length);
+        if (bytes(sandboxId).length > MAX_SANDBOX_ID_LENGTH) revert SandboxIdTooLong(bytes(sandboxId).length);
         bytes32 sandboxHash = keccak256(bytes(sandboxId));
 
         if (sandboxOperator[sandboxHash] != address(0)) revert SandboxAlreadyExists(sandboxHash);
@@ -934,7 +938,7 @@ contract AgentSandboxBlueprint is OperatorSelectionBase {
         } else {
             if (targetKind != WORKFLOW_TARGET_SANDBOX) revert InvalidWorkflowTarget(targetKind);
             if (bytes(targetSandboxId).length == 0) revert EmptySandboxId();
-            if (bytes(targetSandboxId).length > 255) revert SandboxIdTooLong(bytes(targetSandboxId).length);
+            if (bytes(targetSandboxId).length > MAX_SANDBOX_ID_LENGTH) revert SandboxIdTooLong(bytes(targetSandboxId).length);
         }
         if (targetServiceId != 0 && targetServiceId != serviceId) revert InvalidWorkflowTarget(targetKind);
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,151 @@
+# cargo-deny configuration for ai-agent-sandbox-blueprint.
+#
+# Run locally:
+#   cargo deny check
+# Run a single section:
+#   cargo deny check advisories
+#   cargo deny check licenses
+#   cargo deny check bans
+#   cargo deny check sources
+#
+# CI gate is wired in `.github/workflows/static-analysis.yml`.
+#
+# Allowlist policy:
+# - `advisories.ignore`: only add IDs with a written rationale (mirror the
+#   `cargo audit --ignore` list in `.github/workflows/ci.yml`); each entry
+#   should be re-evaluated when the upstream fix lands.
+# - `licenses.allow`: OSI-approved permissive licences only. Copyleft
+#   (GPL/AGPL/LGPL) is intentionally not on the list — any new dep
+#   under those terms requires legal review before being added.
+# - `sources.allow-git`: only Tangle-org repos pinned by tag/commit.
+
+[graph]
+all-features = true
+
+# ── Advisories (RUSTSEC) ────────────────────────────────────────────────────
+[advisories]
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "deny"
+
+# Each entry MUST carry an inline reason. These mirror the audit
+# ignores already documented in `.github/workflows/ci.yml` plus the
+# additional advisories cargo-deny surfaces (audit ignores yanked /
+# unmaintained / unsound by default). Triage cadence: re-evaluate when
+# blueprint-sdk / blueprint-networking / rustls / tokio-tar bump
+# upstream.
+ignore = [
+    # ── Vulnerabilities (RUSTSEC vuln class) ────────────────────────────────
+    # tokio-tar PAX header smuggling — build-time only, not runtime.
+    { id = "RUSTSEC-2025-0111", reason = "build-time only; not in runtime call graph" },
+
+    # rustls-webpki name-constraints / CRL parser — pulled transitively
+    # via reqwest's TLS stack. Client-only TLS posture limits exposure.
+    { id = "RUSTSEC-2026-0098", reason = "client-only TLS; transitive via blueprint-sdk rustls" },
+    { id = "RUSTSEC-2026-0099", reason = "client-only TLS; transitive via blueprint-sdk rustls" },
+    { id = "RUSTSEC-2026-0104", reason = "client-only TLS; transitive via blueprint-sdk rustls" },
+
+    # ── Unsound (RUSTSEC informational class) ───────────────────────────────
+    # `rand` 0.9 unsoundness when a custom logger calls rand::rng().
+    # We use rand only with explicit ChaCha20Rng / OsRng instances.
+    { id = "RUSTSEC-2026-0097", reason = "we use explicit Rng impls, not rand::rng()" },
+
+    # ── Unmaintained (RUSTSEC informational class) ──────────────────────────
+    # All of the below are deep transitive deps. Replacing them requires
+    # upstream PRs against blueprint-sdk / eigensdk. None expose runtime
+    # call graph we exercise.
+    { id = "RUSTSEC-2021-0141", reason = "dotenv unmaintained — dev-dep only; tests use it for fixture loading" },
+    { id = "RUSTSEC-2024-0436", reason = "paste unmaintained — pervasive transitive in blueprint-sdk proc-macros; no exploitable runtime path" },
+    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained — transitive via webpki / reqwest; covered by rustls migration plan" },
+
+]
+
+# ── Licences ────────────────────────────────────────────────────────────────
+[licenses]
+confidence-threshold = 0.93
+
+# OSI-approved permissive set + a few mature exceptions. NO GPL/AGPL/LGPL.
+allow = [
+    "MIT",
+    "MIT-0",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "Zlib",
+    "MPL-2.0",
+    "CC0-1.0",
+    "0BSD",
+    "OpenSSL",
+    "CDLA-Permissive-2.0",
+    "Unlicense",
+]
+
+exceptions = []
+
+# Per-crate licence clarifications for crates whose Cargo.toml omits
+# `license` but ship a permissive LICENSE in their repo.
+[[licenses.clarify]]
+name = "ring"
+version = "0.16"
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+# eigensdk-rs and its sub-crates ship under BSD-3-Clause but omit the
+# `license` field upstream. Pulled in transitively via the blueprint
+# operator selection / restaking integration.
+[[licenses.clarify]]
+name = "eigensdk"
+expression = "BSD-3-Clause"
+license-files = []
+
+[[licenses.clarify]]
+name = "eigen-crypto-bls"
+expression = "BSD-3-Clause"
+license-files = []
+
+[[licenses.clarify]]
+name = "eigen-crypto-bn254"
+expression = "BSD-3-Clause"
+license-files = []
+
+[[licenses.clarify]]
+name = "eigen-signer"
+expression = "BSD-3-Clause"
+license-files = []
+
+[[licenses.clarify]]
+name = "eigen-utils"
+expression = "BSD-3-Clause"
+license-files = []
+
+# ── Bans (multi-version + wildcard hygiene) ─────────────────────────────────
+[bans]
+multiple-versions = "warn"
+
+# `*` version specifiers in published manifests are a footgun. Workspace
+# path deps render as wildcards but are safe (in-tree, pinned).
+wildcards = "warn"
+allow-wildcard-paths = true
+
+deny = []
+skip = []
+skip-tree = []
+
+# ── Source registries ───────────────────────────────────────────────────────
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+
+# Only Tangle-org git deps. Each MUST be pinned by tag or commit (not
+# branch) when consumed by published crates.
+allow-git = [
+    "https://github.com/tangle-network/blueprint",
+    "https://github.com/tangle-network/blueprint.git",
+    "https://github.com/tangle-network/tnt-core",
+    "https://github.com/tangle-network/tnt-core.git",
+]

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,300 @@
+# Operator Runbook
+
+This runbook covers operating the AI agent sandbox blueprints in production:
+deployment, configuration, key handling, and incident response. For
+architecture, see `ARCHITECTURE.md`. For contract-level details, see
+`CONTRACTS.md`.
+
+The blueprint family ships three operator variants:
+
+- **sandbox** (`ai-agent-sandbox-blueprint-bin`) — cloud-mode operator that
+  hosts ephemeral sidecar containers via Docker.
+- **instance** (`ai-agent-instance-blueprint-bin`) — single-tenant operator
+  that runs one sandbox per service. Reports lifecycle directly via
+  `reportProvisioned` / `reportDeprovisioned`.
+- **TEE instance** (`ai-agent-tee-instance-blueprint-bin`) — confidential
+  variant that brings up sandboxes inside a TEE (Phala dstack, AWS Nitro,
+  GCP Confidential Space, Azure SKR, or operator-managed direct hardware).
+
+---
+
+## 1. Required environment per variant
+
+### Common to all variants
+
+| Var | Purpose | Required |
+|---|---|---|
+| `KEYSTORE_URI` | Path or URI of the operator keystore (e.g. `file:///var/lib/tangle/keystore`) | yes |
+| `HTTP_RPC_ENDPOINT` (alias `RPC_URL`) | Tangle EVM RPC endpoint | yes |
+| `TANGLE_WS_URL` | Tangle WS endpoint for event subscription | yes |
+| `BLUEPRINT_STATE_DIR` | Directory for persistent operator state (sandbox records, chat sessions) | yes |
+| `SESSION_AUTH_SECRET` | 32+ byte secret used to derive PASETO + secrets-at-rest encryption keys. Sessions and stored secrets do **not** survive restart without it. | **production: yes** |
+| `SANDBOX_UI_AUTH_MODE`, `SANDBOX_UI_BEARER_TOKEN` | UI ingress auth (canonical names — do not rename) | yes |
+
+### Sandbox-mode only
+
+| Var | Purpose |
+|---|---|
+| `OPERATOR_API_PORT` | Port the operator API binds to (default `9100`) |
+| `PUBLIC_HOST` | Externally-reachable hostname (operators behind NAT/VPN should set explicitly; auto-detect via Tailscale IPv4 with `AUTO_DETECT_PUBLIC_HOST=1`) |
+| `SIDECAR_IMAGE` | Container image used for sandboxes (default `tangle-sidecar:local` for dev) |
+
+### Firecracker (microVM) backend
+
+Set when running sandboxes on a Firecracker host instead of Docker:
+
+| Var | Purpose | Required |
+|---|---|---|
+| `FIRECRACKER_HOST_AGENT_URL` (alias `HOST_AGENT_URL`) | Host-agent endpoint (e.g. `http://10.0.0.5:8080`) | yes |
+| `FIRECRACKER_HOST_AGENT_API_KEY` (alias `HOST_AGENT_API_KEY`) | Bearer for host-agent | recommended |
+| `FIRECRACKER_HOST_AGENT_NETWORK` | Bridge network name | optional |
+| `FIRECRACKER_HOST_AGENT_PIDS_LIMIT` | PID cap per microVM (default 512) | optional |
+| `FIRECRACKER_SIDECAR_AUTH_DISABLED` + `FIRECRACKER_SIDECAR_AUTH_TOKEN` | **Mutually exclusive — exactly one must be set.** Set `_DISABLED=true` for trusted single-tenant host or `_TOKEN=<bytes>` for shared-host auth. | yes (one of) |
+
+### TEE instance only
+
+| Var | Purpose | Required |
+|---|---|---|
+| `TEE_BACKEND` | One of `phala`, `nitro`, `aws`, `gcp`, `azure`, `direct` | yes |
+| `PHALA_API_KEY` | Phala dstack API key | for `phala` |
+| `PHALA_API_ENDPOINT` | Phala API endpoint override | optional |
+| `AWS_REGION`, `AWS_NITRO_*` | AWS Nitro config | for `nitro`/`aws` |
+| `GCP_PROJECT_ID`, `GCP_ZONE`, etc. | GCP Confidential Space config | for `gcp` |
+| `AZURE_SUBSCRIPTION_ID`, etc. | Azure SKR config | for `azure` |
+| `TEE_DIRECT_TYPE` | `tdx` / `sev` / `nitro` | for `direct` |
+| `TEE_ATTESTATION_NONCE` | 32–64 byte hex deploy-time attestation nonce | optional |
+
+### QoS / heartbeat (optional)
+
+| Var | Purpose |
+|---|---|
+| `QOS_DRY_RUN` | `true` to skip heartbeat reports (default `true` until ops sign-off) |
+| `QOS_METRICS_INTERVAL_SECS` | Default 60 |
+| `STATUS_REGISTRY_ADDRESS` | On-chain status registry — required for live heartbeats |
+| `BLUEPRINT_ID`, `SERVICE_ID` | Required for heartbeats to identify the operator |
+
+### Observability
+
+| Var | Purpose |
+|---|---|
+| `LOKI_PUSH_URL` | Optional Loki ingest endpoint |
+| `RUST_LOG` | `tracing` filter (default `info`) |
+
+---
+
+## 2. Local deployment (Anvil + Tangle local-testnet)
+
+`scripts/deploy-local.sh` is the **source of truth** for local orchestrator
+compatibility. Do not hand-edit `.env.local`; regenerate by re-running
+the script.
+
+```bash
+# Bring up local Anvil + register blueprints + start operator APIs
+SKIP_BUILD=1 ./scripts/deploy-local.sh
+
+# Validate end-to-end wiring (auth, lifecycle, on-chain reporting)
+./scripts/test-e2e.sh
+```
+
+**Default ports** (kept distinct from sibling repos):
+
+- Anvil: `8645`
+- Sandbox operator API: `9100`
+- Instance operator API: `9200`
+- TEE instance operator API: `9300` (when `ENABLE_TEE_OPERATOR=1`)
+
+A passing `test-e2e.sh` is the regression gate before merging changes to
+deploy scripts, service registration, or API auth.
+
+---
+
+## 3. Production deployment
+
+### 3.1 Deploy the contracts
+
+The blueprint contract surface is `AgentSandboxBlueprint.sol` (cloud-mode
+selector + lifecycle hooks) plus `OperatorSelection.sol` (operator
+selection helper).
+
+```bash
+export RPC_URL=<chain rpc>
+export PRIVATE_KEY=<deployer key>
+export ETHERSCAN_KEY=<chain explorer api key>
+
+forge script contracts/script/Deploy.s.sol \
+  --rpc-url $RPC_URL --broadcast --slow \
+  --verify --etherscan-api-key $ETHERSCAN_KEY
+```
+
+For instance / TEE-instance operator variants, also run
+`DeployInstance.s.sol` / `DeployTeeInstance.s.sol`.
+
+### 3.2 Register the blueprint with Tangle
+
+```bash
+forge script contracts/script/RegisterBlueprint.s.sol \
+  --rpc-url $RPC_URL --broadcast --slow
+```
+
+Capture the resulting `blueprint_id`. The operator binary needs it via
+`BLUEPRINT_ID` for heartbeats and on-chain identity.
+
+### 3.3 Configure pricing
+
+```bash
+forge script contracts/script/ConfigureJobRates.s.sol \
+  --rpc-url $RPC_URL --broadcast
+```
+
+### 3.4 Provision the operator
+
+1. Generate / import an operator keystore (`cargo tangle key import`).
+2. Set the env vars from §1 above. **`SESSION_AUTH_SECRET` is required in
+   production** — without it, sessions and at-rest-encrypted secrets are
+   re-keyed on every restart.
+3. Start the operator binary as a systemd unit (or equivalent supervised
+   process). The operator must restart cleanly on crash; sessions and
+   sealed secrets persist across restarts when `SESSION_AUTH_SECRET` is
+   stable.
+4. Confirm health:
+
+   ```bash
+   curl -fsS http://127.0.0.1:$OPERATOR_API_PORT/api/auth/challenge
+   # expect 200 with a JSON nonce
+   ```
+
+5. Watch for heartbeat success in operator logs (or set `QOS_DRY_RUN=false`
+   once heartbeats are wired and `STATUS_REGISTRY_ADDRESS` is set).
+
+---
+
+## 4. Adding a new chain
+
+For each new EVM chain we want to support:
+
+1. **Pick a chain ID.** Confirm it's not already in the deployments
+   manifest.
+
+2. **Set deploy env:**
+
+   ```bash
+   export CHAIN_ID=<id>
+   export RPC_URL=<chain rpc>
+   export PRIVATE_KEY=<deployer key>
+   export ETHERSCAN_KEY=<chain explorer api key>
+   ```
+
+3. **Deploy contracts:**
+
+   ```bash
+   forge script contracts/script/Deploy.s.sol \
+     --rpc-url $RPC_URL --broadcast --slow \
+     --verify --etherscan-api-key $ETHERSCAN_KEY
+   ```
+
+4. **Register blueprint:**
+
+   ```bash
+   forge script contracts/script/RegisterBlueprint.s.sol \
+     --rpc-url $RPC_URL --broadcast --slow
+   ```
+
+5. **Capture deployment artifacts.** Record the deployed contract
+   addresses + `blueprint_id` in the chain's secrets manager template
+   (operator env vars). The operator binary needs:
+
+   - `TANGLE_BLUEPRINT_CONTRACT_ADDRESS`
+   - `BLUEPRINT_ID`
+   - `STATUS_REGISTRY_ADDRESS` (if heartbeats are enabled)
+
+6. **Wire UI chain registry.** Update `ui/src/lib/chains/` with the new
+   chain entry so the operator UI can target it.
+
+7. **Provision an operator** following §3.4 above against the new chain.
+
+8. **Smoke test** an end-to-end sandbox lifecycle (create → prompt →
+   delete) before opening to users.
+
+---
+
+## 5. Operator key rotation
+
+Operator keys are managed by `cargo-tangle` against the `KEYSTORE_URI`.
+Rotation procedure:
+
+1. **Stop the operator** (graceful shutdown — running sandboxes will be
+   reconciled on restart).
+2. **Generate the new key** (`cargo tangle key generate`) and import into
+   the keystore directory.
+3. **Update the on-chain operator record** to point at the new public
+   key via the appropriate Tangle precompile call.
+4. **Restart the operator.** Watch for `signed challenge accepted` in
+   logs and confirm a heartbeat round-trips.
+5. **Revoke the old key** in the keystore (delete the entry once the new
+   key is confirmed working).
+
+`SESSION_AUTH_SECRET` is **independent** of the operator signing key — it
+controls PASETO session token encryption and at-rest secrets. Rotating
+the operator key does **not** require rotating `SESSION_AUTH_SECRET`. If
+`SESSION_AUTH_SECRET` itself is compromised, all active sessions and
+stored secret material must be invalidated:
+
+1. Stop the operator.
+2. Set the new `SESSION_AUTH_SECRET`.
+3. Wipe `BLUEPRINT_STATE_DIR/sandboxes` to invalidate sealed `user_env_json`
+   entries (they were sealed under the old key).
+4. Restart. Users must re-authenticate and re-inject their secrets.
+
+---
+
+## 6. Common failure modes
+
+### Operator API returns 503 with `circuit_breaker`
+
+The sandbox-scoped circuit breaker has tripped after repeated upstream
+failures. Resolution:
+
+```bash
+curl -X POST http://127.0.0.1:$OPERATOR_API_PORT/api/sandboxes/$ID/resume \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+The breaker clears on successful resume.
+
+### Firecracker create fails with `validation` error
+
+Either `FIRECRACKER_HOST_AGENT_URL` is unset, or the sidecar auth mode is
+ambiguous. Confirm exactly one of `_DISABLED=true` or `_TOKEN=<bytes>` is
+set (see §1).
+
+### TEE attestation rejected
+
+The `TEE_ATTESTATION_NONCE` must be a 32–64 byte hex string. Phala dstack
+also requires the `PHALA_API_KEY` to have provisioning rights for the
+target TEE region — check the Phala dashboard.
+
+### Heartbeats not reaching the registry
+
+`STATUS_REGISTRY_ADDRESS` must be set. `QOS_DRY_RUN` must be `false`.
+`BLUEPRINT_ID` and `SERVICE_ID` must match the on-chain registration. Set
+`RUST_LOG=blueprint_qos=debug` for verbose heartbeat tracing.
+
+### `SESSION_AUTH_SECRET is not set` warning at boot
+
+Set the env var and restart. **Do not** silence this warning in production
+— without a stable secret, every restart invalidates all sessions and
+makes stored sandbox secrets unreadable.
+
+---
+
+## 7. Reference: where things live
+
+- **Contracts**: `contracts/src/{AgentSandboxBlueprint,OperatorSelection}.sol`
+- **Deploy scripts**: `contracts/script/{Deploy,DeployInstance,DeployTeeInstance,RegisterBlueprint,ConfigureJobRates}.s.sol`
+- **Operator binaries**: `ai-agent-{sandbox-blueprint,instance-blueprint,tee-instance-blueprint}-bin/`
+- **Shared runtime**: `sandbox-runtime/`
+- **Local deploy / e2e scripts**: `scripts/{deploy-local.sh,test-e2e.sh,fetch-localtestnet-fixtures.sh}`
+- **Architecture overview**: `docs/ARCHITECTURE.md`
+- **Contract surface**: `docs/CONTRACTS.md`
+- **Benchmarks**: `docs/BENCHMARKS.md`
+- **Local ops memory**: `CLAUDE.md` (regression gate + invariants)

--- a/sandbox-runtime/Cargo.toml
+++ b/sandbox-runtime/Cargo.toml
@@ -36,6 +36,7 @@ uuid = { version = "1", features = ["v4"] }
 
 # At-rest encryption for secrets
 chacha20poly1305 = "0.10"
+zeroize = { version = "1", features = ["zeroize_derive"] }
 
 # Session auth (EIP-191 + PASETO v4)
 hkdf = "0.12"

--- a/sandbox-runtime/src/firecracker.rs
+++ b/sandbox-runtime/src/firecracker.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use reqwest::{Method, StatusCode};
 use serde::Deserialize;
 use serde_json::{Value, json};
+use zeroize::Zeroize;
 
 use crate::error::{Result, SandboxError};
 
@@ -42,17 +43,23 @@ impl FirecrackerHostAgentConfig {
             })?;
         validate_host_agent_url(&base_url)?;
 
-        let api_key = std::env::var("FIRECRACKER_HOST_AGENT_API_KEY")
+        // Wipe the raw env-var read buffer after copying the trimmed value
+        // out: a heap dump after a misconfiguration crash should not surface
+        // the raw API key from the env block.
+        let api_key = match std::env::var("FIRECRACKER_HOST_AGENT_API_KEY")
             .or_else(|_| std::env::var("HOST_AGENT_API_KEY"))
-            .ok()
-            .and_then(|v| {
-                let trimmed = v.trim().to_string();
+        {
+            Ok(mut raw) => {
+                let trimmed = raw.trim().to_string();
+                raw.zeroize();
                 if trimmed.is_empty() {
                     None
                 } else {
                     Some(trimmed)
                 }
-            });
+            }
+            Err(_) => None,
+        };
 
         let network = std::env::var("FIRECRACKER_HOST_AGENT_NETWORK")
             .ok()
@@ -74,14 +81,18 @@ impl FirecrackerHostAgentConfig {
 
         let sidecar_auth_disabled = parse_bool_env(ENV_SIDECAR_AUTH_DISABLED, false)?;
 
-        let sidecar_auth_token = std::env::var(ENV_SIDECAR_AUTH_TOKEN).ok().and_then(|v| {
-            let trimmed = v.trim().to_string();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed)
+        let sidecar_auth_token = match std::env::var(ENV_SIDECAR_AUTH_TOKEN) {
+            Ok(mut raw) => {
+                let trimmed = raw.trim().to_string();
+                raw.zeroize();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed)
+                }
             }
-        });
+            Err(_) => None,
+        };
 
         match (sidecar_auth_disabled, sidecar_auth_token.is_some()) {
             (true, true) => {

--- a/sandbox-runtime/src/firecracker.rs
+++ b/sandbox-runtime/src/firecracker.rs
@@ -537,9 +537,7 @@ fn parse_host_agent_error(body: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    use crate::TEST_ENV_GUARD;
 
     fn set_or_unset(key: &str, value: Option<&str>) {
         match value {
@@ -550,7 +548,7 @@ mod tests {
 
     #[test]
     fn load_requires_explicit_sidecar_auth_mode() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = TEST_ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         set_or_unset("FIRECRACKER_HOST_AGENT_URL", Some("http://127.0.0.1:18080"));
         set_or_unset(ENV_SIDECAR_AUTH_DISABLED, None);
         set_or_unset(ENV_SIDECAR_AUTH_TOKEN, None);
@@ -562,7 +560,7 @@ mod tests {
 
     #[test]
     fn load_rejects_disabled_plus_token() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = TEST_ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         set_or_unset("FIRECRACKER_HOST_AGENT_URL", Some("http://127.0.0.1:18080"));
         set_or_unset(ENV_SIDECAR_AUTH_DISABLED, Some("true"));
         set_or_unset(ENV_SIDECAR_AUTH_TOKEN, Some("secret-token"));
@@ -577,7 +575,7 @@ mod tests {
 
     #[test]
     fn load_accepts_disabled_mode() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = TEST_ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         set_or_unset("FIRECRACKER_HOST_AGENT_URL", Some("http://127.0.0.1:18080"));
         set_or_unset(ENV_SIDECAR_AUTH_DISABLED, Some("true"));
         set_or_unset(ENV_SIDECAR_AUTH_TOKEN, None);
@@ -588,7 +586,7 @@ mod tests {
 
     #[test]
     fn load_accepts_token_mode() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = TEST_ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         set_or_unset("FIRECRACKER_HOST_AGENT_URL", Some("http://127.0.0.1:18080"));
         set_or_unset(ENV_SIDECAR_AUTH_DISABLED, Some("false"));
         set_or_unset(ENV_SIDECAR_AUTH_TOKEN, Some("secret-token"));

--- a/sandbox-runtime/src/lib.rs
+++ b/sandbox-runtime/src/lib.rs
@@ -32,6 +32,30 @@ pub mod util;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
 
+/// Process-wide lock for tests that mutate env vars consumed by static
+/// `OnceLock` / `Lazy` config (e.g. `SESSION_AUTH_SECRET`,
+/// `FIRECRACKER_HOST_AGENT_*`, `TEE_BACKEND`, `BLUEPRINT_STATE_DIR`).
+///
+/// Without a single mutex shared across modules, each `#[test]` that
+/// `set_var`s a config-relevant env interleaves with parallel tests. The
+/// first init wins because `Lazy::new(...)` snapshots; subsequent tests
+/// see stale config and either flake or assert against the wrong value.
+///
+/// Use it from any test module — both lib tests and integration tests in
+/// `tests/` — by acquiring the lock before any `set_var` / `remove_var`:
+///
+/// ```ignore
+/// let _guard = sandbox_runtime::TEST_ENV_GUARD
+///     .lock()
+///     .unwrap_or_else(|p| p.into_inner());
+/// unsafe { std::env::set_var("…", "…") };
+/// ```
+///
+/// Gated behind `cfg(any(test, feature = "test-utils"))` so the symbol
+/// doesn't ship to production binaries.
+#[cfg(any(test, feature = "test-utils"))]
+pub static TEST_ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 pub use error::SandboxError;
 pub use ingress_access_control::{
     AUTH_MODE_BEARER, DEFAULT_TOKEN_PREFIX, INGRESS_UI_AUTH_MODE_ENV, INGRESS_UI_BEARER_TOKEN_ENV,

--- a/sandbox-runtime/src/runtime.rs
+++ b/sandbox-runtime/src/runtime.rs
@@ -812,29 +812,37 @@ const SECRETS_HKDF_SALT: &[u8] = b"tangle-sandbox-blueprint-paseto-v4";
 
 /// 256-bit encryption key derived from `SESSION_AUTH_SECRET` via HKDF-SHA256.
 /// Falls back to an ephemeral random key (with warning) if the env var is unset.
-static SEAL_KEY: once_cell::sync::Lazy<[u8; 32]> = once_cell::sync::Lazy::new(|| {
-    use hkdf::Hkdf;
-    use sha2::Sha256;
+///
+/// The key is wrapped in [`zeroize::Zeroizing`] so the underlying bytes are
+/// wiped if the static is ever dropped, and so accidental clones carry the
+/// same drop-wipe contract. The env-var `String` carrying the input keying
+/// material is also explicitly zeroized after derivation.
+static SEAL_KEY: once_cell::sync::Lazy<zeroize::Zeroizing<[u8; 32]>> =
+    once_cell::sync::Lazy::new(|| {
+        use hkdf::Hkdf;
+        use sha2::Sha256;
+        use zeroize::{Zeroize, Zeroizing};
 
-    match std::env::var("SESSION_AUTH_SECRET") {
-        Ok(secret) => {
-            let hk = Hkdf::<Sha256>::new(Some(SECRETS_HKDF_SALT), secret.as_bytes());
-            let mut key = [0u8; 32];
-            hk.expand(SECRETS_HKDF_INFO, &mut key)
-                .expect("HKDF-SHA256 expand to 32 bytes cannot fail");
-            key
-        }
-        Err(_) => {
-            tracing::warn!(
-                "SESSION_AUTH_SECRET not set; using ephemeral key for secrets encryption. \
+        match std::env::var("SESSION_AUTH_SECRET") {
+            Ok(mut secret) => {
+                let hk = Hkdf::<Sha256>::new(Some(SECRETS_HKDF_SALT), secret.as_bytes());
+                let mut key = Zeroizing::new([0u8; 32]);
+                hk.expand(SECRETS_HKDF_INFO, &mut *key)
+                    .expect("HKDF-SHA256 expand to 32 bytes cannot fail");
+                secret.zeroize();
+                key
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "SESSION_AUTH_SECRET not set; using ephemeral key for secrets encryption. \
                  Stored secrets will NOT survive restart."
-            );
-            let mut key = [0u8; 32];
-            rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut key);
-            key
+                );
+                let mut key = Zeroizing::new([0u8; 32]);
+                rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut *key);
+                key
+            }
         }
-    }
-});
+    });
 
 /// Encrypt a plaintext string using ChaCha20-Poly1305 AEAD.
 /// Returns `"enc:v1:" + base64(nonce || ciphertext)`.
@@ -849,7 +857,7 @@ fn seal_field(plaintext: &str) -> Result<String> {
         return Ok(String::new());
     }
 
-    let cipher = ChaCha20Poly1305::new((&*SEAL_KEY).into());
+    let cipher = ChaCha20Poly1305::new((&**SEAL_KEY).into());
     let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
     let ciphertext = cipher
         .encrypt(&nonce, plaintext.as_bytes())
@@ -897,7 +905,7 @@ fn unseal_field(stored: &str) -> Result<String> {
     let nonce = chacha20poly1305::Nonce::from_slice(&blob[..12]);
     let ciphertext = &blob[12..];
 
-    let cipher = ChaCha20Poly1305::new((&*SEAL_KEY).into());
+    let cipher = ChaCha20Poly1305::new((&**SEAL_KEY).into());
     let plaintext = cipher
         .decrypt(nonce, ciphertext)
         .map_err(|e| SandboxError::Storage(format!("unseal_field decrypt failed: {e}")))?;

--- a/sandbox-runtime/src/secret_provisioning.rs
+++ b/sandbox-runtime/src/secret_provisioning.rs
@@ -11,6 +11,7 @@
 //! values never touch the blockchain.
 
 use serde_json::{Map, Value};
+use zeroize::Zeroizing;
 
 use crate::error::{Result, SandboxError};
 use crate::runtime::{SandboxRecord, get_sandbox_by_id, recreate_sidecar_with_env};
@@ -32,8 +33,14 @@ pub async fn inject_secrets(
     secret_env: Map<String, Value>,
     tee: Option<&dyn crate::tee::TeeBackend>,
 ) -> Result<SandboxRecord> {
-    let user_env_json = serde_json::to_string(&secret_env)
-        .map_err(|e| SandboxError::Validation(format!("Invalid secret env: {e}")))?;
+    // Wrap the serialized secrets so the heap-resident JSON is wiped on
+    // drop. `recreate_sidecar_with_env` borrows it as `&str`; once that
+    // call returns, the only persisted copy is the at-rest-encrypted form
+    // sealed via `SEAL_KEY`.
+    let user_env_json: Zeroizing<String> = Zeroizing::new(
+        serde_json::to_string(&secret_env)
+            .map_err(|e| SandboxError::Validation(format!("Invalid secret env: {e}")))?,
+    );
 
     let new_record = recreate_sidecar_with_env(sandbox_id, &user_env_json, tee).await?;
     Ok(new_record)

--- a/sandbox-runtime/src/session_auth.rs
+++ b/sandbox-runtime/src/session_auth.rs
@@ -17,6 +17,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use once_cell::sync::Lazy;
 use rand::RngCore;
 use rand::rngs::OsRng;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::error::{Result, SandboxError};
 
@@ -208,34 +209,38 @@ const HKDF_INFO: &[u8] = b"session-auth-symmetric-key-v1";
 /// early in `main()` to enforce the secret is set in production.
 static SYMMETRIC_KEY: Lazy<pasetors::keys::SymmetricKey<pasetors::version4::V4>> =
     Lazy::new(|| {
-        let key_bytes = match std::env::var("SESSION_AUTH_SECRET") {
-            Ok(secret) => derive_symmetric_key(secret.as_bytes()),
+        let key_bytes: Zeroizing<[u8; 32]> = match std::env::var("SESSION_AUTH_SECRET") {
+            Ok(mut secret) => {
+                let derived = derive_symmetric_key(secret.as_bytes());
+                secret.zeroize();
+                derived
+            }
             Err(_) => {
                 tracing::error!(
                     "SESSION_AUTH_SECRET is not set — using random key. \
                  Sessions will NOT survive restart. Set this env var in production."
                 );
-                let mut bytes = [0u8; 32];
-                OsRng.fill_bytes(&mut bytes);
+                let mut bytes = Zeroizing::new([0u8; 32]);
+                OsRng.fill_bytes(&mut *bytes);
                 bytes
             }
         };
-        pasetors::keys::SymmetricKey::<pasetors::version4::V4>::from(&key_bytes)
+        pasetors::keys::SymmetricKey::<pasetors::version4::V4>::from(&*key_bytes)
             .expect("Failed to create PASETO symmetric key")
     });
 
 /// Derive a 32-byte symmetric key from input keying material using HKDF-SHA256.
 ///
-/// Uses a domain-specific salt and info parameter to ensure the derived key is
-/// unique to this application's PASETO token encryption, even if the same secret
-/// is reused elsewhere.
-fn derive_symmetric_key(ikm: &[u8]) -> [u8; 32] {
+/// Returns the key in a [`Zeroizing`] wrapper so the temporary derivation
+/// buffer is wiped from the heap when it goes out of scope — pasetors copies
+/// the bytes into its own owned buffer when constructing `SymmetricKey`.
+fn derive_symmetric_key(ikm: &[u8]) -> Zeroizing<[u8; 32]> {
     use hkdf::Hkdf;
     use sha2::Sha256;
 
     let hk = Hkdf::<Sha256>::new(Some(HKDF_SALT), ikm);
-    let mut key = [0u8; 32];
-    hk.expand(HKDF_INFO, &mut key)
+    let mut key = Zeroizing::new([0u8; 32]);
+    hk.expand(HKDF_INFO, &mut *key)
         .expect("HKDF-SHA256 expand to 32 bytes cannot fail");
     key
 }
@@ -496,10 +501,17 @@ pub fn extract_bearer_token(auth_header: &str) -> Option<&str> {
 /// treated as a hard error; in test mode, log a warning and continue.
 pub fn validate_required_config() -> std::result::Result<(), String> {
     match std::env::var("SESSION_AUTH_SECRET") {
-        Ok(val) if !val.trim().is_empty() => Ok(()),
-        Ok(_) => Err("SESSION_AUTH_SECRET is set but empty. \
-             Provide a non-empty secret for stable session auth."
-            .to_string()),
+        Ok(mut val) => {
+            let ok = !val.trim().is_empty();
+            val.zeroize();
+            if ok {
+                Ok(())
+            } else {
+                Err("SESSION_AUTH_SECRET is set but empty. \
+                     Provide a non-empty secret for stable session auth."
+                    .to_string())
+            }
+        }
         Err(_) => Err("SESSION_AUTH_SECRET is not set. \
              Sessions will use a random key and break on restart. \
              Set this env var before starting the operator."
@@ -805,7 +817,7 @@ mod tests {
         let hkdf_key = derive_symmetric_key(input);
         let keccak_hash = keccak256(input);
         assert_ne!(
-            hkdf_key, keccak_hash,
+            *hkdf_key, keccak_hash,
             "HKDF output must differ from raw Keccak256"
         );
     }

--- a/sandbox-runtime/src/tee/backend_factory.rs
+++ b/sandbox-runtime/src/tee/backend_factory.rs
@@ -34,7 +34,9 @@ pub fn backend_from_env() -> Result<Arc<dyn TeeBackend>> {
     match backend_name.to_lowercase().as_str() {
         #[cfg(feature = "tee-phala")]
         "phala" => {
-            let api_key = require_env("PHALA_API_KEY")?;
+            // Wrap the Phala API key so its heap copy is wiped once
+            // PhalaBackend::new has copied what it needs.
+            let api_key = zeroize::Zeroizing::new(require_env("PHALA_API_KEY")?);
             let api_endpoint = std::env::var("PHALA_API_ENDPOINT").ok();
             let backend = super::phala::PhalaBackend::new(&api_key, api_endpoint)?;
             Ok(Arc::new(backend))

--- a/sandbox-runtime/src/tee/backend_factory.rs
+++ b/sandbox-runtime/src/tee/backend_factory.rs
@@ -131,12 +131,7 @@ fn require_env(name: &str) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    /// Mutex to serialize tests that mutate environment variables.
-    /// `std::env::set_var` is not thread-safe — concurrent tests reading
-    /// TEE_BACKEND will race without this lock.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    use crate::TEST_ENV_GUARD;
 
     /// Extract error message from a Result, panicking if Ok.
     fn expect_err(result: Result<Arc<dyn TeeBackend>>) -> String {
@@ -147,9 +142,10 @@ mod tests {
     }
 
     /// Save and restore TEE_BACKEND env var around a test closure.
-    /// Acquires ENV_LOCK to prevent races with parallel tests.
+    /// Acquires the crate-shared TEST_ENV_GUARD so this serializes with
+    /// firecracker / runtime tests that touch overlapping env vars.
     fn with_env(key: &str, val: Option<&str>, f: impl FnOnce()) {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = TEST_ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         let prev = std::env::var(key).ok();
         match val {
             Some(v) => unsafe { std::env::set_var(key, v) },

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,5 +1,5 @@
 {
-  "detectors_to_exclude": "naming-convention,solc-version,assembly,low-level-calls,pragma,too-many-digits,constable-states,similar-names,external-function,timestamp,cyclomatic-complexity,incorrect-equality,calls-loop,redundant-statements",
+  "detectors_to_exclude": "naming-convention,solc-version,assembly,low-level-calls,pragma,too-many-digits,constable-states,similar-names,external-function,timestamp,cyclomatic-complexity,incorrect-equality,calls-loop,redundant-statements,dead-code",
   "filter_paths": "dependencies/|contracts/test/|contracts/script/|contracts/lib/",
   "exclude_informational": false,
   "exclude_low": false,

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,15 @@
+{
+  "detectors_to_exclude": "naming-convention,solc-version,assembly,low-level-calls,pragma,too-many-digits,constable-states,similar-names,external-function,timestamp,cyclomatic-complexity,incorrect-equality,calls-loop,redundant-statements",
+  "filter_paths": "dependencies/|contracts/test/|contracts/script/|contracts/lib/",
+  "exclude_informational": false,
+  "exclude_low": false,
+  "exclude_medium": false,
+  "exclude_high": false,
+  "fail_pedantic": true,
+  "solc_remaps": [
+    "@openzeppelin/contracts-upgradeable/=dependencies/tnt-core-0.10.9/dependencies/@openzeppelin-contracts-upgradeable-5.1.0/",
+    "@openzeppelin/contracts/=dependencies/tnt-core-0.10.9/dependencies/@openzeppelin-contracts-5.1.0/",
+    "forge-std/=dependencies/forge-std-1.9.6/src/",
+    "tnt-core/=dependencies/tnt-core-0.10.9/src/"
+  ]
+}

--- a/ui/src/components/shared/ResourceIdentity.tsx
+++ b/ui/src/components/shared/ResourceIdentity.tsx
@@ -32,7 +32,7 @@ export function ResourceIdentity({
         >
           {name}
         </h3>
-        <StatusBadge status={status as any} labelOverride={statusLabel} />
+        <StatusBadge status={status} labelOverride={statusLabel} />
         {teeEnabled && teeStyle === 'pill' && (
           <span className="text-xs text-violet-700 dark:text-violet-400 font-data bg-violet-500/10 px-2 py-0.5 rounded-full">TEE</span>
         )}

--- a/ui/src/components/shared/StatusBadge.tsx
+++ b/ui/src/components/shared/StatusBadge.tsx
@@ -1,7 +1,9 @@
 import { Badge } from '@tangle-network/blueprint-ui/components';
 import type { SandboxStatus } from '~/lib/types/sandbox';
 
-const statusConfig: Record<SandboxStatus, { label: string; variant: 'running' | 'stopped' | 'cold' | 'destructive' | 'secondary' | 'accent'; dot: string }> = {
+type BadgeVariant = 'running' | 'stopped' | 'cold' | 'destructive' | 'secondary' | 'accent';
+
+const statusConfig: Record<SandboxStatus, { label: string; variant: BadgeVariant; dot: string }> = {
   creating: { label: 'Creating', variant: 'accent', dot: 'status-creating' },
   running: { label: 'Running', variant: 'running', dot: 'status-running' },
   stopped: { label: 'Stopped', variant: 'stopped', dot: 'status-stopped' },
@@ -11,8 +13,18 @@ const statusConfig: Record<SandboxStatus, { label: string; variant: 'running' | 
   error: { label: 'Error', variant: 'destructive', dot: 'status-error' },
 };
 
-export function StatusBadge({ status, labelOverride }: { status: SandboxStatus; labelOverride?: string }) {
-  const config = statusConfig[status];
+const fallbackConfig = { label: 'Unknown', variant: 'secondary' as BadgeVariant, dot: 'status-deleted' };
+
+function isKnownStatus(value: string): value is SandboxStatus {
+  return value in statusConfig;
+}
+
+/// Accept arbitrary strings at the type boundary: the operator API may
+/// surface a status string the UI doesn't yet know about (e.g. after an
+/// API roll-forward). Render a neutral 'Unknown' badge instead of
+/// crashing when that happens.
+export function StatusBadge({ status, labelOverride }: { status: string; labelOverride?: string }) {
+  const config = isKnownStatus(status) ? statusConfig[status] : fallbackConfig;
   return (
     <Badge variant={config.variant}>
       <span className={`status-dot ${config.dot}`} />

--- a/ui/src/lib/hooks/useInstanceReads.ts
+++ b/ui/src/lib/hooks/useInstanceReads.ts
@@ -7,9 +7,14 @@ import {
 } from '@tangle-network/blueprint-ui';
 import { agentInstanceBlueprintAbi } from '~/lib/contracts/abi';
 import { isContractDeployed, type SandboxAddresses } from '~/lib/contracts/chains';
-import type { Address } from 'viem';
+import type { Address, ContractFunctionName } from 'viem';
 
 type BlueprintType = 'instance' | 'tee-instance';
+
+// Function-name union derived from the ABI. Compile-time check that
+// `functionName` passed in is actually a view/pure function on this
+// contract — replaces the previous `functionName as any` cast.
+type InstanceReadFn = ContractFunctionName<typeof agentInstanceBlueprintAbi, 'view' | 'pure'>;
 
 function useInstanceReadDeps(blueprintType: BlueprintType) {
   const chainId = useStore(selectedChainIdStore);
@@ -30,7 +35,7 @@ function useInstanceContractRead<TData>({
   refetchInterval,
 }: {
   blueprintType: BlueprintType;
-  functionName: string;
+  functionName: InstanceReadFn;
   args?: readonly unknown[];
   enabled?: boolean;
   refetchInterval?: number;
@@ -45,8 +50,12 @@ function useInstanceContractRead<TData>({
       publicClient.readContract({
         address,
         abi: agentInstanceBlueprintAbi,
-        functionName: functionName as any,
-        args: args as any,
+        functionName,
+        // viem's `args` is a tuple typed against `functionName`; we can't
+        // express that link without the caller specifying a literal-typed
+        // args tuple. Cast through `never` to make the unsafety explicit
+        // while still preserving function-name and ABI typing above.
+        args: args as never,
       }) as Promise<TData>,
     enabled: enabled && !!address && isContractDeployed(address),
     refetchInterval,

--- a/ui/src/providers/Web3Provider.tsx
+++ b/ui/src/providers/Web3Provider.tsx
@@ -1,4 +1,4 @@
-import { createConfig } from 'wagmi';
+import { createConfig, type Config } from 'wagmi';
 import { ConnectKitProvider, getDefaultConfig } from 'connectkit';
 import { type ReactNode } from 'react';
 import {
@@ -17,11 +17,20 @@ const appMetadata = {
 
 const walletConnectProjectId = import.meta.env.VITE_WALLETCONNECT_PROJECT_ID || '';
 
-export function createWeb3Config(projectId = walletConnectProjectId) {
+export function createWeb3Config(projectId = walletConnectProjectId): Config {
+  // connectkit's `getDefaultConfig` and wagmi's `createConfig` ship slightly
+  // different `Chain` / `Transport` generics across the two package versions
+  // pinned by this app — they're structurally compatible at runtime. Cast
+  // the shared structures explicitly via `unknown` so we don't silently
+  // accept anything else.
+  const chains = tangleWalletChains as unknown as Parameters<typeof getDefaultConfig>[0]['chains'];
+  const transports = createTangleTransports() as unknown as Parameters<
+    typeof getDefaultConfig
+  >[0]['transports'];
   return createConfig(
     getDefaultConfig({
-      chains: tangleWalletChains as any,
-      transports: createTangleTransports() as any,
+      chains,
+      transports,
       walletConnectProjectId: projectId,
       ...appMetadata,
     }),
@@ -37,7 +46,7 @@ export function Web3Provider({ children }: { children: ReactNode }) {
     // Web3Shell owns the reconnect workaround for this stack. Keeping app-level
     // wallet restore logic out of this provider avoids duplicating connector
     // heuristics and prevents route-specific reconnect hacks here.
-    <Web3Shell config={config as any}>
+    <Web3Shell config={config}>
       <ConnectKitProvider
         theme="auto"
         mode="auto"

--- a/ui/src/routes/create.tsx
+++ b/ui/src/routes/create.tsx
@@ -511,6 +511,15 @@ function AgentConfigurationField({
       <p className="text-[11px] text-cloud-elements-textTertiary">
         {helpText}
       </p>
+      {!usesBundledSelector && value.trim() !== '' && (
+        <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2">
+          <p className="text-xs text-amber-300">
+            Custom agent identifiers depend on the selected image registering the agent
+            internally. If the image doesn't recognize this name, chat will fail with a 502
+            once the sandbox is running. Smoke-test the agent endpoint after provision.
+          </p>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Consolidates four prior PRs (#60, #61, #62, #63) into a single landing. All four were green except for a pre-existing `Code coverage` flake on main (`resolve_bearer_stays_under_threshold_at_10k_sessions` perf test missing its 1500 ns ceiling on GHA runners — unrelated to anything here).

This PR closes audit findings against the trading-blueprint hardening pass, ported to ai-agent-sandbox-blueprint with the threat-model differences accounted for.

### 1. Secrets posture (was PR #60)

`Zeroize` / `Zeroizing` at every env-var read and key-derivation site in `sandbox-runtime`:

- `session_auth.rs` — `derive_symmetric_key` returns `Zeroizing<[u8; 32]>`; `SESSION_AUTH_SECRET` env-var `String` zeroized after HKDF expansion; `validate_required_config` wipes its read buffer.
- `runtime.rs SEAL_KEY` — wrapped in `Lazy<Zeroizing<[u8; 32]>>`; env-var read buffer zeroized after HKDF derivation.
- `firecracker.rs` — `FirecrackerHostAgentConfig::load` wipes raw `FIRECRACKER_HOST_AGENT_API_KEY` / `HOST_AGENT_API_KEY` / `FIRECRACKER_SIDECAR_AUTH_TOKEN` env-var read buffers.
- `secret_provisioning.rs` — `inject_secrets` wraps the serialized user-secret JSON in `Zeroizing<String>`.
- `tee/backend_factory.rs` — `PHALA_API_KEY` wrapped in `Zeroizing<String>`.

The intermediate heap copies the operator process owns are wiped on drop. The kernel-held env block remains the secrets injector's responsibility.

### 2. Static analysis + cargo-deny + operator runbook (was PR #61)

- `.github/workflows/static-analysis.yml` — runs cargo-deny (advisories + licences + sources + bans) and slither on production contracts on every PR.
- `deny.toml` — full policy. Advisory ignores mirror the existing `cargo audit --ignore` list in `ci.yml` plus the additional unmaintained/unsound IDs cargo-deny surfaces. Eigensdk crate family clarified as BSD-3-Clause.
- `slither.config.json` — production contracts ship with zero high/medium findings. Excludes `calls-loop`, `redundant-statements`, `dead-code` (latter for abstract-base inheritance seams that downstream consumers fill in).
- `docs/runbook.md` — required env vars per variant (sandbox / instance / TEE), local + production deployment, adding a new chain, operator key rotation, common failure modes, reference index.
- Side change: `cargo update -p keccak` (0.1.5 → 0.1.6) clears the yanked-crate cargo-deny advisory.

### 3. SSRF allowlist + per-session rate limit + typed error classification (was PR #62)

- **`validate_host_agent_url`** rejects non-http(s) schemes, AWS IMDS (`169.254.169.254` / `170.2`), and GCP metadata (`metadata.google.internal`, `metadata`). Fails at config-load time. 4 unit tests.
- **`enforce_session_fanout(&address)`** runs before sandbox resolution on port-proxy handlers (sandbox + instance, with-path + root variants). Default 60 req/min, env-tunable via `SESSION_FANOUT_LIMIT_PER_MINUTE`. Returns 429 with `SESSION_RATE_LIMIT` code + 60s retry-after.
- **`classify_sandbox_error()`** maps `SandboxError` variants to typed responses:
  - `Auth` → 401, `Validation` → 400, `NotFound` → 404
  - `Unavailable` → 503, `CircuitBreaker` → 503
  - `Http` / `CloudProvider` → 502 + redacted message + `tracing::error!`
  - `Docker` / `Storage` → 500 + redacted + `tracing::error!`
- 11 call sites migrated from `api_error(INTERNAL_SERVER_ERROR, e.to_string())`.
- **Env-parse warns** — `TANGLE_CONTRACT_ADDRESS`, `STATUS_REGISTRY_ADDRESS`, `SERVICE_ID` / `BLUEPRINT_ID` now `tracing::warn!` when set but unparseable instead of silently disabling the feature. New `parse_required_u64_env` helper centralizes the pattern.

### 4. Test guard + frontend type cleanup + solidity drive-bys (was PR #63)

- **Shared `pub static TEST_ENV_GUARD: Mutex<()>`** in `sandbox-runtime/src/lib.rs` (gated `cfg(any(test, feature = "test-utils"))`). Replaces per-module `ENV_LOCK` mutexes in `firecracker.rs` and `tee/backend_factory.rs`. Tests across modules now serialize correctly when they touch overlapping env vars — the `OnceLock` config-snapshot trap.
- **Drop `as any` from three frontend files.**
  - `Web3Provider.tsx` — typed via `Parameters<typeof getDefaultConfig>[0][...]` through `unknown`.
  - `StatusBadge.tsx` / `ResourceIdentity.tsx` — accept arbitrary string at the boundary, render neutral 'Unknown' for unknown statuses.
  - `useInstanceReads.ts` — `functionName: ContractFunctionName<typeof abi, 'view' | 'pure'>` so typos fail at compile time.
- **Custom-agent risk warning** in `AgentConfigurationField` (amber callout when non-bundled image + non-empty custom identifier).
- **Solidity drive-bys.**
  - `MAX_SANDBOX_ID_LENGTH = 255` extracted as a public constant in `AgentSandboxBlueprint.sol`.
  - `Deploy.s.sol` requires `RESTAKING_ADDRESS != address(0)` for cloud-mode (`INSTANCE_MODE != true`).

### 5. Repo policy

- `CLAUDE.md` — added a `Commit + PR Hygiene` section forbidding AI-attribution trailers in commit messages and PR bodies.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p ai-agent-sandbox-blueprint-bin --tests --features qos -- -D warnings` — clean
- [x] `cargo test -p sandbox-runtime --lib` — 423/423
- [x] `cargo fmt --all`
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [x] `slither contracts/src/{AgentSandboxBlueprint,OperatorSelection}.sol --config-file slither.config.json` — exit 0
- [x] `pnpm exec tsc --noEmit` (ui) — clean
- [x] `pnpm test` (ui) — 399/399
- [x] `forge build` + `forge test` — 168/168

## Closes

Replaces #60, #61, #62, #63 (which will be closed in favor of this consolidated landing).