### PR TITLE
Add all-harness sandbox runtime capability

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,7 +2,7 @@
 # Pre-commit hook: blocks commits that fail fmt or clippy.
 # Install: git config core.hooksPath .githooks
 set -e
-TOOLCHAIN="${RUST_TOOLCHAIN:-1.88}"
+TOOLCHAIN="${RUST_TOOLCHAIN:-1.91}"
 echo "pre-commit: checking rustfmt..."
 RUSTUP_TOOLCHAIN="$TOOLCHAIN" cargo fmt --all -- --check
 if [ $? -ne 0 ]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -200,27 +200,27 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dc44b606f29348ce7c127e7f872a6d2df3cfeff85b7d6bba62faca75112fdd"
+checksum = "50ab0cd8afe573d1f7dc2353698a51b1f93aec362c8211e28cfd3948c6adba39"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
- "alloy-eips",
+ "alloy-eips 1.8.3",
  "alloy-genesis",
- "alloy-json-rpc",
+ "alloy-json-rpc 1.8.3",
  "alloy-network",
  "alloy-provider",
  "alloy-pubsub",
- "alloy-rpc-client",
+ "alloy-rpc-client 1.8.3",
  "alloy-rpc-types",
  "alloy-serde",
  "alloy-signer",
  "alloy-signer-aws",
  "alloy-signer-local",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 1.8.3",
+ "alloy-transport-http 1.8.3",
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "alloy-trie",
@@ -239,11 +239,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ff99651d46cef43767b5e8262ea228cd05287409ccb0c947cc25e70a952f9"
+checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 1.8.3",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -257,7 +257,7 @@ dependencies = [
  "k256",
  "once_cell",
  "rand 0.8.5",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -266,12 +266,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0701b0eda8051a2398591113e7862f807ccdd3315d0b441f06c2a0865a379b"
+checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 1.8.3",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c83c7a3c4e1151e8cac383d0a67ddf358f37e5ea51c95a1283d897c9de0a5a"
+checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -294,11 +294,12 @@ dependencies = [
  "alloy-pubsub",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "futures",
  "futures-util",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -316,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ff5ee5f27aa305bda825c735f686ad71bb65508158f059f513895abe69b8c3"
+checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -327,7 +328,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.7.14",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -383,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def1626eea28d48c6cc0a6f16f34d4af0001906e4f889df6c660b39c86fd044d"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -402,16 +403,32 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dca4c89ace90684b4b77366d00631ed498c9af962079af2a5dbc593a0618a77"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "auto_impl",
+ "derive_more",
+ "either",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d9d1aba3f914f0e8db9e4616ae37f3d811426d95bdccf44e47d0605ab202f6"
+checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 1.8.3",
  "alloy-primitives",
  "alloy-serde",
  "alloy-trie",
@@ -422,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8708475665cc00e081c085886e68eada2f64cfa08fc668213a9231655093d4de"
+checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -434,9 +451,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57586581f2008933241d16c3e3f633168b3a5d2738c5c42ea5246ec5e0ef17a"
+checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0a82e56b1843bce483942d54fcadea92e676f1bde162e93c7d3b621fabc4e1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -449,14 +481,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b36c2a0ed74e48851f78415ca5b465211bd678891ba11e88fee09eac534bab1"
+checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
- "alloy-json-rpc",
+ "alloy-eips 1.8.3",
+ "alloy-json-rpc 1.8.3",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
@@ -475,12 +507,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636c8051da58802e757b76c3b65af610b95799f72423dc955737dec73de234fd"
+checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 1.8.3",
  "alloy-primitives",
  "alloy-serde",
  "serde",
@@ -488,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b88cf92ed20685979ed1d8472422f0c6c2d010cec77caf63aaa7669cc1a7bc2"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -498,7 +530,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash 0.2.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "itoa",
  "k256",
@@ -509,25 +541,26 @@ dependencies = [
  "rapidhash",
  "ruint",
  "rustc-hash 2.1.1",
+ "secp256k1 0.31.1",
  "serde",
- "sha3",
+ "sha3 0.11.0",
 ]
 
 [[package]]
 name = "alloy-provider"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3dd56e2eafe8b1803e325867ac2c8a4c73c9fb5f341ffd8347f9344458c5922"
+checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips",
- "alloy-json-rpc",
+ "alloy-eips 1.8.3",
+ "alloy-json-rpc 1.8.3",
  "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-pubsub",
- "alloy-rpc-client",
+ "alloy-rpc-client 1.8.3",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
@@ -535,8 +568,8 @@ dependencies = [
  "alloy-rpc-types-txpool",
  "alloy-signer",
  "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 1.8.3",
+ "alloy-transport-http 1.8.3",
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "async-stream",
@@ -549,7 +582,7 @@ dependencies = [
  "lru 0.16.3",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -561,13 +594,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eebf54983d4fccea08053c218ee5c288adf2e660095a243d0532a8070b43955"
+checksum = "5ad54073131e7292d4e03e1aa2287730f737280eb160d8b579fb31939f558c11"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 1.8.3",
  "alloy-primitives",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "auto_impl",
  "bimap",
  "futures",
@@ -605,20 +638,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91577235d341a1bdbee30a463655d08504408a4d51e9f72edbfc5a622829f402"
+checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 1.8.3",
  "alloy-primitives",
  "alloy-pubsub",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 1.8.3",
+ "alloy-transport-http 1.8.3",
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "tokio",
@@ -630,10 +663,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types"
-version = "1.6.3"
+name = "alloy-rpc-client"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cff039bf01a17d76c0aace3a3a773d5f895eb4c68baaae729ec9da9e86c99c"
+checksum = "24f461f091dc8f657e73b5dea18fd63d5c7049720cd252f1eade4a7ebed6a7e1"
+dependencies = [
+ "alloy-json-rpc 2.0.5",
+ "alloy-primitives",
+ "alloy-transport 2.0.5",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -648,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22250cf438b6a3926de67683c08163bfa1fd1efa47ee9512cbcd631b6b0243c"
+checksum = "47df51bedb3e6062cb9981187a51e86d0d64a4de66eb0855e9efe6574b044ddf"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -660,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73234a141ecce14e2989748c04fcac23deee67a445e2c4c167cfb42d4dacd1b6"
+checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -671,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779f70ab16a77e305571881b07a9bc6b0068ae6f962497baf5762825c5b839fb"
+checksum = "2145138f3214928f08cd13da3cb51ef7482b5920d8ac5a02ecd4e38d1a8f6d1e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -683,12 +736,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10620d600cc46538f613c561ac9a923843c6c74c61f054828dcdb8dd18c72ec4"
+checksum = "bb9b97b6e7965679ad22df297dda809b11cebc13405c1b537e5cffecc95834fa"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 1.8.3",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -700,13 +753,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010e101dbebe0c678248907a2545b574a87d078d82c2f6f5d0e8e7c9a6149a10"
+checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips",
+ "alloy-eips 1.8.3",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
@@ -721,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be096f74d85e1f927580b398bf7bc5b4aa62326f149680ec0867e3c040c9aced"
+checksum = "2e5a4d010f86cd4e01e5205ec273911e538e1738e76d8bafe9ecd245910ea5a3"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -735,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ab75189fbc29c5dd6f0bc1529bccef7b00773b458763f4d9d81a77ae4a1a2d"
+checksum = "942d26a2ca8891b26de4a8529d21091e21c1093e27eb99698f1a86405c76b1ff"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -747,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6d631f8b975229361d8af7b2c749af31c73b3cf1352f90e144ddb06227105e"
+checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -758,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f40010b5e8f79b70bf163b38cd15f529b18ca88c4427c0e43441ee54e4ed82"
+checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -773,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8857c6346edb898df606130a7d29b3dfc765746ccc7915b36466a1e16347b93"
+checksum = "8194c416115dc27f03796c0075dee0731239e2d7fbce735a74894aa8f6a47d7d"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -792,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4ec1cc27473819399a3f0da83bc1cef0ceaac8c1c93997696e46dc74377a58"
+checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -811,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fa1ca7e617c634d2bd9fa71f9ec8e47c07106e248b9fcbd3eaddc13cabd625"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -825,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c00c0c3a75150a9dc7c8c679ca21853a137888b4e1c5569f92d7e2b15b5102"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -837,16 +890,16 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "sha3",
+ "sha3 0.11.0",
  "syn 2.0.117",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297db260eb4d67c105f68d6ba11b8874eec681caec5505eab8fbebee97f790bc"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -862,19 +915,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b91b13181d3bcd23680fd29d7bc861d1f33fbe90fdd0af67162434aeba902d"
+checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
 dependencies = [
  "serde",
- "winnow 0.7.14",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc442cc2a75207b708d481314098a0f8b6f7b58e3148dd8d8cc7407b0d6f9385"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -884,11 +937,34 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03bb3f02b9a7ab23dacd1822fa7f69aa5c8eefcdcf57fad085e0b8d76fb4334"
+checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 1.8.3",
+ "auto_impl",
+ "base64 0.22.1",
+ "derive_more",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86052fdcec72d37ca4aa4b66254601e7453c45a6e1c70aa4561033d002fb80cc"
+dependencies = [
+ "alloy-json-rpc 2.0.5",
  "auto_impl",
  "base64 0.22.1",
  "derive_more",
@@ -907,14 +983,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
+checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
- "alloy-json-rpc",
- "alloy-transport",
+ "alloy-json-rpc 1.8.3",
+ "alloy-transport 1.8.3",
  "itertools 0.14.0",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "serde_json",
  "tower",
  "tracing",
@@ -922,14 +998,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-transport-ipc"
-version = "1.6.3"
+name = "alloy-transport-http"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49963a2561ebd439549915ea61efb70a7b13b97500ec16ca507721c9d9957d07"
+checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-transport 2.0.5",
+ "itertools 0.14.0",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-ipc"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1bd98c3870b8a44b79091dde5216a81d58ffbc1fd8ed61b776f9fee0f3bdf20"
+dependencies = [
+ "alloy-json-rpc 1.8.3",
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "bytes",
  "futures",
  "interprocess",
@@ -943,18 +1030,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed38ea573c6658e0c2745af9d1f1773b1ed83aa59fbd9c286358ad469c3233a"
+checksum = "ec3ab7a72b180992881acc112628b7668337a19ce15293ee974600ea7b693691"
 dependencies = [
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "futures",
  "http 1.4.0",
+ "rustls 0.23.39",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "url",
  "ws_stream_wasm",
 ]
 
@@ -977,11 +1066,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.6.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
+checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1004,9 +1093,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -1025,9 +1114,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -1066,7 +1155,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -2088,12 +2177,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -2252,7 +2335,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2274,6 +2357,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blst"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,18 +2379,19 @@ dependencies = [
 
 [[package]]
 name = "blueprint-anvil-testing-utils"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb32464c7989033ab534fd64da520122e0ab016359a2c2d1e677c73c3bf72509"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
+ "alloy-eips 2.0.5",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-rpc-types-eth",
  "alloy-signer-local",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "anyhow",
  "blueprint-chain-setup-anvil",
  "blueprint-client-tangle",
@@ -2325,8 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-auth"
-version = "0.1.0-alpha.10"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3504a08957da822bddf08aa400f730adedc80fe602239aae5712ec7a0547efbe"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2344,7 +2438,7 @@ dependencies = [
  "k256",
  "once_cell",
  "pasetors 0.7.7",
- "pem 1.1.1",
+ "pem",
  "prost",
  "protobuf-src",
  "rcgen 0.14.7",
@@ -2354,6 +2448,7 @@ dependencies = [
  "schnorrkel",
  "serde",
  "serde_json",
+ "subtle",
  "thiserror 2.0.18",
  "time",
  "tiny-keccak",
@@ -2369,16 +2464,18 @@ dependencies = [
 
 [[package]]
 name = "blueprint-chain-setup"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "123d950197bad76ab30cda44713a98f5a739fe087c27e1623fc0b83e9c5243b8"
 dependencies = [
  "blueprint-chain-setup-anvil",
 ]
 
 [[package]]
 name = "blueprint-chain-setup-anvil"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8dae7045ef4e9e80af2a320b7cf23006e3b4da7f10b6316ffdf7e559607369"
 dependencies = [
  "alloy-contract",
  "alloy-provider",
@@ -2399,24 +2496,27 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-core"
-version = "0.1.0-alpha.4"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71adeaa60fd95d0223c7531ee3021928ca877beaf87ceffb3fa5921d24195e50"
 dependencies = [
  "auto_impl",
  "blueprint-std",
  "thiserror 2.0.18",
+ "workspace-hack",
 ]
 
 [[package]]
 name = "blueprint-client-eigenlayer"
-version = "0.1.0-alpha.20"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a4c0a7923fab83343172b4e669d0eebb9572d7e75ba6372a3cd7a109b39ef9b"
 dependencies = [
  "alloy-contract",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "blueprint-client-core",
  "blueprint-core",
  "blueprint-evm-extra",
@@ -2432,11 +2532,12 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-evm"
-version = "0.1.0-alpha.7"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f081f3fad3424bbab7e73a38d71c6acf9dbbb0cb3f2b1e1beadf86f327d0fc"
 dependencies = [
  "alloy-consensus",
- "alloy-json-rpc",
+ "alloy-json-rpc 1.8.3",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
@@ -2444,7 +2545,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-rpc-types-eth",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "blueprint-client-core",
  "blueprint-core",
  "blueprint-metrics-rpc-calls",
@@ -2455,12 +2556,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "url",
+ "workspace-hack",
 ]
 
 [[package]]
 name = "blueprint-client-tangle"
-version = "0.1.1"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984f9cd6b30cad39c93bfe1ce43a4de7f2bba8e3742d752722f7a74843d772b6"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -2470,7 +2573,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "blueprint-client-core",
  "blueprint-core",
  "blueprint-crypto",
@@ -2490,8 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-clients"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9feacfa38abd176addd9f19d072a4d1e0364c4fbcce67f9226ae23e2221f064"
 dependencies = [
  "blueprint-client-core",
  "blueprint-client-eigenlayer",
@@ -2503,8 +2607,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-context-derive"
-version = "0.1.0-alpha.13"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c661d1281230aab9b9f4f18233c1654a7b0c486372f541710760c3aa90e0234b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2513,8 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-contexts"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458596181163f66fdb9573a18f11f080eb360fca39416f22628877ed26dc0b2f"
 dependencies = [
  "blueprint-client-tangle",
  "blueprint-clients",
@@ -2526,8 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-core"
-version = "0.1.0-alpha.5"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e2f5e1fbc95bfa7300c14c6eb99bb841055924bb5a7d115fb05dbcf113fd44"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2536,12 +2643,14 @@ dependencies = [
  "tiny-keccak",
  "tower",
  "tracing",
+ "workspace-hack",
 ]
 
 [[package]]
 name = "blueprint-core-testing-utils"
-version = "0.1.0-alpha.21"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe125f7dc946ea37abce9e7cd812f89b42090b64fdff2913cc2e52620d82865d"
 dependencies = [
  "blueprint-auth",
  "blueprint-clients",
@@ -2560,8 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto"
-version = "0.1.0-alpha.14"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c6267b013690f534748272a8b7711d53416f83300e979454a50d2b08bfd3b2"
 dependencies = [
  "blueprint-crypto-bls",
  "blueprint-crypto-bn254",
@@ -2575,8 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-bls"
-version = "0.1.0-alpha.9"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b32443a7c6b5f50bf7cf89ff87174565be4e72fb476d107aedb93180642088f"
 dependencies = [
  "ark-serialize 0.5.0",
  "blueprint-crypto-core",
@@ -2587,12 +2698,14 @@ dependencies = [
  "serde_bytes",
  "thiserror 2.0.18",
  "tnt-bls",
+ "zeroize",
 ]
 
 [[package]]
 name = "blueprint-crypto-bn254"
-version = "0.1.0-alpha.9"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "181887d477d75b8421390c4e4d04b545f520b4f3f403375cd50b9628b5145483"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2607,23 +2720,27 @@ dependencies = [
  "serde_bytes",
  "sha2 0.10.9",
  "thiserror 2.0.18",
+ "zeroize",
 ]
 
 [[package]]
 name = "blueprint-crypto-core"
-version = "0.1.0-alpha.9"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f653922fb69dd9002424992587795cdd27fad4e74be6f70dda1683d5e3d7162"
 dependencies = [
  "blueprint-std",
  "clap",
  "serde",
  "thiserror 2.0.18",
+ "workspace-hack",
 ]
 
 [[package]]
 name = "blueprint-crypto-ed25519"
-version = "0.1.0-alpha.10"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68891f3d1f4ffe373cedf7e5e851afe4d3b9e5215eae72814fdcd1f525849b84"
 dependencies = [
  "blueprint-crypto-core",
  "blueprint-std",
@@ -2632,25 +2749,30 @@ dependencies = [
  "serde",
  "serde_bytes",
  "thiserror 2.0.18",
+ "workspace-hack",
+ "zeroize",
 ]
 
 [[package]]
 name = "blueprint-crypto-hashing"
-version = "0.1.0-alpha.5"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d048e186a7270bc6462f8580412d2b02717143e6434effd47661a8fde75b9d64"
 dependencies = [
  "argon2",
  "blake3",
  "blueprint-std",
  "hkdf",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.8",
+ "workspace-hack",
 ]
 
 [[package]]
 name = "blueprint-crypto-k256"
-version = "0.1.0-alpha.10"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63ee0e7163050a43e124e7c6648d33d7d21165626f29167ab480bfdde0745e0d"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -2661,12 +2783,15 @@ dependencies = [
  "serde",
  "serde_bytes",
  "thiserror 2.0.18",
+ "workspace-hack",
+ "zeroize",
 ]
 
 [[package]]
 name = "blueprint-crypto-sr25519"
-version = "0.1.0-alpha.10"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "827c14e24bcc03abd469539819ecad186d8e189205f67fbc2a3af2e403ade606"
 dependencies = [
  "blueprint-crypto-core",
  "blueprint-std",
@@ -2675,12 +2800,15 @@ dependencies = [
  "serde",
  "serde_bytes",
  "thiserror 2.0.18",
+ "workspace-hack",
+ "zeroize",
 ]
 
 [[package]]
 name = "blueprint-eigenlayer-extra"
-version = "0.1.0-alpha.13"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e07bd500ac4313ffcd388b5e47f04a8f211167a9611ffefba2f2f0ac33904a"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -2712,20 +2840,21 @@ dependencies = [
 
 [[package]]
 name = "blueprint-evm-extra"
-version = "0.1.0-alpha.8"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058e4eb13b7a7061679a80f738d3734a2dd2b3cadc8af319c236482d5dc517d8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rlp",
- "alloy-rpc-client",
+ "alloy-rpc-client 2.0.5",
  "alloy-rpc-types",
  "alloy-signer-local",
  "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 1.8.3",
+ "alloy-transport-http 2.0.5",
  "async-stream",
  "blueprint-core",
  "blueprint-std",
@@ -2739,12 +2868,14 @@ dependencies = [
  "tokio",
  "tower",
  "url",
+ "workspace-hack",
 ]
 
 [[package]]
 name = "blueprint-keystore"
-version = "0.1.0-alpha.15"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88c87e32a99ff9275958b7a569c75723e9102a99e2daccfbc490ddae76103371"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -2762,7 +2893,7 @@ dependencies = [
  "hex",
  "k256",
  "parking_lot",
- "ripemd",
+ "ripemd 0.2.0",
  "rust-bls-bn254",
  "schnorrkel",
  "serde",
@@ -2776,8 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-macros"
-version = "0.1.0-alpha.7"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9feb72af12895fe3fc93dbe64c2953ef79c2d214ac3442b115aed3bee0932ff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2786,8 +2918,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-manager-bridge"
-version = "0.1.0-alpha.9"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6ff28209f41ecc552c43a8b79bd7c7f572f87cc144bc38a6bac2c0c9b5f539"
 dependencies = [
  "blueprint-auth",
  "blueprint-core",
@@ -2805,16 +2938,18 @@ dependencies = [
 
 [[package]]
 name = "blueprint-metrics-rpc-calls"
-version = "0.1.0-alpha.3"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f39e4bbd724672dfe1c791c9aaedd3d2bd3b0ffc5e625d93e22e77578387646"
 dependencies = [
  "metrics",
 ]
 
 [[package]]
 name = "blueprint-networking"
-version = "0.1.0-alpha.15"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02f4e5e7d5dfc917ad7ac3a5dcb57730b1524958fc3b388f56139139407f6245"
 dependencies = [
  "alloy-primitives",
  "bincode",
@@ -2838,8 +2973,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-producers-extra"
-version = "0.1.0-alpha.6"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0726a7d3faa67caaf9b45524fe6602a45618522885583e7633679a7dcaf5020"
 dependencies = [
  "blueprint-core",
  "chrono",
@@ -2851,8 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-qos"
-version = "0.1.0-alpha.6"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f65a49ffcadf1b1e8fcd021f252f43a5810a81f6b88dbd71ea8e7c593f6efb0"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -2860,7 +2997,7 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-signer-local",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "async-trait",
  "axum",
  "blueprint-core",
@@ -2870,7 +3007,7 @@ dependencies = [
  "bollard",
  "futures",
  "k256",
- "opentelemetry",
+ "opentelemetry 0.29.1",
  "opentelemetry-prometheus",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
@@ -2896,8 +3033,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-router"
-version = "0.1.0-alpha.6"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7ed4833de5c10dacb92f9f5f73fcce7e315bbff0ba3f3770dd5276fd3cc6ea"
 dependencies = [
  "blueprint-core",
  "bytes",
@@ -2906,12 +3044,14 @@ dependencies = [
  "hashbrown 0.16.1",
  "pin-project-lite",
  "tower",
+ "workspace-hack",
 ]
 
 [[package]]
 name = "blueprint-runner"
-version = "0.1.0-alpha.20"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233e559f2d1da8b206807f36d8305bdeb24c8efdd9619cfa65ae5df15e672076"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -2947,8 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-sdk"
-version = "0.1.0-alpha.22"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef536590de938f7b01231b21f44c1acba25cd11fd8aa5dad4936877db33cd5b"
 dependencies = [
  "alloy",
  "blueprint-auth",
@@ -2979,19 +3120,22 @@ dependencies = [
 
 [[package]]
 name = "blueprint-std"
-version = "0.1.0-alpha.4"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1dd44c5cdc9f828097fc3bf05e0cb05154b6ba66f024ddaac63c348bf6dc8a"
 dependencies = [
  "colored",
  "num-traits",
  "rand 0.8.5",
  "thiserror 2.0.18",
+ "workspace-hack",
 ]
 
 [[package]]
 name = "blueprint-store-local-database"
-version = "0.1.0-alpha.7"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba744786260dad6b846736d8494cf20afc03b55b65be00a4790a2693ba74a78"
 dependencies = [
  "blueprint-std",
  "serde",
@@ -3001,8 +3145,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-stores"
-version = "0.1.0-alpha.8"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42eb9c77399d1c54aa433a7bd4be98c349731b1c0f58fad4b4813f90e837dfcc"
 dependencies = [
  "blueprint-store-local-database",
  "document-features",
@@ -3011,8 +3156,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-tangle-extra"
-version = "0.1.1"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2706bc893136757ece35ddd1278278e35296324e47d1ec8e3a95514ec237e2"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -3035,8 +3181,9 @@ dependencies = [
 
 [[package]]
 name = "blueprint-testing-utils"
-version = "0.1.0-alpha.20"
-source = "git+https://github.com/tangle-network/blueprint.git?branch=main#19bbe980121166d978f857cb89c4de4851cf8c4f"
+version = "0.2.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80920a13b7eebd27b193ad7146f959323ab21d588ea37e7e6385a0256d5d9588"
 dependencies = [
  "blueprint-anvil-testing-utils",
  "blueprint-core-testing-utils",
@@ -3253,7 +3400,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -3316,7 +3463,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -3334,9 +3481,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -3344,9 +3491,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3356,9 +3503,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3368,9 +3515,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -3425,10 +3572,10 @@ dependencies = [
  "const-hex",
  "digest 0.10.7",
  "generic-array",
- "ripemd",
+ "ripemd 0.1.3",
  "serde",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.8",
  "thiserror 1.0.69",
 ]
 
@@ -3461,6 +3608,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3476,7 +3633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -3574,6 +3731,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -3722,6 +3888,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ct-codecs"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3743,7 +3918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto 0.2.9",
@@ -3769,8 +3944,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -3780,6 +3965,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
@@ -3794,7 +3992,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -3836,7 +4045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3957,8 +4166,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -4485,7 +4704,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.8",
  "thiserror 1.0.69",
  "uuid 0.8.2",
 ]
@@ -4641,9 +4860,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4682,14 +4901,13 @@ checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
@@ -4983,8 +5201,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -4992,6 +5208,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heck"
@@ -5168,6 +5389,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -5696,6 +5926,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5749,7 +6028,17 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -6506,9 +6795,9 @@ dependencies = [
 
 [[package]]
 name = "macro-string"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6563,7 +6852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
- "keccak",
+ "keccak 0.1.6",
  "rand_core 0.6.4",
  "zeroize",
 ]
@@ -7058,13 +7347,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "opentelemetry-prometheus"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "098a71a4430bb712be6130ed777335d2e5b19bc8566de5f2edddfce906def6ab"
 dependencies = [
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.29.1",
  "opentelemetry_sdk",
  "prometheus",
 ]
@@ -7085,7 +7387,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "glob",
- "opentelemetry",
+ "opentelemetry 0.29.1",
  "percent-encoding",
  "rand 0.9.2",
  "thiserror 2.0.18",
@@ -7282,15 +7584,6 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
-]
-
-[[package]]
-name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
@@ -7460,7 +7753,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -7472,7 +7765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -7785,6 +8078,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -7941,7 +8235,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
 dependencies = [
- "pem 3.0.6",
+ "pem",
  "ring 0.16.20",
  "time",
  "yasna",
@@ -7953,7 +8247,7 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
- "pem 3.0.6",
+ "pem",
  "ring 0.17.14",
  "rustls-pki-types",
  "time",
@@ -8148,6 +8442,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.39",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8199,6 +8530,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -8445,6 +8785,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.39",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -8698,8 +9065,19 @@ checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.2",
+ "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -8707,6 +9085,15 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -8898,7 +9285,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8960,7 +9347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -8972,7 +9359,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -8984,7 +9371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -8995,7 +9382,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -9048,6 +9445,22 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -9215,9 +9628,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2379beea9476b89d0237078be761cf8e012d92d5ae4ae0c9a329f974838870fc"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -9543,16 +9956,16 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.9",
- "sha3",
+ "sha3 0.10.8",
  "thiserror 1.0.69",
  "zeroize",
 ]
 
 [[package]]
 name = "tnt-core-bindings"
-version = "0.10.4"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49957ef799873b6ae506f4e84387709ab7deae38734901f8cdc70cc775584e8f"
+checksum = "9638c85526f68b60d95bbe660f6f09ab116dfd06a4793f747374646278b82256"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -9662,9 +10075,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -9947,14 +10360,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.30.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.22",
@@ -10020,9 +10431,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -10100,7 +10511,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -10423,6 +10834,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -10969,6 +11389,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11094,6 +11523,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "workspace-hack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beffa227304dbaea3ad6a06ac674f9bc83a3dec3b7f63eeb442de37e7cb6bb01"
 
 [[package]]
 name = "writeable"

--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ UI behavior:
 - Selecting `firecracker` forces `tee_required=false` (current release does not support Firecracker+TEE composition).
 - Selecting `firecracker` accepts `metadata_json.ports` as either bare `[3000]` or structured `[{container_port:3000, host_port:30000, protocol:"tcp"}]`. The runtime parses, validates (1..=65535, no duplicate `host_port`/`container_port`, protocol ∈ {tcp,udp}, capped at `MAX_EXTRA_PORTS=8`) and persists them on the sandbox record so they round-trip across restarts. Forwarding to the Firecracker microVM via the host-agent is gated on the upstream host-agent shipping a stable port-forwarding field — until then, ports are recorded but not yet routed by the host network namespace.
 
+### Sidecar Capabilities
+
+Sandbox and instance provisioning accept `capabilities_json`, a JSON-encoded string array:
+
+- `computer_use`: enables the sidecar computer-use subsystem.
+- `all_harness`: requests the open-source all-harness runtime image path with Claude, Codex, opencode, Kimi, and Gemini available inside the sandbox.
+
+The runtime injects accepted values into the sandbox as `SIDECAR_CAPABILITIES`, preserving the same contract surface for Docker, Firecracker, and TEE-backed creation. The UI exposes `all_harness` as an explicit create/provision option while keeping the ABI field itself internal.
+
 ### Instance Lifecycle Semantics
 
 - Canonical path is operator-signed direct reporting:
@@ -165,6 +174,7 @@ Note: `/api/sandbox/secrets` is not currently exposed; secret provisioning is cu
 - `GET /readyz` — Strict readiness probe (503 unless all subsystems healthy)
 - `GET /metrics` — Prometheus metrics
 - `GET /api/provisions` — List provision status
+- `GET /api/capabilities` — Advertise supported sidecar capabilities and harness feature matrix
 
 `GET /health` response contract:
 - `status`: `"ok"` or `"degraded"`

--- a/ai-agent-instance-blueprint-bin/Cargo.toml
+++ b/ai-agent-instance-blueprint-bin/Cargo.toml
@@ -17,10 +17,10 @@ billing = ["ai-agent-instance-blueprint-lib/billing", "dep:blueprint-tangle-extr
 [dependencies]
 ai-agent-instance-blueprint-lib = { path = "../ai-agent-instance-blueprint-lib" }
 axum = { version = "0.8", features = ["macros"] }
-blueprint-producers-extra = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", features = ["cron"] }
-blueprint-qos = { version = "0.2.0-alpha.5", optional = true }
-blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tangle"] }
-blueprint-tangle-extra = { version = "0.2.0-alpha.5", features = ["keepers"], optional = true }
+blueprint-producers-extra = { version = "=0.2.0-alpha.4", features = ["cron"] }
+blueprint-qos = { version = "=0.2.0-alpha.6", optional = true }
+blueprint-sdk = { version = "=0.2.0-alpha.6", default-features = false, features = ["std", "tangle"] }
+blueprint-tangle-extra = { version = "=0.2.0-alpha.6", features = ["keepers"], optional = true }
 sandbox-runtime = { path = "../sandbox-runtime" }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/ai-agent-instance-blueprint-lib/Cargo.toml
+++ b/ai-agent-instance-blueprint-lib/Cargo.toml
@@ -11,7 +11,7 @@ billing = ["dep:reqwest"]
 
 [dependencies]
 sandbox-runtime = { path = "../sandbox-runtime" }
-blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tracing", "macros", "tangle", "local-store"] }
+blueprint-sdk = { version = "=0.2.0-alpha.6", default-features = false, features = ["std", "tracing", "macros", "tangle", "local-store"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 cron = "0.15"
 once_cell = "1"
@@ -26,7 +26,7 @@ url = "2"
 anyhow = "1"
 axum = "0.8"
 sandbox-runtime = { path = "../sandbox-runtime", features = ["test-utils"] }
-blueprint-anvil-testing-utils = { git = "https://github.com/tangle-network/blueprint.git", branch = "main" }
+blueprint-anvil-testing-utils = { version = "=0.2.0-alpha.6" }
 hex = "0.4"
 docktopus = { version = "0.4.0-alpha.3", features = ["deploy"] }
 futures-util = "0.3"

--- a/ai-agent-instance-blueprint-lib/src/auto_provision.rs
+++ b/ai-agent-instance-blueprint-lib/src/auto_provision.rs
@@ -230,15 +230,15 @@ async fn reuse_existing_instance_record(
         record.id
     );
 
-    if let Some(client) = report_client {
-        if let Err(err) = ensure_local_provision_reported(client, service_id, &record).await {
-            warn!(
-                service_id = service_id,
-                error = %err,
-                sandbox_id = %record.id,
-                "Auto-provision: reconcile report failed; pending report will be retried"
-            );
-        }
+    if let Some(client) = report_client
+        && let Err(err) = ensure_local_provision_reported(client, service_id, &record).await
+    {
+        warn!(
+            service_id = service_id,
+            error = %err,
+            sandbox_id = %record.id,
+            "Auto-provision: reconcile report failed; pending report will be retried"
+        );
     }
 
     Ok(())
@@ -396,16 +396,16 @@ pub async fn run_auto_provision(
     set_instance_sandbox(record.clone()).map_err(|e| e.to_string())?;
     sync_runtime_service_binding(&record)?;
 
-    if let Some(client) = report_client.as_ref() {
-        if let Err(err) = report_local_provision(client, config.service_id, &output).await {
-            warn!(
-                service_id = config.service_id,
-                error = %err,
-                sandbox_id = %output.sandbox_id,
-                "Auto-provision: direct report failed; queued pending report for retry"
-            );
-            mark_pending_provision_report(config.service_id, &output, &err)?;
-        }
+    if let Some(client) = report_client.as_ref()
+        && let Err(err) = report_local_provision(client, config.service_id, &output).await
+    {
+        warn!(
+            service_id = config.service_id,
+            error = %err,
+            sandbox_id = %output.sandbox_id,
+            "Auto-provision: direct report failed; queued pending report for retry"
+        );
+        mark_pending_provision_report(config.service_id, &output, &err)?;
     }
 
     info!(

--- a/ai-agent-instance-blueprint-lib/src/jobs/exec.rs
+++ b/ai-agent-instance-blueprint-lib/src/jobs/exec.rs
@@ -28,10 +28,10 @@ pub fn build_exec_payload(
     if timeout_ms > 0 {
         payload.insert("timeout".to_string(), json!(timeout_ms));
     }
-    if !env_json.trim().is_empty() {
-        if let Ok(Some(env_map)) = crate::util::parse_json_object(env_json, "env_json") {
-            payload.insert("env".to_string(), env_map);
-        }
+    if !env_json.trim().is_empty()
+        && let Ok(Some(env_map)) = crate::util::parse_json_object(env_json, "env_json")
+    {
+        payload.insert("env".to_string(), env_map);
     }
     payload
 }

--- a/ai-agent-instance-blueprint-lib/src/jobs/provision.rs
+++ b/ai-agent-instance-blueprint-lib/src/jobs/provision.rs
@@ -36,12 +36,13 @@ pub async fn provision_core(
 
     let mut params = CreateSandboxParams::from(request);
     params.owner = owner.to_string();
-    if request.tee_required && !request.attestation_nonce.trim().is_empty() {
-        if let Some(cfg) = params.tee_config.as_mut() {
-            cfg.attestation_nonce = Some(crate::tee::decode_attestation_nonce_hex(
-                &request.attestation_nonce,
-            )?);
-        }
+    if request.tee_required
+        && !request.attestation_nonce.trim().is_empty()
+        && let Some(cfg) = params.tee_config.as_mut()
+    {
+        cfg.attestation_nonce = Some(crate::tee::decode_attestation_nonce_hex(
+            &request.attestation_nonce,
+        )?);
     }
     let (record, attestation) = create_sidecar(&params, tee)
         .await

--- a/ai-agent-instance-blueprint-lib/src/reporting.rs
+++ b/ai-agent-instance-blueprint-lib/src/reporting.rs
@@ -372,14 +372,14 @@ pub async fn report_local_deprovision(
 
 /// Best-effort wrapper that logs warning and returns success.
 pub async fn try_report_local_deprovision(client: Option<&TangleClient>, service_id: u64) {
-    if let Some(client) = client {
-        if let Err(err) = report_local_deprovision(client, service_id).await {
-            warn!(
-                service_id,
-                error = %err,
-                "Failed to report direct deprovision to manager"
-            );
-        }
+    if let Some(client) = client
+        && let Err(err) = report_local_deprovision(client, service_id).await
+    {
+        warn!(
+            service_id,
+            error = %err,
+            "Failed to report direct deprovision to manager"
+        );
     }
 }
 

--- a/ai-agent-instance-blueprint-lib/src/workflows.rs
+++ b/ai-agent-instance-blueprint-lib/src/workflows.rs
@@ -454,10 +454,10 @@ fn merge_local_workflow_metadata(
         return Ok(());
     }
 
-    if entry.owner.is_empty() {
-        if let Some(owner) = resolve_workflow_owner(entry)? {
-            entry.owner = owner;
-        }
+    if entry.owner.is_empty()
+        && let Some(owner) = resolve_workflow_owner(entry)?
+    {
+        entry.owner = owner;
     }
 
     Ok(())

--- a/ai-agent-sandbox-blueprint-bin/Cargo.toml
+++ b/ai-agent-sandbox-blueprint-bin/Cargo.toml
@@ -15,9 +15,9 @@ qos = ["dep:blueprint-qos"]
 
 [dependencies]
 ai-agent-sandbox-blueprint-lib = { path = "../ai-agent-sandbox-blueprint-lib" }
-blueprint-producers-extra = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", features = ["cron"] }
-blueprint-qos = { version = "0.2.0-alpha.5", optional = true }
-blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tangle"] }
+blueprint-producers-extra = { version = "=0.2.0-alpha.4", features = ["cron"] }
+blueprint-qos = { version = "=0.2.0-alpha.6", optional = true }
+blueprint-sdk = { version = "=0.2.0-alpha.6", default-features = false, features = ["std", "tangle"] }
 axum = "0.8"
 futures-util = "0.3"
 sandbox-runtime = { path = "../sandbox-runtime" }

--- a/ai-agent-sandbox-blueprint-bin/src/main.rs
+++ b/ai-agent-sandbox-blueprint-bin/src/main.rs
@@ -529,14 +529,14 @@ async fn main() -> Result<(), blueprint_sdk::Error> {
     // The contract's onRegister decodes abi.encode(uint32 capacity) from these inputs.
     let tangle_config = {
         let mut config = TangleConfig::default();
-        if let Ok(cap_str) = std::env::var("OPERATOR_MAX_CAPACITY") {
-            if let Ok(capacity) = cap_str.parse::<u32>() {
-                info!("Registering with OPERATOR_MAX_CAPACITY={capacity}");
-                // ABI-encode a single uint32 (padded to 32 bytes)
-                let mut inputs = vec![0u8; 32];
-                inputs[28..32].copy_from_slice(&capacity.to_be_bytes());
-                config = config.with_registration_inputs(inputs);
-            }
+        if let Ok(cap_str) = std::env::var("OPERATOR_MAX_CAPACITY")
+            && let Ok(capacity) = cap_str.parse::<u32>()
+        {
+            info!("Registering with OPERATOR_MAX_CAPACITY={capacity}");
+            // ABI-encode a single uint32 (padded to 32 bytes)
+            let mut inputs = vec![0u8; 32];
+            inputs[28..32].copy_from_slice(&capacity.to_be_bytes());
+            config = config.with_registration_inputs(inputs);
         }
         config
     };
@@ -921,12 +921,11 @@ async fn replay_error_is_already_materialized(
         }
     }
 
-    if let Ok(create_output) = SandboxCreateOutput::abi_decode(output.as_ref()) {
-        if ai_agent_sandbox_blueprint_lib::runtime::get_sandbox_by_id(&create_output.sandboxId)
+    if let Ok(create_output) = SandboxCreateOutput::abi_decode(output.as_ref())
+        && ai_agent_sandbox_blueprint_lib::runtime::get_sandbox_by_id(&create_output.sandboxId)
             .is_ok()
-        {
-            return true;
-        }
+    {
+        return true;
     }
 
     // Workflow IDs are derived from the create call ID. If a replayed

--- a/ai-agent-sandbox-blueprint-lib/Cargo.toml
+++ b/ai-agent-sandbox-blueprint-lib/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 
 [dependencies]
 sandbox-runtime = { path = "../sandbox-runtime" }
-blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tracing", "macros", "tangle", "local-store"] }
+blueprint-sdk = { version = "=0.2.0-alpha.6", default-features = false, features = ["std", "tracing", "macros", "tangle", "local-store"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 cron = "0.15"
 once_cell = "1"
@@ -22,7 +22,7 @@ uuid = { version = "1", features = ["v4"] }
 anyhow = "1"
 axum = "0.8"
 sandbox-runtime = { path = "../sandbox-runtime", features = ["test-utils"] }
-blueprint-anvil-testing-utils = { git = "https://github.com/tangle-network/blueprint.git", branch = "main" }
+blueprint-anvil-testing-utils = { version = "=0.2.0-alpha.6" }
 docktopus = { version = "0.4.0-alpha.3", features = ["deploy"] }
 futures = "0.3"
 futures-util = "0.3"

--- a/ai-agent-sandbox-blueprint-lib/src/jobs/batch.rs
+++ b/ai-agent-sandbox-blueprint-lib/src/jobs/batch.rs
@@ -32,12 +32,11 @@ pub async fn batch_create(
     params.owner = super::caller_hex(&caller);
     if request.template_request.tee_required
         && !request.template_request.attestation_nonce.trim().is_empty()
+        && let Some(cfg) = params.tee_config.as_mut()
     {
-        if let Some(cfg) = params.tee_config.as_mut() {
-            cfg.attestation_nonce = Some(crate::tee::decode_attestation_nonce_hex(
-                &request.template_request.attestation_nonce,
-            )?);
-        }
+        cfg.attestation_nonce = Some(crate::tee::decode_attestation_nonce_hex(
+            &request.template_request.attestation_nonce,
+        )?);
     }
     let tee = crate::tee_backend().map(|b| b.as_ref());
     let mut sandboxes_out = Vec::with_capacity(request.count as usize);

--- a/ai-agent-sandbox-blueprint-lib/src/jobs/exec.rs
+++ b/ai-agent-sandbox-blueprint-lib/src/jobs/exec.rs
@@ -55,10 +55,10 @@ pub fn build_exec_payload(
     if timeout_ms > 0 {
         payload.insert("timeout".to_string(), json!(timeout_ms));
     }
-    if !env_json.trim().is_empty() {
-        if let Ok(Some(env_map)) = crate::util::parse_json_object(env_json, "env_json") {
-            payload.insert("env".to_string(), env_map);
-        }
+    if !env_json.trim().is_empty()
+        && let Ok(Some(env_map)) = crate::util::parse_json_object(env_json, "env_json")
+    {
+        payload.insert("env".to_string(), env_map);
     }
     payload
 }
@@ -147,12 +147,11 @@ pub fn build_agent_payload(
     if !model.is_empty() {
         backend.insert("model".to_string(), Value::String(model.to_string()));
     }
-    if let Some(profile) = backend_profile {
-        if let Some(obj) = profile.as_object() {
-            if !obj.is_empty() {
-                backend.insert("profile".to_string(), profile.clone());
-            }
-        }
+    if let Some(profile) = backend_profile
+        && let Some(obj) = profile.as_object()
+        && !obj.is_empty()
+    {
+        backend.insert("profile".to_string(), profile.clone());
     }
     if !backend.is_empty() {
         payload.insert("backend".to_string(), Value::Object(backend));

--- a/ai-agent-sandbox-blueprint-lib/src/jobs/sandbox.rs
+++ b/ai-agent-sandbox-blueprint-lib/src/jobs/sandbox.rs
@@ -41,12 +41,13 @@ pub async fn sandbox_create(
     let mut params = CreateSandboxParams::from(&request);
     params.owner = super::caller_hex(&caller);
     params.service_id = Some(service_id);
-    if request.tee_required && !request.attestation_nonce.trim().is_empty() {
-        if let Some(cfg) = params.tee_config.as_mut() {
-            cfg.attestation_nonce = Some(crate::tee::decode_attestation_nonce_hex(
-                &request.attestation_nonce,
-            )?);
-        }
+    if request.tee_required
+        && !request.attestation_nonce.trim().is_empty()
+        && let Some(cfg) = params.tee_config.as_mut()
+    {
+        cfg.attestation_nonce = Some(crate::tee::decode_attestation_nonce_hex(
+            &request.attestation_nonce,
+        )?);
     }
 
     let _ = provision_progress::update_provision(

--- a/ai-agent-sandbox-blueprint-lib/src/lib.rs
+++ b/ai-agent-sandbox-blueprint-lib/src/lib.rs
@@ -84,10 +84,12 @@ sol! {
         /// Hex-encoded 32-64 byte caller nonce to embed in deploy-time attestation.
         string attestation_nonce;
         /// JSON array of sidecar capabilities to enable at boot.
-        /// Currently supported: ["computer_use"] — boots Xvfb + dbus + an MCP
-        /// server inside the sandbox so the Anthropic / OpenAI Responses
-        /// computer-use surfaces can drive mouse/keyboard/screenshots. Empty
-        /// or "" means no extra subsystems are started.
+        /// Currently supported: ["computer_use", "all_harness"].
+        /// "computer_use" boots Xvfb + dbus + an MCP server inside the sandbox
+        /// so computer-use surfaces can drive mouse/keyboard/screenshots.
+        /// "all_harness" requests the open-source multi-harness agent runtime
+        /// with Claude, Codex, opencode, Kimi, and Gemini available in the
+        /// sandbox image. Empty or "" means no extra subsystems are started.
         ///
         /// Wire format: a JSON-encoded array of strings, e.g.
         /// `["computer_use"]`. Encoded as a string (rather than `string[]`)

--- a/ai-agent-sandbox-blueprint-lib/src/workflows.rs
+++ b/ai-agent-sandbox-blueprint-lib/src/workflows.rs
@@ -568,10 +568,10 @@ fn merge_local_workflow_metadata(
         return Ok(());
     }
 
-    if entry.owner.is_empty() {
-        if let Some(owner) = resolve_workflow_owner(entry)? {
-            entry.owner = owner;
-        }
+    if entry.owner.is_empty()
+        && let Some(owner) = resolve_workflow_owner(entry)?
+    {
+        entry.owner = owner;
     }
 
     Ok(())

--- a/ai-agent-tee-instance-blueprint-bin/Cargo.toml
+++ b/ai-agent-tee-instance-blueprint-bin/Cargo.toml
@@ -16,10 +16,10 @@ billing = ["ai-agent-tee-instance-blueprint-lib/billing", "dep:blueprint-tangle-
 [dependencies]
 ai-agent-tee-instance-blueprint-lib = { path = "../ai-agent-tee-instance-blueprint-lib" }
 axum = { version = "0.8", features = ["macros"] }
-blueprint-producers-extra = { git = "https://github.com/tangle-network/blueprint.git", branch = "main", features = ["cron"] }
+blueprint-producers-extra = { version = "=0.2.0-alpha.4", features = ["cron"] }
 sandbox-runtime = { path = "../sandbox-runtime", features = ["tee-all"] }
-blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tangle"] }
-blueprint-tangle-extra = { version = "0.2.0-alpha.5", features = ["keepers"], optional = true }
+blueprint-sdk = { version = "=0.2.0-alpha.6", default-features = false, features = ["std", "tangle"] }
+blueprint-tangle-extra = { version = "=0.2.0-alpha.6", features = ["keepers"], optional = true }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/ai-agent-tee-instance-blueprint-lib/Cargo.toml
+++ b/ai-agent-tee-instance-blueprint-lib/Cargo.toml
@@ -12,7 +12,7 @@ billing = ["ai-agent-instance-blueprint-lib/billing"]
 [dependencies]
 ai-agent-instance-blueprint-lib = { path = "../ai-agent-instance-blueprint-lib" }
 sandbox-runtime = { path = "../sandbox-runtime", features = ["tee-all"] }
-blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tracing", "macros", "tangle", "local-store"] }
+blueprint-sdk = { version = "=0.2.0-alpha.6", default-features = false, features = ["std", "tracing", "macros", "tangle", "local-store"] }
 tracing = "0.1"
 serde_json = "1"
 

--- a/bench-harness/src/manifest.rs
+++ b/bench-harness/src/manifest.rs
@@ -148,10 +148,10 @@ fn gather_host_info() -> HostInfo {
 fn hostname() -> String {
     // Prefer `hostname` env var (set in many CI environments); fall back to
     // running `hostname` or `uname -n`.
-    if let Ok(h) = std::env::var("HOSTNAME") {
-        if !h.is_empty() {
-            return h;
-        }
+    if let Ok(h) = std::env::var("HOSTNAME")
+        && !h.is_empty()
+    {
+        return h;
     }
     Command::new("hostname")
         .output()

--- a/sandbox-runtime/Cargo.toml
+++ b/sandbox-runtime/Cargo.toml
@@ -8,8 +8,8 @@ license.workspace = true
 
 [dependencies]
 async-trait = "0.1"
-alloy = { version = "1", default-features = false, features = ["sol-types"] }
-blueprint-sdk = { version = "0.2.0-alpha.5", default-features = false, features = ["std", "tracing", "local-store"] }
+alloy = { version = "=1.8.3", default-features = false, features = ["sol-types"] }
+blueprint-sdk = { version = "=0.2.0-alpha.6", default-features = false, features = ["std", "tracing", "local-store"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 dashmap = "6"
 docktopus = { version = "0.4.0-alpha.3", features = ["deploy"] }

--- a/sandbox-runtime/src/api_types.rs
+++ b/sandbox-runtime/src/api_types.rs
@@ -121,6 +121,8 @@ pub struct PromptApiRequest {
     #[serde(default)]
     pub session_id: String,
     #[serde(default)]
+    pub backend_type: String,
+    #[serde(default)]
     pub model: String,
     #[serde(default)]
     pub context_json: String,
@@ -161,6 +163,8 @@ pub struct TaskApiRequest {
     pub session_id: String,
     #[serde(default)]
     pub max_turns: u64,
+    #[serde(default)]
+    pub backend_type: String,
     #[serde(default)]
     pub model: String,
     #[serde(default)]
@@ -216,10 +220,10 @@ pub struct SshProvisionApiRequest {
 
 impl SshProvisionApiRequest {
     pub fn validate(&self) -> Result<(), String> {
-        if let Some(username) = self.username.as_deref() {
-            if !username.trim().is_empty() {
-                validate_username(username)?;
-            }
+        if let Some(username) = self.username.as_deref()
+            && !username.trim().is_empty()
+        {
+            validate_username(username)?;
         }
         validate_ssh_public_key(&self.public_key)
     }
@@ -234,10 +238,10 @@ pub struct SshRevokeApiRequest {
 
 impl SshRevokeApiRequest {
     pub fn validate(&self) -> Result<(), String> {
-        if let Some(username) = self.username.as_deref() {
-            if !username.trim().is_empty() {
-                validate_username(username)?;
-            }
+        if let Some(username) = self.username.as_deref()
+            && !username.trim().is_empty()
+        {
+            validate_username(username)?;
         }
         validate_ssh_public_key(&self.public_key)
     }

--- a/sandbox-runtime/src/firecracker.rs
+++ b/sandbox-runtime/src/firecracker.rs
@@ -516,19 +516,19 @@ fn parse_host_agent_error(body: &str) -> String {
         return "empty error body".to_string();
     }
 
-    if let Ok(parsed) = serde_json::from_str::<HostAgentErrorResponse>(trimmed) {
-        if !parsed.error.trim().is_empty() {
-            if parsed.code.trim().is_empty() {
-                return parsed.error;
-            }
-            return format!("{} ({})", parsed.error, parsed.code);
+    if let Ok(parsed) = serde_json::from_str::<HostAgentErrorResponse>(trimmed)
+        && !parsed.error.trim().is_empty()
+    {
+        if parsed.code.trim().is_empty() {
+            return parsed.error;
         }
+        return format!("{} ({})", parsed.error, parsed.code);
     }
 
-    if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
-        if let Some(error) = value.get("error").and_then(|v| v.as_str()) {
-            return error.to_string();
-        }
+    if let Ok(value) = serde_json::from_str::<Value>(trimmed)
+        && let Some(error) = value.get("error").and_then(|v| v.as_str())
+    {
+        return error.to_string();
     }
 
     trimmed.to_string()

--- a/sandbox-runtime/src/http.rs
+++ b/sandbox-runtime/src/http.rs
@@ -74,10 +74,10 @@ pub async fn sidecar_post_json(
 
     // Propagate the operator request ID to the sidecar so that sidecar logs
     // can be correlated with the originating operator API request.
-    if let Ok(rid) = crate::operator_api::CURRENT_REQUEST_ID.try_with(|id| id.clone()) {
-        if let Ok(val) = HeaderValue::from_str(&rid) {
-            headers.insert("x-request-id", val);
-        }
+    if let Ok(rid) = crate::operator_api::CURRENT_REQUEST_ID.try_with(|id| id.clone())
+        && let Ok(val) = HeaderValue::from_str(&rid)
+    {
+        headers.insert("x-request-id", val);
     }
 
     let (_, body) = send_json(Method::POST, url, Some(payload), headers).await?;
@@ -94,10 +94,10 @@ pub async fn sidecar_post_json_without_timeout(
     let url = build_url(sidecar_url, path)?;
     let mut headers = auth_headers(token)?;
 
-    if let Ok(rid) = crate::operator_api::CURRENT_REQUEST_ID.try_with(|id| id.clone()) {
-        if let Ok(val) = HeaderValue::from_str(&rid) {
-            headers.insert("x-request-id", val);
-        }
+    if let Ok(rid) = crate::operator_api::CURRENT_REQUEST_ID.try_with(|id| id.clone())
+        && let Ok(val) = HeaderValue::from_str(&rid)
+    {
+        headers.insert("x-request-id", val);
     }
 
     let client = http_client_no_timeout()?;
@@ -111,10 +111,10 @@ pub async fn sidecar_get_json(sidecar_url: &str, path: &str, token: &str) -> Res
     let url = build_url(sidecar_url, path)?;
     let mut headers = auth_headers(token)?;
 
-    if let Ok(rid) = crate::operator_api::CURRENT_REQUEST_ID.try_with(|id| id.clone()) {
-        if let Ok(val) = HeaderValue::from_str(&rid) {
-            headers.insert("x-request-id", val);
-        }
+    if let Ok(rid) = crate::operator_api::CURRENT_REQUEST_ID.try_with(|id| id.clone())
+        && let Ok(val) = HeaderValue::from_str(&rid)
+    {
+        headers.insert("x-request-id", val);
     }
 
     let (_, body) = send_json(Method::GET, url, None, headers).await?;
@@ -177,10 +177,10 @@ pub async fn proxy_http(
     }
 
     // Propagate request ID for tracing
-    if let Ok(rid) = crate::operator_api::CURRENT_REQUEST_ID.try_with(|id| id.clone()) {
-        if let Ok(val) = HeaderValue::from_str(&rid) {
-            request = request.header("x-request-id", val);
-        }
+    if let Ok(rid) = crate::operator_api::CURRENT_REQUEST_ID.try_with(|id| id.clone())
+        && let Ok(val) = HeaderValue::from_str(&rid)
+    {
+        request = request.header("x-request-id", val);
     }
 
     if !body.is_empty() {

--- a/sandbox-runtime/src/operator_api.rs
+++ b/sandbox-runtime/src/operator_api.rs
@@ -480,12 +480,11 @@ fn normalize_stream_part(part: &Value) -> Option<Value> {
         return None;
     }
 
-    if object.get("type").and_then(Value::as_str) == Some("tool") {
-        if let Some(state) = object.get_mut("state").and_then(Value::as_object_mut) {
-            if state.get("status").and_then(Value::as_str) == Some("failed") {
-                state.insert("status".into(), json!("error"));
-            }
-        }
+    if object.get("type").and_then(Value::as_str) == Some("tool")
+        && let Some(state) = object.get_mut("state").and_then(Value::as_object_mut)
+        && state.get("status").and_then(Value::as_str) == Some("failed")
+    {
+        state.insert("status".into(), json!("error"));
     }
 
     Some(Value::Object(object))
@@ -829,10 +828,10 @@ fn derive_operator_address_from_keystore_uri(
 
 fn current_managing_operator() -> Option<String> {
     for key in ["MANAGING_OPERATOR_ADDRESS", "OPERATOR_ADDRESS"] {
-        if let Ok(value) = std::env::var(key) {
-            if let Some(address) = normalize_operator_address(&value) {
-                return Some(address);
-            }
+        if let Ok(value) = std::env::var(key)
+            && let Some(address) = normalize_operator_address(&value)
+        {
+            return Some(address);
         }
     }
 
@@ -847,13 +846,13 @@ fn current_managing_operator() -> Option<String> {
 }
 
 async fn list_sandboxes(SessionAuth(address): SessionAuth) -> impl IntoResponse {
-    if let Ok(repaired) = runtime::repair_sandbox_service_links_from_provisions() {
-        if repaired > 0 {
-            tracing::info!(
-                repaired,
-                "Repaired missing sandbox service links from provision metadata"
-            );
-        }
+    if let Ok(repaired) = runtime::repair_sandbox_service_links_from_provisions()
+        && repaired > 0
+    {
+        tracing::info!(
+            repaired,
+            "Repaired missing sandbox service links from provision metadata"
+        );
     }
 
     let managing_operator = current_managing_operator();
@@ -1271,17 +1270,15 @@ fn delete_chat_session(
     if !chat_session_matches(&session, scope_id, owner) {
         return Err(api_error(StatusCode::NOT_FOUND, "Chat session not found"));
     }
-    if let Some(active_run_id) = session.active_run_id.as_deref() {
-        if let Some(run) = chat_state::get_run(active_run_id)
+    if let Some(active_run_id) = session.active_run_id.as_deref()
+        && let Some(run) = chat_state::get_run(active_run_id)
             .map_err(|e| api_error(StatusCode::INTERNAL_SERVER_ERROR, e))?
-        {
-            if run.status.is_active() {
-                return Err(api_error(
-                    StatusCode::CONFLICT,
-                    "Cannot delete a chat session while a run is active",
-                ));
-            }
-        }
+        && run.status.is_active()
+    {
+        return Err(api_error(
+            StatusCode::CONFLICT,
+            "Cannot delete a chat session while a run is active",
+        ));
     }
     chat_state::delete_session(session_id)
         .map_err(|e| api_error(StatusCode::INTERNAL_SERVER_ERROR, e))?;
@@ -2045,10 +2042,10 @@ fn build_exec_payload(command: &str, cwd: &str, env_json: &str, timeout_ms: u64)
     if timeout_ms > 0 {
         payload.insert("timeout".to_string(), json!(timeout_ms));
     }
-    if !env_json.trim().is_empty() {
-        if let Ok(Some(env_map)) = crate::util::parse_json_object(env_json, "env_json") {
-            payload.insert("env".to_string(), env_map);
-        }
+    if !env_json.trim().is_empty()
+        && let Ok(Some(env_map)) = crate::util::parse_json_object(env_json, "env_json")
+    {
+        payload.insert("env".to_string(), env_map);
     }
     Value::Object(payload)
 }
@@ -2150,64 +2147,68 @@ fn parse_detected_ssh_username(
 }
 
 /// Build `/agents/run` payload for prompt/task operations.
-fn build_agent_payload(
-    message: &str,
-    session_id: &str,
-    model: &str,
-    context_json: &str,
+struct AgentPayloadRequest<'a> {
+    message: &'a str,
+    session_id: &'a str,
+    backend_type: &'a str,
+    model: &'a str,
+    context_json: &'a str,
     timeout_ms: u64,
     max_turns: Option<u64>,
-    agent_identifier: &str,
-) -> Value {
+    agent_identifier: &'a str,
+}
+
+fn build_agent_payload(request: AgentPayloadRequest<'_>) -> Value {
     let mut payload = Map::new();
-    let identifier = if agent_identifier.is_empty() {
+    let identifier = if request.agent_identifier.is_empty() {
         "default"
     } else {
-        agent_identifier
+        request.agent_identifier
     };
     payload.insert("identifier".into(), json!(identifier));
-    payload.insert("message".into(), json!(message));
+    payload.insert("message".into(), json!(request.message));
 
-    if !session_id.is_empty() {
-        payload.insert("sessionId".into(), json!(session_id));
+    if !request.session_id.is_empty() {
+        payload.insert("sessionId".into(), json!(request.session_id));
     }
 
     let mut backend = Map::new();
-    if !model.is_empty() {
-        backend.insert("model".into(), json!(model));
+    if !request.backend_type.is_empty() {
+        backend.insert("type".into(), json!(request.backend_type));
+    }
+    if !request.model.is_empty() {
+        backend.insert("model".into(), json!(request.model));
     }
     if !backend.is_empty() {
         payload.insert("backend".into(), Value::Object(backend));
     }
 
-    if let Some(turns) = max_turns {
+    if let Some(turns) = request.max_turns {
         if turns > 0 {
             let mut metadata = Map::new();
             // Extend from context_json FIRST, then insert maxTurns — so
             // user-supplied context cannot override the operator-enforced
             // turn limit.
-            if !context_json.trim().is_empty() {
-                if let Ok(Some(Value::Object(mut ctx))) =
-                    crate::util::parse_json_object(context_json, "context_json")
-                {
-                    // Strip any attempt to override protected keys
-                    ctx.remove("maxTurns");
-                    metadata.extend(ctx);
-                }
+            if !request.context_json.trim().is_empty()
+                && let Ok(Some(Value::Object(mut ctx))) =
+                    crate::util::parse_json_object(request.context_json, "context_json")
+            {
+                // Strip any attempt to override protected keys
+                ctx.remove("maxTurns");
+                metadata.extend(ctx);
             }
             metadata.insert("maxTurns".into(), json!(turns));
             payload.insert("metadata".into(), Value::Object(metadata));
         }
-    } else if !context_json.trim().is_empty() {
-        if let Ok(Some(Value::Object(ctx))) =
-            crate::util::parse_json_object(context_json, "context_json")
-        {
-            payload.insert("metadata".into(), Value::Object(ctx));
-        }
+    } else if !request.context_json.trim().is_empty()
+        && let Ok(Some(Value::Object(ctx))) =
+            crate::util::parse_json_object(request.context_json, "context_json")
+    {
+        payload.insert("metadata".into(), Value::Object(ctx));
     }
 
-    if timeout_ms > 0 {
-        payload.insert("timeout".into(), json!(timeout_ms));
+    if request.timeout_ms > 0 {
+        payload.insert("timeout".into(), json!(request.timeout_ms));
     }
     Value::Object(payload)
 }
@@ -2236,6 +2237,86 @@ struct SidecarAgentList {
 struct AgentListApiResponse {
     agents: Vec<AgentDescriptor>,
     count: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct RuntimeCapabilityDescriptor {
+    id: &'static str,
+    label: &'static str,
+    description: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct HarnessCapabilityDescriptor {
+    id: &'static str,
+    label: &'static str,
+    mcp: bool,
+    skills: bool,
+    subagents: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct RuntimeCapabilitiesResponse {
+    capabilities: Vec<RuntimeCapabilityDescriptor>,
+    harnesses: Vec<HarnessCapabilityDescriptor>,
+}
+
+fn runtime_capabilities_response() -> RuntimeCapabilitiesResponse {
+    RuntimeCapabilitiesResponse {
+        capabilities: vec![
+            RuntimeCapabilityDescriptor {
+                id: "computer_use",
+                label: "Computer Use",
+                description: "Enable browser/computer-use sidecar services.",
+            },
+            RuntimeCapabilityDescriptor {
+                id: "all_harness",
+                label: "All Harness Runtime",
+                description: "Enable the open-source all-harness agent runtime: Claude, Codex, opencode, Kimi, and Gemini.",
+            },
+        ],
+        harnesses: vec![
+            HarnessCapabilityDescriptor {
+                id: "claude-code",
+                label: "Claude Code",
+                mcp: true,
+                skills: true,
+                subagents: true,
+            },
+            HarnessCapabilityDescriptor {
+                id: "codex",
+                label: "Codex",
+                mcp: true,
+                skills: false,
+                subagents: false,
+            },
+            HarnessCapabilityDescriptor {
+                id: "opencode",
+                label: "opencode",
+                mcp: true,
+                skills: true,
+                subagents: true,
+            },
+            HarnessCapabilityDescriptor {
+                id: "kimi-code",
+                label: "Kimi Code",
+                mcp: true,
+                skills: false,
+                subagents: false,
+            },
+            HarnessCapabilityDescriptor {
+                id: "gemini",
+                label: "Gemini CLI",
+                mcp: true,
+                skills: false,
+                subagents: false,
+            },
+        ],
+    }
+}
+
+async fn capabilities_handler() -> impl IntoResponse {
+    (StatusCode::OK, Json(runtime_capabilities_response()))
 }
 
 fn format_available_agents(agents: &[AgentDescriptor]) -> String {
@@ -2329,6 +2410,7 @@ fn parse_agent_descriptors(
 struct AgentStreamRequest<'a> {
     message: &'a str,
     session_id: &'a str,
+    backend_type: &'a str,
     model: &'a str,
     context_json: &'a str,
     timeout_ms: u64,
@@ -2340,15 +2422,16 @@ async fn agent_stream_on_sidecar(
     request: AgentStreamRequest<'_>,
     mut on_event: impl FnMut(&SidecarSseEvent),
 ) -> Result<AgentStreamOutcome, (StatusCode, Json<ApiError>)> {
-    let payload = build_agent_payload(
-        request.message,
-        request.session_id,
-        request.model,
-        request.context_json,
-        resolve_agent_run_timeout_ms(request.timeout_ms, request.max_turns),
-        request.max_turns,
-        &record.agent_identifier,
-    );
+    let payload = build_agent_payload(AgentPayloadRequest {
+        message: request.message,
+        session_id: request.session_id,
+        backend_type: request.backend_type,
+        model: request.model,
+        context_json: request.context_json,
+        timeout_ms: resolve_agent_run_timeout_ms(request.timeout_ms, request.max_turns),
+        max_turns: request.max_turns,
+        agent_identifier: &record.agent_identifier,
+    });
     let client = crate::util::http_client_no_timeout().map_err(|err| {
         api_error(
             StatusCode::BAD_GATEWAY,
@@ -2372,10 +2455,10 @@ async fn agent_stream_on_sidecar(
             )
         })?;
 
-        if let Ok(rid) = CURRENT_REQUEST_ID.try_with(|id| id.clone()) {
-            if let Ok(value) = reqwest::header::HeaderValue::from_str(&rid) {
-                headers.insert("x-request-id", value);
-            }
+        if let Ok(rid) = CURRENT_REQUEST_ID.try_with(|id| id.clone())
+            && let Ok(value) = reqwest::header::HeaderValue::from_str(&rid)
+        {
+            headers.insert("x-request-id", value);
         }
 
         let response = client
@@ -2476,12 +2559,11 @@ async fn agent_stream_on_sidecar(
                 };
                 match event.event_type.as_str() {
                     "message.part.updated" => {
-                        if let Some(part) = event.data.get("part").and_then(normalize_stream_part) {
-                            if part.get("type").and_then(Value::as_str) == Some("text") {
-                                if let Some(text) = part.get("text").and_then(Value::as_str) {
-                                    accumulated_text = text.to_string();
-                                }
-                            }
+                        if let Some(part) = event.data.get("part").and_then(normalize_stream_part)
+                            && part.get("type").and_then(Value::as_str) == Some("text")
+                            && let Some(text) = part.get("text").and_then(Value::as_str)
+                        {
+                            accumulated_text = text.to_string();
                         }
                         on_event(&event);
                     }
@@ -2689,10 +2771,10 @@ async fn run_sidecar_patch_json_attempt(
     match tokio::time::timeout(timeout, async move {
         let url = build_url(&sidecar_url, &path)?;
         let mut headers = auth_headers(&token)?;
-        if let Ok(rid) = CURRENT_REQUEST_ID.try_with(|id| id.clone()) {
-            if let Ok(value) = reqwest::header::HeaderValue::from_str(&rid) {
-                headers.insert("x-request-id", value);
-            }
+        if let Ok(rid) = CURRENT_REQUEST_ID.try_with(|id| id.clone())
+            && let Ok(value) = reqwest::header::HeaderValue::from_str(&rid)
+        {
+            headers.insert("x-request-id", value);
         }
 
         let response = crate::util::http_client()?
@@ -2749,25 +2831,26 @@ async fn sidecar_call(
             ))
         }
         Err(SidecarAttemptFailure::Error(err)) => {
-            if allow_transport_retry && is_retryable_transport_error(&err) {
-                if let Some(refreshed) = try_refresh_stale_endpoint(record, op_name).await {
-                    match run_sidecar_json_attempt(&refreshed, path, &payload, timeout).await {
-                        Ok(parsed) => {
-                            circuit_breaker::mark_healthy(&record.id);
-                            runtime::touch_sandbox(&record.id);
-                            return Ok(parsed);
-                        }
-                        Err(SidecarAttemptFailure::Timeout) => {
-                            circuit_breaker::mark_unhealthy(&record.id);
-                            return Err(api_error(
-                                StatusCode::GATEWAY_TIMEOUT,
-                                format!("Sidecar {op_name} timed out after {}s", timeout.as_secs()),
-                            ));
-                        }
-                        Err(SidecarAttemptFailure::Error(retry_err)) => {
-                            circuit_breaker::mark_unhealthy(&record.id);
-                            return Err(api_error(StatusCode::BAD_GATEWAY, retry_err.to_string()));
-                        }
+            if allow_transport_retry
+                && is_retryable_transport_error(&err)
+                && let Some(refreshed) = try_refresh_stale_endpoint(record, op_name).await
+            {
+                match run_sidecar_json_attempt(&refreshed, path, &payload, timeout).await {
+                    Ok(parsed) => {
+                        circuit_breaker::mark_healthy(&record.id);
+                        runtime::touch_sandbox(&record.id);
+                        return Ok(parsed);
+                    }
+                    Err(SidecarAttemptFailure::Timeout) => {
+                        circuit_breaker::mark_unhealthy(&record.id);
+                        return Err(api_error(
+                            StatusCode::GATEWAY_TIMEOUT,
+                            format!("Sidecar {op_name} timed out after {}s", timeout.as_secs()),
+                        ));
+                    }
+                    Err(SidecarAttemptFailure::Error(retry_err)) => {
+                        circuit_breaker::mark_unhealthy(&record.id);
+                        return Err(api_error(StatusCode::BAD_GATEWAY, retry_err.to_string()));
                     }
                 }
             }
@@ -2807,28 +2890,29 @@ async fn terminal_sidecar_call(
                 return Err(api_err);
             }
 
-            if allow_transport_retry && is_retryable_transport_error(&err) {
-                if let Some(refreshed) = try_refresh_stale_endpoint(record, op_name).await {
-                    match run_sidecar_json_attempt(&refreshed, path, &payload, timeout).await {
-                        Ok(parsed) => {
-                            circuit_breaker::mark_healthy(&record.id);
-                            runtime::touch_sandbox(&record.id);
-                            return Ok(parsed);
+            if allow_transport_retry
+                && is_retryable_transport_error(&err)
+                && let Some(refreshed) = try_refresh_stale_endpoint(record, op_name).await
+            {
+                match run_sidecar_json_attempt(&refreshed, path, &payload, timeout).await {
+                    Ok(parsed) => {
+                        circuit_breaker::mark_healthy(&record.id);
+                        runtime::touch_sandbox(&record.id);
+                        return Ok(parsed);
+                    }
+                    Err(SidecarAttemptFailure::Timeout) => {
+                        circuit_breaker::mark_unhealthy(&record.id);
+                        return Err(api_error(
+                            StatusCode::GATEWAY_TIMEOUT,
+                            format!("Sidecar {op_name} timed out after {}s", timeout.as_secs()),
+                        ));
+                    }
+                    Err(SidecarAttemptFailure::Error(retry_err)) => {
+                        if let Some(api_err) = terminal_api_error(&retry_err, op_name) {
+                            return Err(api_err);
                         }
-                        Err(SidecarAttemptFailure::Timeout) => {
-                            circuit_breaker::mark_unhealthy(&record.id);
-                            return Err(api_error(
-                                StatusCode::GATEWAY_TIMEOUT,
-                                format!("Sidecar {op_name} timed out after {}s", timeout.as_secs()),
-                            ));
-                        }
-                        Err(SidecarAttemptFailure::Error(retry_err)) => {
-                            if let Some(api_err) = terminal_api_error(&retry_err, op_name) {
-                                return Err(api_err);
-                            }
-                            circuit_breaker::mark_unhealthy(&record.id);
-                            return Err(api_error(StatusCode::BAD_GATEWAY, retry_err.to_string()));
-                        }
+                        circuit_breaker::mark_unhealthy(&record.id);
+                        return Err(api_error(StatusCode::BAD_GATEWAY, retry_err.to_string()));
                     }
                 }
             }
@@ -2867,31 +2951,31 @@ async fn sidecar_get_call(
                 return Err(api_error(StatusCode::BAD_GATEWAY, err_message));
             }
 
-            if is_retryable_transport_error(&err) {
-                if let Some(refreshed) = try_refresh_stale_endpoint(record, op_name).await {
-                    match run_sidecar_get_json_attempt(&refreshed, path, timeout).await {
-                        Ok(parsed) => {
-                            circuit_breaker::mark_healthy(&record.id);
-                            runtime::touch_sandbox(&record.id);
-                            return Ok(parsed);
-                        }
-                        Err(SidecarAttemptFailure::Timeout) => {
-                            circuit_breaker::mark_unhealthy(&record.id);
-                            return Err(api_error(
-                                StatusCode::GATEWAY_TIMEOUT,
-                                format!("Sidecar {op_name} timed out after {}s", timeout.as_secs()),
-                            ));
-                        }
-                        Err(SidecarAttemptFailure::Error(retry_err)) => {
-                            let retry_message = retry_err.to_string();
-                            if op_name == "agents"
-                                && agent_discovery_not_supported_message(&retry_message)
-                            {
-                                return Err(api_error(StatusCode::BAD_GATEWAY, retry_message));
-                            }
-                            circuit_breaker::mark_unhealthy(&record.id);
+            if is_retryable_transport_error(&err)
+                && let Some(refreshed) = try_refresh_stale_endpoint(record, op_name).await
+            {
+                match run_sidecar_get_json_attempt(&refreshed, path, timeout).await {
+                    Ok(parsed) => {
+                        circuit_breaker::mark_healthy(&record.id);
+                        runtime::touch_sandbox(&record.id);
+                        return Ok(parsed);
+                    }
+                    Err(SidecarAttemptFailure::Timeout) => {
+                        circuit_breaker::mark_unhealthy(&record.id);
+                        return Err(api_error(
+                            StatusCode::GATEWAY_TIMEOUT,
+                            format!("Sidecar {op_name} timed out after {}s", timeout.as_secs()),
+                        ));
+                    }
+                    Err(SidecarAttemptFailure::Error(retry_err)) => {
+                        let retry_message = retry_err.to_string();
+                        if op_name == "agents"
+                            && agent_discovery_not_supported_message(&retry_message)
+                        {
                             return Err(api_error(StatusCode::BAD_GATEWAY, retry_message));
                         }
+                        circuit_breaker::mark_unhealthy(&record.id);
+                        return Err(api_error(StatusCode::BAD_GATEWAY, retry_message));
                     }
                 }
             }
@@ -2929,28 +3013,28 @@ async fn terminal_sidecar_get_call(
                 return Err(api_err);
             }
 
-            if is_retryable_transport_error(&err) {
-                if let Some(refreshed) = try_refresh_stale_endpoint(record, op_name).await {
-                    match run_sidecar_get_json_attempt(&refreshed, path, timeout).await {
-                        Ok(parsed) => {
-                            circuit_breaker::mark_healthy(&record.id);
-                            runtime::touch_sandbox(&record.id);
-                            return Ok(parsed);
+            if is_retryable_transport_error(&err)
+                && let Some(refreshed) = try_refresh_stale_endpoint(record, op_name).await
+            {
+                match run_sidecar_get_json_attempt(&refreshed, path, timeout).await {
+                    Ok(parsed) => {
+                        circuit_breaker::mark_healthy(&record.id);
+                        runtime::touch_sandbox(&record.id);
+                        return Ok(parsed);
+                    }
+                    Err(SidecarAttemptFailure::Timeout) => {
+                        circuit_breaker::mark_unhealthy(&record.id);
+                        return Err(api_error(
+                            StatusCode::GATEWAY_TIMEOUT,
+                            format!("Sidecar {op_name} timed out after {}s", timeout.as_secs()),
+                        ));
+                    }
+                    Err(SidecarAttemptFailure::Error(retry_err)) => {
+                        if let Some(api_err) = terminal_api_error(&retry_err, op_name) {
+                            return Err(api_err);
                         }
-                        Err(SidecarAttemptFailure::Timeout) => {
-                            circuit_breaker::mark_unhealthy(&record.id);
-                            return Err(api_error(
-                                StatusCode::GATEWAY_TIMEOUT,
-                                format!("Sidecar {op_name} timed out after {}s", timeout.as_secs()),
-                            ));
-                        }
-                        Err(SidecarAttemptFailure::Error(retry_err)) => {
-                            if let Some(api_err) = terminal_api_error(&retry_err, op_name) {
-                                return Err(api_err);
-                            }
-                            circuit_breaker::mark_unhealthy(&record.id);
-                            return Err(api_error(StatusCode::BAD_GATEWAY, retry_err.to_string()));
-                        }
+                        circuit_breaker::mark_unhealthy(&record.id);
+                        return Err(api_error(StatusCode::BAD_GATEWAY, retry_err.to_string()));
                     }
                 }
             }
@@ -2989,29 +3073,28 @@ async fn terminal_sidecar_patch_call(
                 return Err(api_err);
             }
 
-            if is_retryable_transport_error(&err) {
-                if let Some(refreshed) = try_refresh_stale_endpoint(record, op_name).await {
-                    match run_sidecar_patch_json_attempt(&refreshed, path, &payload, timeout).await
-                    {
-                        Ok(parsed) => {
-                            circuit_breaker::mark_healthy(&record.id);
-                            runtime::touch_sandbox(&record.id);
-                            return Ok(parsed);
+            if is_retryable_transport_error(&err)
+                && let Some(refreshed) = try_refresh_stale_endpoint(record, op_name).await
+            {
+                match run_sidecar_patch_json_attempt(&refreshed, path, &payload, timeout).await {
+                    Ok(parsed) => {
+                        circuit_breaker::mark_healthy(&record.id);
+                        runtime::touch_sandbox(&record.id);
+                        return Ok(parsed);
+                    }
+                    Err(SidecarAttemptFailure::Timeout) => {
+                        circuit_breaker::mark_unhealthy(&record.id);
+                        return Err(api_error(
+                            StatusCode::GATEWAY_TIMEOUT,
+                            format!("Sidecar {op_name} timed out after {}s", timeout.as_secs()),
+                        ));
+                    }
+                    Err(SidecarAttemptFailure::Error(retry_err)) => {
+                        if let Some(api_err) = terminal_api_error(&retry_err, op_name) {
+                            return Err(api_err);
                         }
-                        Err(SidecarAttemptFailure::Timeout) => {
-                            circuit_breaker::mark_unhealthy(&record.id);
-                            return Err(api_error(
-                                StatusCode::GATEWAY_TIMEOUT,
-                                format!("Sidecar {op_name} timed out after {}s", timeout.as_secs()),
-                            ));
-                        }
-                        Err(SidecarAttemptFailure::Error(retry_err)) => {
-                            if let Some(api_err) = terminal_api_error(&retry_err, op_name) {
-                                return Err(api_err);
-                            }
-                            circuit_breaker::mark_unhealthy(&record.id);
-                            return Err(api_error(StatusCode::BAD_GATEWAY, retry_err.to_string()));
-                        }
+                        circuit_breaker::mark_unhealthy(&record.id);
+                        return Err(api_error(StatusCode::BAD_GATEWAY, retry_err.to_string()));
                     }
                 }
             }
@@ -3040,10 +3123,10 @@ async fn open_sidecar_stream_attempt(
         Err(err) => return Err(SidecarAttemptFailure::Error(err)),
     };
 
-    if let Ok(rid) = CURRENT_REQUEST_ID.try_with(|id| id.clone()) {
-        if let Ok(value) = reqwest::header::HeaderValue::from_str(&rid) {
-            headers.insert("x-request-id", value);
-        }
+    if let Ok(rid) = CURRENT_REQUEST_ID.try_with(|id| id.clone())
+        && let Ok(value) = reqwest::header::HeaderValue::from_str(&rid)
+    {
+        headers.insert("x-request-id", value);
     }
 
     let client = match crate::util::http_client_no_timeout() {
@@ -3097,49 +3180,40 @@ async fn terminal_sidecar_stream_call(
                     return Err(api_err);
                 }
 
-                if is_retryable_transport_error(inner) {
-                    if let Some(refreshed) = try_refresh_stale_endpoint(record, op_name).await {
-                        match tokio::time::timeout(
-                            timeout,
-                            open_sidecar_stream_attempt(&refreshed, path),
-                        )
-                        .await
-                        {
-                            Err(_) => {
-                                circuit_breaker::mark_unhealthy(&record.id);
-                                return Err(api_error(
-                                    StatusCode::GATEWAY_TIMEOUT,
-                                    format!(
-                                        "Sidecar {op_name} timed out after {}s",
-                                        timeout.as_secs()
-                                    ),
-                                ));
+                if is_retryable_transport_error(inner)
+                    && let Some(refreshed) = try_refresh_stale_endpoint(record, op_name).await
+                {
+                    match tokio::time::timeout(
+                        timeout,
+                        open_sidecar_stream_attempt(&refreshed, path),
+                    )
+                    .await
+                    {
+                        Err(_) => {
+                            circuit_breaker::mark_unhealthy(&record.id);
+                            return Err(api_error(
+                                StatusCode::GATEWAY_TIMEOUT,
+                                format!("Sidecar {op_name} timed out after {}s", timeout.as_secs()),
+                            ));
+                        }
+                        Ok(Ok(response)) => {
+                            circuit_breaker::mark_healthy(&record.id);
+                            runtime::touch_sandbox(&record.id);
+                            return Ok(response);
+                        }
+                        Ok(Err(SidecarAttemptFailure::Error(retry_err))) => {
+                            if let Some(api_err) = terminal_api_error(&retry_err, op_name) {
+                                return Err(api_err);
                             }
-                            Ok(Ok(response)) => {
-                                circuit_breaker::mark_healthy(&record.id);
-                                runtime::touch_sandbox(&record.id);
-                                return Ok(response);
-                            }
-                            Ok(Err(SidecarAttemptFailure::Error(retry_err))) => {
-                                if let Some(api_err) = terminal_api_error(&retry_err, op_name) {
-                                    return Err(api_err);
-                                }
-                                circuit_breaker::mark_unhealthy(&record.id);
-                                return Err(api_error(
-                                    StatusCode::BAD_GATEWAY,
-                                    retry_err.to_string(),
-                                ));
-                            }
-                            Ok(Err(SidecarAttemptFailure::Timeout)) => {
-                                circuit_breaker::mark_unhealthy(&record.id);
-                                return Err(api_error(
-                                    StatusCode::GATEWAY_TIMEOUT,
-                                    format!(
-                                        "Sidecar {op_name} timed out after {}s",
-                                        timeout.as_secs()
-                                    ),
-                                ));
-                            }
+                            circuit_breaker::mark_unhealthy(&record.id);
+                            return Err(api_error(StatusCode::BAD_GATEWAY, retry_err.to_string()));
+                        }
+                        Ok(Err(SidecarAttemptFailure::Timeout)) => {
+                            circuit_breaker::mark_unhealthy(&record.id);
+                            return Err(api_error(
+                                StatusCode::GATEWAY_TIMEOUT,
+                                format!("Sidecar {op_name} timed out after {}s", timeout.as_secs()),
+                            ));
                         }
                     }
                 }
@@ -3181,10 +3255,10 @@ async fn terminal_sidecar_delete_call(
                 .map_err(|err| api_error(StatusCode::BAD_GATEWAY, err.to_string()))?;
             let mut headers = auth_headers(&token)
                 .map_err(|err| api_error(StatusCode::BAD_GATEWAY, err.to_string()))?;
-            if let Ok(rid) = CURRENT_REQUEST_ID.try_with(|id| id.clone()) {
-                if let Ok(value) = reqwest::header::HeaderValue::from_str(&rid) {
-                    headers.insert("x-request-id", value);
-                }
+            if let Ok(rid) = CURRENT_REQUEST_ID.try_with(|id| id.clone())
+                && let Ok(value) = reqwest::header::HeaderValue::from_str(&rid)
+            {
+                headers.insert("x-request-id", value);
             }
 
             let client = crate::util::http_client()
@@ -3233,35 +3307,34 @@ async fn terminal_sidecar_delete_call(
             }
 
             let err_text = err.1.0.error.clone();
-            if err_text.contains("error sending request for url") {
-                if let Some(refreshed) = try_refresh_stale_endpoint(record, op_name).await {
-                    match tokio::time::timeout(
-                        timeout,
-                        run_delete(refreshed.sidecar_url.clone(), refreshed.token.clone()),
-                    )
-                    .await
-                    {
-                        Err(_) => {
-                            circuit_breaker::mark_unhealthy(&record.id);
-                            return Err(api_error(
-                                StatusCode::GATEWAY_TIMEOUT,
-                                format!("Sidecar {op_name} timed out after {}s", timeout.as_secs()),
-                            ));
+            if err_text.contains("error sending request for url")
+                && let Some(refreshed) = try_refresh_stale_endpoint(record, op_name).await
+            {
+                match tokio::time::timeout(
+                    timeout,
+                    run_delete(refreshed.sidecar_url.clone(), refreshed.token.clone()),
+                )
+                .await
+                {
+                    Err(_) => {
+                        circuit_breaker::mark_unhealthy(&record.id);
+                        return Err(api_error(
+                            StatusCode::GATEWAY_TIMEOUT,
+                            format!("Sidecar {op_name} timed out after {}s", timeout.as_secs()),
+                        ));
+                    }
+                    Ok(Ok(())) => {
+                        circuit_breaker::mark_healthy(&record.id);
+                        runtime::touch_sandbox(&record.id);
+                        return Ok(());
+                    }
+                    Ok(Err(retry_err)) => {
+                        if let Some(api_err) = terminal_api_error_from_response(&retry_err, op_name)
+                        {
+                            return Err(api_err);
                         }
-                        Ok(Ok(())) => {
-                            circuit_breaker::mark_healthy(&record.id);
-                            runtime::touch_sandbox(&record.id);
-                            return Ok(());
-                        }
-                        Ok(Err(retry_err)) => {
-                            if let Some(api_err) =
-                                terminal_api_error_from_response(&retry_err, op_name)
-                            {
-                                return Err(api_err);
-                            }
-                            circuit_breaker::mark_unhealthy(&record.id);
-                            return Err(retry_err);
-                        }
+                        circuit_breaker::mark_unhealthy(&record.id);
+                        return Err(retry_err);
                     }
                 }
             }
@@ -3558,12 +3631,12 @@ fn enqueue_chat_run(
         error: None,
     };
     publish_chat_message(&session.id, user_message, "user_message");
-    if let Ok(Some(current_session)) = chat_state::get_session(&session.id) {
-        if let Some(message) = current_session.messages.last() {
-            emit_message_updated(&session.id, message);
-            for part in &message.parts {
-                emit_message_part_updated(&session.id, &message.id, part.clone());
-            }
+    if let Ok(Some(current_session)) = chat_state::get_session(&session.id)
+        && let Some(message) = current_session.messages.last()
+    {
+        emit_message_updated(&session.id, message);
+        for part in &message.parts {
+            emit_message_part_updated(&session.id, &message.id, part.clone());
         }
     }
     if let Ok(Some(queued_run)) = chat_state::get_run(&run.id) {
@@ -3578,6 +3651,7 @@ struct SpawnChatRunRequest {
     session_id: String,
     run_id: String,
     message: String,
+    backend_type: String,
     model: String,
     context_json: String,
     timeout_ms: u64,
@@ -3589,6 +3663,7 @@ fn spawn_chat_run(record: SandboxRecord, request: SpawnChatRunRequest) {
         session_id,
         run_id,
         message,
+        backend_type,
         model,
         context_json,
         timeout_ms,
@@ -3671,6 +3746,7 @@ fn spawn_chat_run(record: SandboxRecord, request: SpawnChatRunRequest) {
             AgentStreamRequest {
                 message: &message,
                 session_id: &sidecar_session_id,
+                backend_type: &backend_type,
                 model: &model,
                 context_json: &context_json,
                 timeout_ms,
@@ -3688,49 +3764,49 @@ fn spawn_chat_run(record: SandboxRecord, request: SpawnChatRunRequest) {
                     _ => None,
                 };
 
-                if let Some((candidate_session_id, candidate_source)) = streamed_session {
-                    if candidate_source > authoritative_sidecar_session_source {
-                        authoritative_sidecar_session_source = candidate_source;
-                        authoritative_sidecar_session_id = Some(candidate_session_id.clone());
-                        let _ = chat_state::set_session_sidecar_session_id(
-                            &session_id,
-                            Some(candidate_session_id.clone()),
-                        );
-                        let _ = chat_state::update_run(&run_id, |run| {
-                            run.sidecar_session_id = Some(candidate_session_id.clone());
-                        });
-                    }
+                if let Some((candidate_session_id, candidate_source)) = streamed_session
+                    && candidate_source > authoritative_sidecar_session_source
+                {
+                    authoritative_sidecar_session_source = candidate_source;
+                    authoritative_sidecar_session_id = Some(candidate_session_id.clone());
+                    let _ = chat_state::set_session_sidecar_session_id(
+                        &session_id,
+                        Some(candidate_session_id.clone()),
+                    );
+                    let _ = chat_state::update_run(&run_id, |run| {
+                        run.sidecar_session_id = Some(candidate_session_id.clone());
+                    });
                 }
 
-                if event.event_type == "message.part.updated" {
-                    if let Some(part) = event.data.get("part").and_then(normalize_stream_part) {
-                        if !should_forward_stream_part(
-                            &part,
-                            &message,
-                            &mut ignored_upstream_message_ids,
-                            &mut assistant_upstream_message_ids,
-                        ) {
-                            return;
-                        }
-                        let _ = chat_state::upsert_message_part(
-                            &session_id,
-                            &assistant_message_id,
-                            part.clone(),
-                        );
-                        emit_message_part_updated(&session_id, &assistant_message_id, part);
+                if event.event_type == "message.part.updated"
+                    && let Some(part) = event.data.get("part").and_then(normalize_stream_part)
+                {
+                    if !should_forward_stream_part(
+                        &part,
+                        &message,
+                        &mut ignored_upstream_message_ids,
+                        &mut assistant_upstream_message_ids,
+                    ) {
+                        return;
                     }
+                    let _ = chat_state::upsert_message_part(
+                        &session_id,
+                        &assistant_message_id,
+                        part.clone(),
+                    );
+                    emit_message_part_updated(&session_id, &assistant_message_id, part);
                 }
             },
         )
         .await;
 
-        if let Ok(Some(existing_run)) = chat_state::get_run(&run_id) {
-            if matches!(
+        if let Ok(Some(existing_run)) = chat_state::get_run(&run_id)
+            && matches!(
                 existing_run.status,
                 ChatRunStatus::Cancelled | ChatRunStatus::Cancelling
-            ) {
-                return;
-            }
+            )
+        {
+            return;
         }
 
         match result {
@@ -3941,6 +4017,7 @@ async fn sandbox_prompt_handler(
             session_id: session.id.clone(),
             run_id: run.id.clone(),
             message: req.message,
+            backend_type: req.backend_type,
             model: req.model,
             context_json: req.context_json,
             timeout_ms: req.timeout_ms,
@@ -3975,6 +4052,7 @@ async fn instance_prompt_handler(
             session_id: session.id.clone(),
             run_id: run.id.clone(),
             message: req.message,
+            backend_type: req.backend_type,
             model: req.model,
             context_json: req.context_json,
             timeout_ms: req.timeout_ms,
@@ -4012,6 +4090,7 @@ async fn sandbox_task_handler(
             session_id: session.id.clone(),
             run_id: run.id.clone(),
             message: req.prompt,
+            backend_type: req.backend_type,
             model: req.model,
             context_json: req.context_json,
             timeout_ms: req.timeout_ms,
@@ -4046,6 +4125,7 @@ async fn instance_task_handler(
             session_id: session.id.clone(),
             run_id: run.id.clone(),
             message: req.prompt,
+            backend_type: req.backend_type,
             model: req.model,
             context_json: req.context_json,
             timeout_ms: req.timeout_ms,
@@ -4529,39 +4609,39 @@ async fn run_port_proxy(
             ))
         }
         Err(SidecarAttemptFailure::Error(err)) => {
-            if is_retryable_transport_error(&err) {
-                if let Some(refreshed) = try_refresh_stale_endpoint(&record, "port_proxy").await {
-                    match proxy_once(build_target(&refreshed)?, method, headers, body).await {
-                        Ok((status, resp_headers, resp_body)) => {
-                            circuit_breaker::mark_healthy(&record.id);
-                            runtime::touch_sandbox(&record.id);
+            if is_retryable_transport_error(&err)
+                && let Some(refreshed) = try_refresh_stale_endpoint(&record, "port_proxy").await
+            {
+                match proxy_once(build_target(&refreshed)?, method, headers, body).await {
+                    Ok((status, resp_headers, resp_body)) => {
+                        circuit_breaker::mark_healthy(&record.id);
+                        runtime::touch_sandbox(&record.id);
 
-                            let mut response =
-                                axum::response::Response::builder().status(status.as_u16());
-                            for (name, value) in resp_headers.iter() {
-                                response = response.header(name.as_str(), value.as_bytes());
-                            }
+                        let mut response =
+                            axum::response::Response::builder().status(status.as_u16());
+                        for (name, value) in resp_headers.iter() {
+                            response = response.header(name.as_str(), value.as_bytes());
+                        }
 
-                            return response
-                                .body(axum::body::Body::from(resp_body))
-                                .map_err(|e| {
-                                    api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-                                });
-                        }
-                        Err(SidecarAttemptFailure::Timeout) => {
-                            circuit_breaker::mark_unhealthy(&record.id);
-                            return Err(api_error(
-                                StatusCode::GATEWAY_TIMEOUT,
-                                format!(
-                                    "Port proxy timed out after {}s",
-                                    PORT_PROXY_TIMEOUT.as_secs()
-                                ),
-                            ));
-                        }
-                        Err(SidecarAttemptFailure::Error(retry_err)) => {
-                            circuit_breaker::mark_unhealthy(&record.id);
-                            return Err(api_error(StatusCode::BAD_GATEWAY, retry_err.to_string()));
-                        }
+                        return response
+                            .body(axum::body::Body::from(resp_body))
+                            .map_err(|e| {
+                                api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+                            });
+                    }
+                    Err(SidecarAttemptFailure::Timeout) => {
+                        circuit_breaker::mark_unhealthy(&record.id);
+                        return Err(api_error(
+                            StatusCode::GATEWAY_TIMEOUT,
+                            format!(
+                                "Port proxy timed out after {}s",
+                                PORT_PROXY_TIMEOUT.as_secs()
+                            ),
+                        ));
+                    }
+                    Err(SidecarAttemptFailure::Error(retry_err)) => {
+                        circuit_breaker::mark_unhealthy(&record.id);
+                        return Err(api_error(StatusCode::BAD_GATEWAY, retry_err.to_string()));
                     }
                 }
             }
@@ -4960,6 +5040,7 @@ pub fn operator_api_router_with_tee_and_routes(
     let infra_routes = Router::new()
         .route("/health", get(health))
         .route("/readyz", get(readyz))
+        .route("/api/capabilities", get(capabilities_handler))
         .route("/metrics", get(prometheus_metrics))
         .route("/api/provisions", get(list_provisions))
         .route("/api/provisions/{call_id}", get(get_provision))
@@ -6107,6 +6188,34 @@ data: {{\"finalText\":\"mock-agent-response\",\"metadata\":{{\"sessionId\":\"{se
             json["runtime_backend"].is_string(),
             "missing runtime_backend field"
         );
+    }
+
+    #[tokio::test]
+    async fn test_capabilities_endpoint_includes_all_harness_runtime() {
+        let response = app()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/capabilities")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = body_json(response.into_body()).await;
+        let capabilities = json["capabilities"].as_array().expect("capabilities");
+        assert!(
+            capabilities.iter().any(|cap| cap["id"] == "all_harness"),
+            "missing all_harness capability: {json}",
+        );
+        let harnesses = json["harnesses"].as_array().expect("harnesses");
+        for id in ["claude-code", "codex", "opencode", "kimi-code", "gemini"] {
+            assert!(
+                harnesses.iter().any(|h| h["id"] == id),
+                "missing harness {id}: {json}",
+            );
+        }
     }
 
     #[tokio::test]
@@ -9613,15 +9722,16 @@ data: {\"finalText\":\"first reply\",\"metadata\":{\"sessionId\":\"backend-resul
     fn test_build_agent_payload_context_json_cannot_override_max_turns() {
         // A malicious client sends context_json with a maxTurns override
         // attempting to remove the operator-enforced turn limit.
-        let payload = build_agent_payload(
-            "hello",
-            "sess-1",
-            "",
-            r#"{"maxTurns": 999999, "custom_key": "safe"}"#,
-            60_000,
-            Some(5), // operator-enforced limit
-            "default",
-        );
+        let payload = build_agent_payload(AgentPayloadRequest {
+            message: "hello",
+            session_id: "sess-1",
+            backend_type: "",
+            model: "",
+            context_json: r#"{"maxTurns": 999999, "custom_key": "safe"}"#,
+            timeout_ms: 60_000,
+            max_turns: Some(5), // operator-enforced limit
+            agent_identifier: "default",
+        });
 
         let metadata = payload.get("metadata").expect("metadata should exist");
         assert_eq!(
@@ -9639,15 +9749,16 @@ data: {\"finalText\":\"first reply\",\"metadata\":{\"sessionId\":\"backend-resul
     #[test]
     fn test_build_agent_payload_context_json_without_max_turns_override() {
         // Normal case: context_json doesn't try to override maxTurns
-        let payload = build_agent_payload(
-            "hello",
-            "",
-            "gpt-4",
-            r#"{"user_context": "some data"}"#,
-            0,
-            Some(10),
-            "",
-        );
+        let payload = build_agent_payload(AgentPayloadRequest {
+            message: "hello",
+            session_id: "",
+            backend_type: "gemini",
+            model: "gpt-4",
+            context_json: r#"{"user_context": "some data"}"#,
+            timeout_ms: 0,
+            max_turns: Some(10),
+            agent_identifier: "",
+        });
 
         let metadata = payload.get("metadata").expect("metadata should exist");
         assert_eq!(metadata.get("maxTurns").and_then(|v| v.as_u64()), Some(10),);
@@ -9655,5 +9766,8 @@ data: {\"finalText\":\"first reply\",\"metadata\":{\"sessionId\":\"backend-resul
             metadata.get("user_context").and_then(|v| v.as_str()),
             Some("some data"),
         );
+        let backend = payload.get("backend").expect("backend should exist");
+        assert_eq!(backend.get("type").and_then(|v| v.as_str()), Some("gemini"));
+        assert_eq!(backend.get("model").and_then(|v| v.as_str()), Some("gpt-4"));
     }
 }

--- a/sandbox-runtime/src/reaper.rs
+++ b/sandbox-runtime/src/reaper.rs
@@ -164,33 +164,32 @@ pub async fn gc_tick() {
         if record_uses_firecracker(&record) {
             if let (Some(container_removed_at), Some(s3_url)) =
                 (record.container_removed_at, &record.snapshot_s3_url)
+                && container_removed_at + config.sandbox_gc_cold_retention <= now
             {
-                if container_removed_at + config.sandbox_gc_cold_retention <= now {
-                    let is_operator_managed = is_operator_s3(s3_url, &record, config);
-                    if is_operator_managed {
-                        info!(
-                            "gc: firecracker cold->gone for sandbox {} (deleting S3 snapshot)",
-                            record.id
-                        );
-                        if let Err(err) = delete_s3_snapshot(s3_url).await {
-                            error!(
-                                "gc: failed to delete firecracker S3 snapshot for sandbox {}: {err}",
-                                record.id
-                            );
-                        }
-                        metrics().record_gc_s3_cleaned();
-                    } else {
-                        info!(
-                            "gc: removing firecracker record for sandbox {} (user BYOS3 preserved at {s3_url})",
+                let is_operator_managed = is_operator_s3(s3_url, &record, config);
+                if is_operator_managed {
+                    info!(
+                        "gc: firecracker cold->gone for sandbox {} (deleting S3 snapshot)",
+                        record.id
+                    );
+                    if let Err(err) = delete_s3_snapshot(s3_url).await {
+                        error!(
+                            "gc: failed to delete firecracker S3 snapshot for sandbox {}: {err}",
                             record.id
                         );
                     }
-                    if let Ok(store) = sandboxes() {
-                        let _ = store.remove(&record.id);
-                    }
-                    metrics().record_garbage_collected();
-                    continue;
+                    metrics().record_gc_s3_cleaned();
+                } else {
+                    info!(
+                        "gc: removing firecracker record for sandbox {} (user BYOS3 preserved at {s3_url})",
+                        record.id
+                    );
                 }
+                if let Ok(store) = sandboxes() {
+                    let _ = store.remove(&record.id);
+                }
+                metrics().record_garbage_collected();
+                continue;
             }
 
             if record.container_removed_at.is_some()
@@ -261,70 +260,67 @@ pub async fn gc_tick() {
         // Tier 2: Warm -> Cold (remove committed image, keep S3)
         if let (Some(container_removed_at), Some(image_id)) =
             (record.container_removed_at, &record.snapshot_image_id)
+            && container_removed_at + config.sandbox_gc_warm_retention <= now
         {
-            if container_removed_at + config.sandbox_gc_warm_retention <= now {
-                info!(
-                    "gc: warm->cold for sandbox {} (removing image {})",
-                    record.id, image_id
+            info!(
+                "gc: warm->cold for sandbox {} (removing image {})",
+                record.id, image_id
+            );
+            if let Err(err) = remove_snapshot_image(image_id).await {
+                error!(
+                    "gc: failed to remove snapshot image for sandbox {}: {err}",
+                    record.id
                 );
-                if let Err(err) = remove_snapshot_image(image_id).await {
-                    error!(
-                        "gc: failed to remove snapshot image for sandbox {}: {err}",
-                        record.id
-                    );
-                }
-                if let Ok(store) = sandboxes() {
-                    let _ = store.update(&record.id, |r| {
-                        r.snapshot_image_id = None;
-                        r.image_removed_at = Some(now);
-                    });
-                }
-                metrics().record_gc_image_removed();
-
-                // If no S3 snapshot exists, remove record entirely
-                if record.snapshot_s3_url.is_none() {
-                    if let Ok(store) = sandboxes() {
-                        let _ = store.remove(&record.id);
-                    }
-                    metrics().record_garbage_collected();
-                }
-                continue;
             }
+            if let Ok(store) = sandboxes() {
+                let _ = store.update(&record.id, |r| {
+                    r.snapshot_image_id = None;
+                    r.image_removed_at = Some(now);
+                });
+            }
+            metrics().record_gc_image_removed();
+
+            // If no S3 snapshot exists, remove record entirely
+            if record.snapshot_s3_url.is_none() {
+                if let Ok(store) = sandboxes() {
+                    let _ = store.remove(&record.id);
+                }
+                metrics().record_garbage_collected();
+            }
+            continue;
         }
 
         // Tier 3: Cold -> Gone (remove S3 snapshot, remove record)
-        if record.snapshot_image_id.is_none() {
-            if let (Some(s3_url), Some(image_removed_at)) =
+        if record.snapshot_image_id.is_none()
+            && let (Some(s3_url), Some(image_removed_at)) =
                 (&record.snapshot_s3_url, record.image_removed_at)
-            {
-                if image_removed_at + config.sandbox_gc_cold_retention <= now {
-                    // Only delete operator-managed S3 snapshots, not user BYOS3
-                    let is_operator_managed = is_operator_s3(s3_url, &record, config);
-                    if is_operator_managed {
-                        info!(
-                            "gc: cold->gone for sandbox {} (deleting S3 snapshot)",
-                            record.id
-                        );
-                        if let Err(err) = delete_s3_snapshot(s3_url).await {
-                            error!(
-                                "gc: failed to delete S3 snapshot for sandbox {}: {err}",
-                                record.id
-                            );
-                        }
-                        metrics().record_gc_s3_cleaned();
-                    } else {
-                        info!(
-                            "gc: removing record for sandbox {} (user BYOS3 preserved at {s3_url})",
-                            record.id
-                        );
-                    }
-                    if let Ok(store) = sandboxes() {
-                        let _ = store.remove(&record.id);
-                    }
-                    metrics().record_garbage_collected();
-                    continue;
+            && image_removed_at + config.sandbox_gc_cold_retention <= now
+        {
+            // Only delete operator-managed S3 snapshots, not user BYOS3
+            let is_operator_managed = is_operator_s3(s3_url, &record, config);
+            if is_operator_managed {
+                info!(
+                    "gc: cold->gone for sandbox {} (deleting S3 snapshot)",
+                    record.id
+                );
+                if let Err(err) = delete_s3_snapshot(s3_url).await {
+                    error!(
+                        "gc: failed to delete S3 snapshot for sandbox {}: {err}",
+                        record.id
+                    );
                 }
+                metrics().record_gc_s3_cleaned();
+            } else {
+                info!(
+                    "gc: removing record for sandbox {} (user BYOS3 preserved at {s3_url})",
+                    record.id
+                );
             }
+            if let Ok(store) = sandboxes() {
+                let _ = store.remove(&record.id);
+            }
+            metrics().record_garbage_collected();
+            continue;
         }
 
         // Cleanup: record has no container, no image, no S3 -> remove
@@ -491,13 +487,13 @@ pub async fn reconcile_on_startup() {
                         });
                     }
                 } else if running {
-                    if supports_docker_endpoint_refresh(&record) {
-                        if let Err(err) = refresh_docker_sandbox_endpoint(&record).await {
-                            error!(
-                                "reconcile: failed to refresh endpoint for sandbox {}: {err}",
-                                record.id
-                            );
-                        }
+                    if supports_docker_endpoint_refresh(&record)
+                        && let Err(err) = refresh_docker_sandbox_endpoint(&record).await
+                    {
+                        error!(
+                            "reconcile: failed to refresh endpoint for sandbox {}: {err}",
+                            record.id
+                        );
                     }
 
                     if record.state == SandboxState::Stopped {

--- a/sandbox-runtime/src/runtime.rs
+++ b/sandbox-runtime/src/runtime.rs
@@ -92,7 +92,8 @@ pub struct CreateSandboxParams {
     /// Parsed from `metadata_json.ports` at creation time.
     pub port_mappings: Vec<u16>,
     /// Sidecar capabilities to enable at boot, encoded as a JSON array
-    /// (e.g. `["computer_use"]`). Currently supported entries: `computer_use`.
+    /// (e.g. `["computer_use"]`). Currently supported entries:
+    /// `computer_use`, `all_harness`.
     /// When non-empty, the runtime sets `SIDECAR_CAPABILITIES` on the
     /// container env so the sidecar boots Xvfb / dbus / MCP at startup.
     /// Empty string means no extra subsystems start.
@@ -130,7 +131,7 @@ pub(crate) fn parse_sidecar_capabilities(raw: &str) -> Option<String> {
     };
     let known: Vec<String> = entries
         .into_iter()
-        .filter(|c| c == "computer_use")
+        .filter(|c| c == "computer_use" || c == "all_harness")
         .collect();
     if known.is_empty() {
         None
@@ -2049,17 +2050,17 @@ async fn create_sidecar_firecracker(
     if let Some(caps) = parse_sidecar_capabilities(&request.capabilities_json) {
         env.insert("SIDECAR_CAPABILITIES".to_string(), caps);
     }
-    if !effective_env.trim().is_empty() {
-        if let Some(Value::Object(map)) = parse_json_object(&effective_env, "env_json")? {
-            for (key, value) in map {
-                let val = match value {
-                    Value::String(v) => v,
-                    Value::Number(v) => v.to_string(),
-                    Value::Bool(v) => v.to_string(),
-                    _ => continue,
-                };
-                env.insert(key, val);
-            }
+    if !effective_env.trim().is_empty()
+        && let Some(Value::Object(map)) = parse_json_object(&effective_env, "env_json")?
+    {
+        for (key, value) in map {
+            let val = match value {
+                Value::String(v) => v,
+                Value::Number(v) => v.to_string(),
+                Value::Bool(v) => v.to_string(),
+                _ => continue,
+            };
+            env.insert(key, val);
         }
     }
 
@@ -2612,16 +2613,16 @@ pub async fn stop_sidecar(record: &SandboxRecord) -> Result<()> {
     }
 
     // TEE-managed sandbox: delegate to the TEE backend.
-    if let Some(deployment_id) = &record.tee_deployment_id {
-        if let Some(backend) = crate::tee::try_tee_backend() {
-            backend.stop(deployment_id).await?;
-            let now = crate::util::now_ts();
-            let _ = sandboxes()?.update(&record.id, |r| {
-                r.state = SandboxState::Stopped;
-                r.stopped_at = Some(now);
-            });
-            return Ok(());
-        }
+    if let Some(deployment_id) = &record.tee_deployment_id
+        && let Some(backend) = crate::tee::try_tee_backend()
+    {
+        backend.stop(deployment_id).await?;
+        let now = crate::util::now_ts();
+        let _ = sandboxes()?.update(&record.id, |r| {
+            r.state = SandboxState::Stopped;
+            r.stopped_at = Some(now);
+        });
+        return Ok(());
     }
 
     if record_uses_firecracker(record) {
@@ -2656,12 +2657,11 @@ async fn wait_for_sidecar_health(sidecar_url: &str, timeout_secs: u64) -> bool {
     let ready = tokio::time::timeout(Duration::from_secs(timeout_secs), async {
         loop {
             let url = format!("{sidecar_url}/health");
-            if let Ok(resp) = crate::util::http_client().map(|c| c.get(&url)) {
-                if let Ok(r) = resp.send().await {
-                    if r.status().is_success() {
-                        return;
-                    }
-                }
+            if let Ok(resp) = crate::util::http_client().map(|c| c.get(&url))
+                && let Ok(r) = resp.send().await
+                && r.status().is_success()
+            {
+                return;
             }
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
@@ -3538,12 +3538,12 @@ fn parse_extra_ports(metadata_json: &str, explicit: &[u16]) -> Vec<u16> {
     let mut ports: Vec<u16> = Vec::new();
 
     // From metadata_json.ports
-    if let Ok(Some(meta)) = parse_json_object(metadata_json, "metadata_json") {
-        if let Some(arr) = meta.get("ports").and_then(|v| v.as_array()) {
-            for v in arr {
-                if let Some(p) = v.as_u64().and_then(|n| u16::try_from(n).ok()) {
-                    ports.push(p);
-                }
+    if let Ok(Some(meta)) = parse_json_object(metadata_json, "metadata_json")
+        && let Some(arr) = meta.get("ports").and_then(|v| v.as_array())
+    {
+        for v in arr {
+            if let Some(p) = v.as_u64().and_then(|n| u16::try_from(n).ok()) {
+                ports.push(p);
             }
         }
     }
@@ -3964,6 +3964,14 @@ mod sidecar_capability_tests {
             parse_sidecar_capabilities(r#"["computer_use"]"#).as_deref(),
             Some("computer_use"),
         );
+        assert_eq!(
+            parse_sidecar_capabilities(r#"["all_harness"]"#).as_deref(),
+            Some("all_harness"),
+        );
+        assert_eq!(
+            parse_sidecar_capabilities(r#"["computer_use","all_harness"]"#).as_deref(),
+            Some("computer_use,all_harness"),
+        );
     }
 
     #[test]
@@ -4010,6 +4018,12 @@ mod sidecar_capability_tests {
         assert!(
             env_vars.contains(&"SIDECAR_CAPABILITIES=computer_use".to_string()),
             "expected SIDECAR_CAPABILITIES in env, got {env_vars:?}",
+        );
+        let env_vars =
+            build_env_vars("{}", "tok", 8080, r#"["computer_use","all_harness"]"#).unwrap();
+        assert!(
+            env_vars.contains(&"SIDECAR_CAPABILITIES=computer_use,all_harness".to_string()),
+            "expected all-harness SIDECAR_CAPABILITIES in env, got {env_vars:?}",
         );
     }
 

--- a/sandbox-runtime/src/session_auth.rs
+++ b/sandbox-runtime/src/session_auth.rs
@@ -311,10 +311,10 @@ pub fn validate_session_token(token: &str) -> Result<SessionClaims> {
     // First try server-side session store (faster)
     {
         let sessions = SESSIONS.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(claims) = sessions.get(token) {
-            if now_secs() <= claims.expires_at {
-                return Ok(claims.clone());
-            }
+        if let Some(claims) = sessions.get(token)
+            && now_secs() <= claims.expires_at
+        {
+            return Ok(claims.clone());
         }
     }
 

--- a/sandbox-runtime/src/tee/aws_nitro.rs
+++ b/sandbox-runtime/src/tee/aws_nitro.rs
@@ -190,26 +190,23 @@ impl NitroBackend {
                 .reservations()
                 .first()
                 .and_then(|r| r.instances().first())
+                && let Some(state) = instance.state()
             {
-                if let Some(state) = instance.state() {
-                    if state.name() == Some(&InstanceStateName::Running) {
-                        return instance
-                            .public_ip_address()
-                            .map(|ip| ip.to_string())
-                            .ok_or_else(|| {
-                                SandboxError::CloudProvider(
-                                    "No public IP assigned to instance".into(),
-                                )
-                            });
-                    }
-                    if matches!(
-                        state.name(),
-                        Some(&InstanceStateName::Terminated | &InstanceStateName::ShuttingDown)
-                    ) {
-                        return Err(SandboxError::CloudProvider(format!(
-                            "EC2 instance {instance_id} entered terminal state"
-                        )));
-                    }
+                if state.name() == Some(&InstanceStateName::Running) {
+                    return instance
+                        .public_ip_address()
+                        .map(|ip| ip.to_string())
+                        .ok_or_else(|| {
+                            SandboxError::CloudProvider("No public IP assigned to instance".into())
+                        });
+                }
+                if matches!(
+                    state.name(),
+                    Some(&InstanceStateName::Terminated | &InstanceStateName::ShuttingDown)
+                ) {
+                    return Err(SandboxError::CloudProvider(format!(
+                        "EC2 instance {instance_id} entered terminal state"
+                    )));
                 }
             }
 

--- a/sandbox-runtime/src/tee/azure.rs
+++ b/sandbox-runtime/src/tee/azure.rs
@@ -112,10 +112,10 @@ impl AzureSkrBackend {
         // Check cache first.
         {
             let cache = self.token_cache.read().await;
-            if let Some(ref cached) = *cache {
-                if cached.expires_at > std::time::Instant::now() + Duration::from_secs(60) {
-                    return Ok(cached.token.clone());
-                }
+            if let Some(ref cached) = *cache
+                && cached.expires_at > std::time::Instant::now() + Duration::from_secs(60)
+            {
+                return Ok(cached.token.clone());
             }
         }
 

--- a/sandbox-runtime/src/tee/mod.rs
+++ b/sandbox-runtime/src/tee/mod.rs
@@ -115,19 +115,18 @@ impl TeeDeployParams {
         }
 
         // Parse env_json into env var pairs.
-        if !params.env_json.trim().is_empty() {
-            if let Ok(Some(serde_json::Value::Object(map))) =
+        if !params.env_json.trim().is_empty()
+            && let Ok(Some(serde_json::Value::Object(map))) =
                 crate::util::parse_json_object(&params.env_json, "env_json")
-            {
-                for (key, value) in map {
-                    let val = match value {
-                        serde_json::Value::String(v) => v,
-                        serde_json::Value::Number(v) => v.to_string(),
-                        serde_json::Value::Bool(v) => v.to_string(),
-                        _ => continue,
-                    };
-                    env_vars.push((key, val));
-                }
+        {
+            for (key, value) in map {
+                let val = match value {
+                    serde_json::Value::String(v) => v,
+                    serde_json::Value::Number(v) => v.to_string(),
+                    serde_json::Value::Bool(v) => v.to_string(),
+                    _ => continue,
+                };
+                env_vars.push((key, val));
             }
         }
 
@@ -180,7 +179,7 @@ pub fn decode_attestation_nonce_hex(value: &str) -> crate::error::Result<Vec<u8>
         return Ok(Vec::new());
     }
     let hex = trimmed.strip_prefix("0x").unwrap_or(trimmed);
-    if hex.len() % 2 != 0 {
+    if !hex.len().is_multiple_of(2) {
         return Err(crate::error::SandboxError::Validation(
             "attestation_nonce must be even-length hex".into(),
         ));
@@ -460,13 +459,11 @@ pub(crate) async fn wait_for_sidecar_health(
         if let (Ok(url), Ok(headers)) = (
             crate::http::build_url(sidecar_url, "/health"),
             crate::http::auth_headers(token),
-        ) {
-            if crate::http::send_json(reqwest::Method::GET, url, None, headers)
-                .await
-                .is_ok()
-            {
-                return Ok(());
-            }
+        ) && crate::http::send_json(reqwest::Method::GET, url, None, headers)
+            .await
+            .is_ok()
+        {
+            return Ok(());
         }
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     }

--- a/ui/src/lib/blueprints/abi-integration.test.ts
+++ b/ui/src/lib/blueprints/abi-integration.test.ts
@@ -185,13 +185,13 @@ describe('Cross-Blueprint Consistency', () => {
   });
 
   it('field count matches Rust struct field count for workflow jobs', () => {
-    // SandboxCreateRequest: 16 fields
+    // SandboxCreateRequest: 18 fields
     const sandboxCreate = getJobById('ai-agent-sandbox-blueprint', JOB_IDS.SANDBOX_CREATE)!;
-    expect(sandboxCreate.fields.filter(f => f.abiType).length).toBe(16);
+    expect(sandboxCreate.fields.filter(f => f.abiType).length).toBe(18);
 
-    // ProvisionRequest: 16 fields
+    // ProvisionRequest: 18 fields
     const instanceProvision = getJobById('ai-agent-instance-blueprint', INSTANCE_JOB_IDS.PROVISION)!;
-    expect(instanceProvision.fields.filter(f => f.abiType).length).toBe(16);
+    expect(instanceProvision.fields.filter(f => f.abiType).length).toBe(18);
 
     // WorkflowCreateRequest: 8 fields
     const instanceWorkflowCreate = getJobById('ai-agent-instance-blueprint', INSTANCE_JOB_IDS.WORKFLOW_CREATE)!;

--- a/ui/src/lib/blueprints/instance-blueprint.ts
+++ b/ui/src/lib/blueprints/instance-blueprint.ts
@@ -22,7 +22,8 @@ export function createInstanceJobs(opts?: {
     {
       // ABI: ProvisionRequest { name, image, stack, agent_identifier, env_json, metadata_json,
       //   ssh_enabled, ssh_public_key, web_terminal_enabled, max_lifetime_seconds,
-      //   idle_timeout_seconds, cpu_cores, memory_mb, disk_gb, tee_required, tee_type }
+      //   idle_timeout_seconds, cpu_cores, memory_mb, disk_gb, tee_required, tee_type,
+      //   attestation_nonce, capabilities_json }
       // Not an on-chain submitJob target — the encoded fields are passed as requestInputs
       // to requestService (Path B) or used by the operator's auto-provision decoder.
       id: INSTANCE_JOB_IDS.PROVISION,
@@ -59,6 +60,8 @@ export function createInstanceJobs(opts?: {
         { name: 'diskGb', label: 'Disk (GB)', type: 'number', defaultValue: 10, min: 1, max: 100, helperText: '10 GB typical for dev, 50+ for large models', abiType: 'uint64', abiParam: 'disk_gb' },
         { name: 'teeRequired', label: 'TEE Required', type: 'boolean', defaultValue: false, abiType: 'bool', abiParam: 'tee_required' },
         { name: 'teeType', label: 'TEE Type', type: 'select', defaultValue: '0', abiType: 'uint8', abiParam: 'tee_type', options: TEE_TYPE_OPTIONS },
+        { name: 'attestationNonce', label: 'Attestation Nonce', type: 'text', defaultValue: '', abiType: 'string', abiParam: 'attestation_nonce', internal: true },
+        { name: 'capabilitiesJson', label: 'Capabilities (JSON)', type: 'json', placeholder: '[]', defaultValue: '[]', abiType: 'string', abiParam: 'capabilities_json', internal: true },
       ],
     },
     {

--- a/ui/src/lib/blueprints/registry.test.ts
+++ b/ui/src/lib/blueprints/registry.test.ts
@@ -66,11 +66,11 @@ describe('Blueprint Registry', () => {
 // ── ABI Metadata Correctness ──
 
 describe('Blueprint ABI Metadata', () => {
-  it('sandbox create keeps 16 ABI-encoded fields', () => {
+  it('sandbox create keeps 18 ABI-encoded fields', () => {
     const job = getJobById('ai-agent-sandbox-blueprint', JOB_IDS.SANDBOX_CREATE)!;
     const fieldsWithAbi = job.fields.filter((f) => f.abiType);
     // Non-ABI UI-only helper fields may exist (for metadata shaping).
-    expect(fieldsWithAbi.length).toBe(16);
+    expect(fieldsWithAbi.length).toBe(18);
     expect(job.fields.some((f) => f.name === 'runtimeBackend' && !f.abiType)).toBe(true);
   });
 

--- a/ui/src/lib/blueprints/sandbox-blueprint.ts
+++ b/ui/src/lib/blueprints/sandbox-blueprint.ts
@@ -46,7 +46,7 @@ const SANDBOX_JOBS: JobDefinition[] = [
   {
     // ABI: SandboxCreateRequest { name, image, stack, agent_identifier, env_json, metadata_json,
     //   ssh_enabled, ssh_public_key, web_terminal_enabled, max_lifetime_seconds, idle_timeout_seconds,
-    //   cpu_cores, memory_mb, disk_gb, tee_required, tee_type }
+    //   cpu_cores, memory_mb, disk_gb, tee_required, tee_type, attestation_nonce, capabilities_json }
     id: JOB_IDS.SANDBOX_CREATE,
     name: 'sandbox_create',
     label: 'Create Sandbox',
@@ -82,6 +82,8 @@ const SANDBOX_JOBS: JobDefinition[] = [
       { name: 'diskGb', label: 'Disk (GB)', type: 'number', defaultValue: 10, min: 1, max: 100, helperText: '10 GB typical for dev, 50+ for large models', abiType: 'uint64', abiParam: 'disk_gb' },
       { name: 'teeRequired', label: 'TEE Required', type: 'boolean', defaultValue: false, abiType: 'bool', abiParam: 'tee_required' },
       { name: 'teeType', label: 'TEE Type', type: 'select', defaultValue: '0', abiType: 'uint8', abiParam: 'tee_type', options: TEE_TYPE_OPTIONS },
+      { name: 'attestationNonce', label: 'Attestation Nonce', type: 'text', defaultValue: '', abiType: 'string', abiParam: 'attestation_nonce', internal: true },
+      { name: 'capabilitiesJson', label: 'Capabilities (JSON)', type: 'json', placeholder: '[]', defaultValue: '[]', abiType: 'string', abiParam: 'capabilities_json', internal: true },
     ],
   },
   {

--- a/ui/src/routes/create.tsx
+++ b/ui/src/routes/create.tsx
@@ -86,6 +86,20 @@ function parsePortsInput(value: string): number[] {
     .filter((n) => n > 0 && n <= 65535);
 }
 
+function parseCapabilitiesJson(value: unknown): Set<string> {
+  if (Array.isArray(value)) {
+    return new Set(value.filter((item): item is string => typeof item === 'string'));
+  }
+  try {
+    const parsed = JSON.parse(String(value || '[]'));
+    return Array.isArray(parsed)
+      ? new Set(parsed.filter((item): item is string => typeof item === 'string'))
+      : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
 export default function CreatePage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -167,6 +181,7 @@ export default function CreatePage() {
 
   // Extra ports input (not an ABI field — merged into metadataJson before deploy)
   const [portsInput, setPortsInput] = useState('');
+  const allHarnessEnabled = parseCapabilitiesJson(values.capabilitiesJson).has('all_harness');
   const runtimeBackend = String(values.runtimeBackend || 'docker').toLowerCase();
   const supportsMetadataPorts = runtimeBackend !== 'firecracker';
   const selectedImage = String(values.image || '');
@@ -228,6 +243,7 @@ export default function CreatePage() {
     const nextValues: Record<string, unknown> = {
       ...values,
       metadataJson: JSON.stringify(metadata),
+      capabilitiesJson: allHarnessEnabled ? JSON.stringify(['all_harness']) : JSON.stringify([]),
       // Keep the deprecated ABI field pinned for backward-compatible encoding.
       webTerminalEnabled: true,
     };
@@ -239,7 +255,7 @@ export default function CreatePage() {
     }
 
     return nextValues;
-  }, [runtimeBackend, supportsMetadataPorts, values, portsInput]);
+  }, [runtimeBackend, supportsMetadataPorts, values, portsInput, allHarnessEnabled]);
 
   // Unified deploy hook — manages both submitJob and requestService paths
   const deploy = useCreateDeploy({ blueprint: selectedBlueprint, job: createJob, values: mergedValues, infra, validate, capacity });
@@ -367,6 +383,11 @@ export default function CreatePage() {
                   onChange={(next) => onChange('agentIdentifier', next)}
                 />
               )}
+
+              <AllHarnessCapabilityField
+                enabled={allHarnessEnabled}
+                onChange={(enabled) => onChange('capabilitiesJson', enabled ? JSON.stringify(['all_harness']) : JSON.stringify([]))}
+              />
 
               {configuredAgentIdentifier && (
                 <div className="mt-4 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2">
@@ -520,6 +541,35 @@ function AgentConfigurationField({
           </p>
         </div>
       )}
+    </div>
+  );
+}
+
+function AllHarnessCapabilityField({
+  enabled,
+  onChange,
+}: {
+  enabled: boolean;
+  onChange: (enabled: boolean) => void;
+}) {
+  return (
+    <div className="mt-6 pt-4 border-t border-cloud-elements-dividerColor">
+      <label className="flex items-start gap-3">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => onChange(e.target.checked)}
+          className="mt-0.5 h-4 w-4 rounded border-cloud-elements-borderColor bg-cloud-elements-background-depth-2"
+        />
+        <span className="space-y-1">
+          <span className="block text-xs font-display font-medium text-cloud-elements-textSecondary">
+            All-Harness Runtime
+          </span>
+          <span className="block text-[11px] text-cloud-elements-textTertiary">
+            Request the open-source runtime with Claude, Codex, opencode, Kimi, and Gemini harnesses available in the sandbox image.
+          </span>
+        </span>
+      </label>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add an all_harness sidecar capability and advertise the supported harness matrix through /api/capabilities
- pass backend_type through prompt/task operator API payloads so sidecars can select a concrete harness
- expose the all-harness option in the create/provision UI while preserving the 18-field ABI order
- pin public blueprint crates and remove branch=main dependency drift; align the pre-commit hook with rust-toolchain.toml
- clean existing Rust 1.91 clippy findings hit by the real pre-commit hook

## Verification
- cargo fmt --all --check
- cargo clippy --workspace -- -D warnings
- cargo test -p sandbox-runtime sidecar_capability_tests --features test-utils --locked
- cargo test -p sandbox-runtime test_capabilities_endpoint_includes_all_harness_runtime --features test-utils --locked
- cargo test -p sandbox-runtime test_build_agent_payload_context_json_without_max_turns_override --features test-utils --locked
- pnpm --dir ui typecheck
- pnpm --dir ui test -- create.test.tsx abi-integration.test.ts registry.test.ts agents.test.ts sandboxClient.test.ts --run