### PR TITLE
chore(deps): bump blueprint-sdk to v0.2.0-alpha.5 (crates.io)

### DIFF
--- a/ai-agent-instance-blueprint-bin/Cargo.toml
+++ b/ai-agent-instance-blueprint-bin/Cargo.toml
@@ -18,9 +18,9 @@ billing = ["ai-agent-instance-blueprint-lib/billing", "dep:blueprint-tangle-extr
 ai-agent-instance-blueprint-lib = { path = "../ai-agent-instance-blueprint-lib" }
 axum = { version = "0.8", features = ["macros"] }
 blueprint-producers-extra = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", features = ["cron"] }
-blueprint-qos = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", optional = true }
-blueprint-sdk = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", default-features = false, features = ["std", "tangle"] }
-blueprint-tangle-extra = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", features = ["keepers"], optional = true }
+blueprint-qos = { version = "0.2.0-alpha.5", optional = true }
+blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tangle"] }
+blueprint-tangle-extra = { version = "0.2.0-alpha.5", features = ["keepers"], optional = true }
 sandbox-runtime = { path = "../sandbox-runtime" }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/ai-agent-instance-blueprint-lib/Cargo.toml
+++ b/ai-agent-instance-blueprint-lib/Cargo.toml
@@ -11,7 +11,7 @@ billing = ["dep:reqwest"]
 
 [dependencies]
 sandbox-runtime = { path = "../sandbox-runtime" }
-blueprint-sdk = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", default-features = false, features = ["std", "tracing", "macros", "tangle", "local-store"] }
+blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tracing", "macros", "tangle", "local-store"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 cron = "0.15"
 once_cell = "1"

--- a/ai-agent-sandbox-blueprint-bin/Cargo.toml
+++ b/ai-agent-sandbox-blueprint-bin/Cargo.toml
@@ -16,8 +16,8 @@ qos = ["dep:blueprint-qos"]
 [dependencies]
 ai-agent-sandbox-blueprint-lib = { path = "../ai-agent-sandbox-blueprint-lib" }
 blueprint-producers-extra = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", features = ["cron"] }
-blueprint-qos = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", optional = true }
-blueprint-sdk = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", default-features = false, features = ["std", "tangle"] }
+blueprint-qos = { version = "0.2.0-alpha.5", optional = true }
+blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tangle"] }
 axum = "0.8"
 futures-util = "0.3"
 sandbox-runtime = { path = "../sandbox-runtime" }

--- a/ai-agent-sandbox-blueprint-lib/Cargo.toml
+++ b/ai-agent-sandbox-blueprint-lib/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 
 [dependencies]
 sandbox-runtime = { path = "../sandbox-runtime" }
-blueprint-sdk = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", default-features = false, features = ["std", "tracing", "macros", "tangle", "local-store"] }
+blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tracing", "macros", "tangle", "local-store"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 cron = "0.15"
 once_cell = "1"

--- a/ai-agent-tee-instance-blueprint-bin/Cargo.toml
+++ b/ai-agent-tee-instance-blueprint-bin/Cargo.toml
@@ -18,8 +18,8 @@ ai-agent-tee-instance-blueprint-lib = { path = "../ai-agent-tee-instance-bluepri
 axum = { version = "0.8", features = ["macros"] }
 blueprint-producers-extra = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", features = ["cron"] }
 sandbox-runtime = { path = "../sandbox-runtime", features = ["tee-all"] }
-blueprint-sdk = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", default-features = false, features = ["std", "tangle"] }
-blueprint-tangle-extra = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", features = ["keepers"], optional = true }
+blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tangle"] }
+blueprint-tangle-extra = { version = "0.2.0-alpha.5", features = ["keepers"], optional = true }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/ai-agent-tee-instance-blueprint-lib/Cargo.toml
+++ b/ai-agent-tee-instance-blueprint-lib/Cargo.toml
@@ -12,7 +12,7 @@ billing = ["ai-agent-instance-blueprint-lib/billing"]
 [dependencies]
 ai-agent-instance-blueprint-lib = { path = "../ai-agent-instance-blueprint-lib" }
 sandbox-runtime = { path = "../sandbox-runtime", features = ["tee-all"] }
-blueprint-sdk = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", default-features = false, features = ["std", "tracing", "macros", "tangle", "local-store"] }
+blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tracing", "macros", "tangle", "local-store"] }
 tracing = "0.1"
 serde_json = "1"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88"
+channel = "1.91"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/sandbox-runtime/Cargo.toml
+++ b/sandbox-runtime/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 [dependencies]
 async-trait = "0.1"
 alloy = { version = "1", default-features = false, features = ["sol-types"] }
-blueprint-sdk = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", default-features = false, features = ["std", "tracing", "local-store"] }
+blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tracing", "local-store"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 dashmap = "6"
 docktopus = { version = "0.4.0-alpha.3", features = ["deploy"] }


### PR DESCRIPTION
Switches `blueprint-*` deps from `branch = main` git refs onto pinned crates.io versions. Picks up the audit follow-up batch (M-2 / H-1 / F-001 + governance-tunable operator cap) via tnt-core-bindings v0.17.1.

Bumps `rust-toolchain.toml` to 1.91 to match the new SDK MSRV.