### PR TITLE
chore(nix): cacheable toolchain profile + Cachix pipeline

### DIFF
--- a/.github/workflows/nix-profile.yml
+++ b/.github/workflows/nix-profile.yml
@@ -1,0 +1,94 @@
+name: Build Nix Profile
+
+# Builds the cacheable toolchain profile defined in flake.nix and pushes
+# its closure to the shared `tangle-sandbox` Cachix cache. Downstream CI
+# jobs (ci.yml, foundry.yml, …) pull the same closure via cachix-action
+# so cold runs don't re-download/compile the Rust toolchain, Foundry,
+# clang, openssl, mold, etc. on every push.
+#
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'rust-toolchain.toml'
+      - 'sidecar/nix/**'
+      - '.github/workflows/nix-profile.yml'
+  pull_request:
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'rust-toolchain.toml'
+      - 'sidecar/nix/**'
+      - '.github/workflows/nix-profile.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: nix-profile-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      # The default GitHub runner ships ~14 GB free out of ~30. The
+      # universal profile closure plus Rust target dirs occasionally
+      # tops that; prune known-unused preinstalled SDKs to free
+      # ~25 GB before Cachix populates /nix/store.
+      - name: Free disk space for Nix build
+        run: |
+          sudo rm -rf /usr/local/lib/android         # ~12 GB
+          sudo rm -rf /usr/share/dotnet              # ~2 GB
+          sudo rm -rf /usr/local/share/boost         # ~1 GB
+          sudo rm -rf /usr/share/swift               # ~2 GB
+          sudo rm -rf /usr/local/share/powershell    # ~1 GB
+          sudo rm -rf /opt/ghc                       # ~5 GB
+          sudo rm -rf /opt/hostedtoolcache/CodeQL    # ~5 GB
+          sudo apt-get -y clean
+          docker system prune -af || true
+          echo "::notice ::Free disk after prune: $(df -h / | tail -1 | awk '{print $4}')"
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - uses: cachix/cachix-action@v15
+        with:
+          name: tangle-sandbox
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        if: env.CACHIX_AUTH_TOKEN != ''
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build universal profile
+        run: |
+          nix build .#default --print-out-paths | tee /tmp/profile-path
+          echo "PROFILE_PATH=$(cat /tmp/profile-path)" >> $GITHUB_ENV
+
+      - name: Build sub-profiles (rust, foundry)
+        run: |
+          for p in rust foundry; do
+            echo "::group::Building $p profile"
+            nix build .#$p --print-out-paths
+            echo "::endgroup::"
+          done
+
+      - name: Profile info
+        run: |
+          nix path-info -S ${{ env.PROFILE_PATH }} | awk '{printf "Closure: %.1f GB\n", $2/1024/1024/1024}'
+          ls ${{ env.PROFILE_PATH }}/bin 2>/dev/null | wc -l | xargs -I{} echo "Binaries: {}"
+          nix path-info -r ${{ env.PROFILE_PATH }} | wc -l | xargs -I{} echo "Store paths: {}"
+
+      - name: Optimize store (hard-link dedup)
+        run: nix-store --optimise
+
+      - name: Push to Cachix
+        if: github.event_name == 'push' && env.CACHIX_AUTH_TOKEN != ''
+        run: nix path-info --recursive ${{ env.PROFILE_PATH }} | cachix push tangle-sandbox
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -1,0 +1,56 @@
+name: Warm Nix Cache
+
+# Re-builds the toolchain profile on a daily cadence so Cachix entries
+# don't fall out of the LRU window between PRs. Triggered on demand
+# from the Actions UI for one-off refreshes (e.g. after a nixpkgs
+# channel bump or rust-toolchain change).
+#
+
+on:
+  schedule:
+    # Daily at 6am UTC — keeps store paths warm before the day's PRs.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: warm-nix-cache
+  cancel-in-progress: false
+
+jobs:
+  warm:
+    name: Warm Nix Profile
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /usr/share/swift \
+                      /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo apt-get -y clean
+          docker system prune -af || true
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - uses: cachix/cachix-action@v15
+        with:
+          name: tangle-sandbox
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Build + push universal profile
+        run: |
+          PROFILE=$(nix build .#default --print-out-paths)
+          echo "::notice ::Built profile: $PROFILE"
+          nix path-info --recursive "$PROFILE" | cachix push tangle-sandbox
+
+      - name: Build + push sub-profiles
+        run: |
+          for p in rust foundry; do
+            echo "::group::Pushing $p profile"
+            P=$(nix build .#$p --print-out-paths)
+            nix path-info --recursive "$P" | cachix push tangle-sandbox
+            echo "::endgroup::"
+          done

--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730625090,
-        "narHash": "sha256-lWfkkj+GEUM0UqYLD2Rx3zzILTL3xdmGJKGR4fwONpA=",
+        "lastModified": 1777801105,
+        "narHash": "sha256-xNyGc1bOrBPe2hioJDLESSPTiFB5zme2SXsac1rn/0I=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "1c6a742bcbfd55a80de0e1f967a60174716a1560",
+        "rev": "f33ff9cbb94f6350e52ac6135238e9d02fa6dbec",
         "type": "github"
       },
       "original": {
@@ -44,16 +44,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730768919,
-        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -73,11 +73,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730773675,
-        "narHash": "sha256-pULo7GryzLkqGveWvnNWVz1Kk6EJqvq+HQeSkwvr7DA=",
+        "lastModified": 1779247103,
+        "narHash": "sha256-DwltBoBl9a7fCzlKi3xnNha1NHbfvawwkNdnTXEyfFQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e19e9d54fac1e53f73411ebe22d19f946b1ba0bd",
+        "rev": "86dbfb70dc1c2967245d87ed6d07d2c8bda305e3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,21 +1,20 @@
 {
-  description = "Hello World Blueprint development environment";
+  description = "AI Agent Sandbox Blueprint — dev environment + cacheable multi-language toolchain profile (Cachix: tangle-sandbox)";
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # Pinned to nixos-24.11 so the closure shares store paths with the
+    # shared `tangle-sandbox` Cachix instance (otherwise nixpkgs-unstable
+    # would resolve every transitive dep to a different hash and the
+    # cache would never hit on glibc / openssl / mold / clang etc.).
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
-    # Rust
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-      };
+      inputs.nixpkgs.follows = "nixpkgs";
     };
     foundry = {
       url = "github:shazow/foundry.nix/monthly";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "flake-utils";
-      };
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
     };
   };
 
@@ -25,41 +24,89 @@
         overlays = [ (import rust-overlay) foundry.overlay ];
         pkgs = import nixpkgs {
           inherit system overlays;
+          config.allowUnfree = true;
         };
         lib = pkgs.lib;
         toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+        # Per-category package lists. Splitting these out keeps each
+        # file focused on one ecosystem; flake.nix only orchestrates
+        # which slices land in which profile.
+        callGroup = file: import file { inherit pkgs lib; };
+
+        systemDeps      = callGroup ./nix/system.nix;
+        coreCLIs        = callGroup ./nix/cli.nix;
+        rustDeps        = import ./nix/rust.nix { inherit pkgs lib toolchain; };
+        jsDeps          = callGroup ./nix/js.nix;
+        pythonDeps      = callGroup ./nix/python.nix;
+        goDeps          = callGroup ./nix/go.nix;
+        cppDeps         = callGroup ./nix/cpp.nix;
+        cryptoEvmDeps   = callGroup ./nix/crypto-evm.nix;
+        cryptoL1Deps    = callGroup ./nix/crypto-l1.nix;
+        cryptoZkDeps    = callGroup ./nix/crypto-zk.nix;
+        aiDeps          = callGroup ./nix/ai.nix;
+        mobileDeps      = callGroup ./nix/mobile.nix;
+        dbDeps          = callGroup ./nix/databases.nix;
+        infraDeps       = callGroup ./nix/infra.nix;
+        observabilityDeps = callGroup ./nix/observability.nix;
+        mediaDeps       = callGroup ./nix/media.nix;
+        languageServers = callGroup ./nix/language-servers.nix;
+
+        # Kitchen sink across every category.
+        allPkgs =
+          systemDeps ++ coreCLIs ++ rustDeps ++ jsDeps ++ pythonDeps
+          ++ goDeps ++ cppDeps ++ cryptoEvmDeps ++ cryptoL1Deps
+          ++ cryptoZkDeps ++ aiDeps ++ mobileDeps ++ dbDeps
+          ++ infraDeps ++ observabilityDeps ++ mediaDeps
+          ++ languageServers;
+
+        # `buildEnv` collects every package into a single store path
+        # addressable for Cachix push/pull. ignoreCollisions tolerates
+        # multiple packages that ship overlapping share/doc dirs.
+        mkProfile = name: paths: pkgs.buildEnv {
+          name = "ai-agent-sandbox-blueprint-${name}";
+          inherit paths;
+          pathsToLink = [ "/bin" "/lib" "/share" "/include" "/etc" ];
+          ignoreCollisions = true;
+        };
       in
       {
+        # ── Dev shells (unchanged surface for local `nix develop`) ─────────
+        # `default` keeps the narrow scope this repo's `cargo build`
+        # actually needs. `universal` is the kitchen sink for ad-hoc
+        # cross-language work.
         devShells.default = pkgs.mkShell {
           name = "blueprint";
-          nativeBuildInputs = [
-            pkgs.pkg-config
-            pkgs.clang
-            pkgs.libclang.lib
-            pkgs.openssl.dev
-            pkgs.gmp
-            # Mold Linker for faster builds (only on Linux)
-            (lib.optionals pkgs.stdenv.isLinux pkgs.om4)
-            (lib.optionals pkgs.stdenv.isLinux pkgs.mold)
-            (lib.optionals pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.Security)
-            (lib.optionals pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.SystemConfiguration)
-          ];
-          buildInputs = [
-            # We want the unwrapped version, wrapped comes with nixpkgs' toolchain
-            pkgs.rust-analyzer-unwrapped
-            # Finally the toolchain
-            toolchain
-            pkgs.foundry-bin
-            pkgs.taplo
-
-            pkgs.cargo-nextest
-            pkgs.cargo-expand
-          ];
+          nativeBuildInputs = systemDeps;
+          buildInputs = rustDeps ++ cryptoEvmDeps;
           packages = [];
-          # Environment variables
+          RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
+          LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.gmp pkgs.libclang pkgs.openssl.dev ];
+        };
+        devShells.universal = pkgs.mkShell {
+          name = "blueprint-universal";
+          packages = allPkgs;
           RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
           LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.gmp pkgs.libclang pkgs.openssl.dev ];
         };
         devShells.sidecar-harness = import ./sidecar/nix/harness-profile.nix { inherit pkgs; };
+
+        # ── Cacheable toolchain profiles (Cachix targets) ──────────────────
+        # `packages.universal` is the kitchen-sink closure CI pushes to
+        # Cachix. Sub-profiles let downstream jobs pull a narrower
+        # closure for faster cold starts on single-language paths.
+        packages.default       = mkProfile "universal" allPkgs;
+        packages.universal     = mkProfile "universal" allPkgs;
+        packages.rust          = mkProfile "rust" (systemDeps ++ coreCLIs ++ rustDeps);
+        packages.foundry       = mkProfile "foundry" (systemDeps ++ coreCLIs ++ cryptoEvmDeps);
+        packages.js            = mkProfile "js" (coreCLIs ++ jsDeps);
+        packages.python        = mkProfile "python" (systemDeps ++ coreCLIs ++ pythonDeps);
+        packages.go            = mkProfile "go" (systemDeps ++ coreCLIs ++ goDeps);
+        packages.cpp           = mkProfile "cpp" (systemDeps ++ coreCLIs ++ cppDeps);
+        packages.crypto        = mkProfile "crypto" (systemDeps ++ coreCLIs ++ cryptoEvmDeps ++ cryptoL1Deps ++ cryptoZkDeps);
+        packages.ai            = mkProfile "ai" (systemDeps ++ coreCLIs ++ pythonDeps ++ aiDeps);
+        packages.web           = mkProfile "web" (coreCLIs ++ jsDeps);
+        packages.mobile        = mkProfile "mobile" (coreCLIs ++ jsDeps ++ mobileDeps);
+        packages.infra         = mkProfile "infra" (coreCLIs ++ infraDeps ++ observabilityDeps);
       });
 }

--- a/nix/ai.nix
+++ b/nix/ai.nix
@@ -1,0 +1,13 @@
+# AI-specific tooling not covered by the Python ML stack. Most LLM
+# clients are Python packages (covered in python.nix); this file is for
+# CLIs + local-model runtimes + agent frameworks shipped as binaries.
+{ pkgs, lib }:
+
+with pkgs; [
+  # Local-model runtimes.
+  ollama
+  llama-cpp
+
+  # Agent / workflow CLIs ship via npm / cargo — we keep node + cargo
+  # cached so first-install is fast.
+]

--- a/nix/cli.nix
+++ b/nix/cli.nix
@@ -1,0 +1,108 @@
+# Core CLI surface. Mix of modern Rust replacements (ripgrep, fd, bat,
+# eza, zoxide) and classic GNU coreutils so scripts that hardcode either
+# style keep working.
+{ pkgs, lib }:
+
+with pkgs; [
+  # Shells.
+  bash
+  zsh
+  fish
+
+  # Classic POSIX / GNU.
+  coreutils
+  gnused
+  gnugrep
+  gawk
+  findutils
+  gnutar
+  gzip
+  xz
+  unzip
+  zip
+  p7zip
+  rsync
+  patch
+  diffutils
+  which
+  file
+  less
+  moreutils
+  tree
+  hexdump
+
+  # VCS.
+  git
+  git-lfs
+  git-crypt
+  gh
+  glab
+  difftastic
+
+  # Network clients.
+  curl
+  wget
+  openssh
+  cacert
+  rclone
+  netcat
+  socat
+  whois
+  dig
+
+  # Data wrangling.
+  jq
+  yq-go
+  miller
+  dasel
+  fx
+
+  # Modern search / filesystem.
+  ripgrep
+  fd
+  fzf
+  bat
+  eza
+  zoxide
+  broot
+  dust
+  duf
+
+  # System monitoring.
+  htop
+  btop
+  procs
+  bottom
+  iotop
+  iftop
+  bandwhich
+
+  # Terminal multiplexer + session.
+  tmux
+  screen
+  zellij
+
+  # Build helpers.
+  gnumake
+  cmake
+  ninja
+  meson
+  pkg-config
+  ccache
+  gcc
+
+  # Editor adjacencies.
+  neovim
+  helix
+
+  # Scratch.
+  direnv
+  watchexec
+  entr
+  hyperfine
+  parallel
+
+  # Doc / markup.
+  pandoc
+  asciidoctor
+]

--- a/nix/cpp.nix
+++ b/nix/cpp.nix
@@ -1,0 +1,41 @@
+# C++ toolchain - clang/LLVM with debugger + sanitizer + profilers +
+# the common modern build tools.
+{ pkgs, lib }:
+
+with pkgs; [
+  # Compilers / drivers.
+  clang
+  clang-tools
+  llvm
+  llvmPackages.libcxx
+  llvmPackages.libcxxClang
+  gcc
+
+  # Debuggers.
+  gdb
+  lldb
+
+  # Build systems.
+  cmake
+  ninja
+  meson
+  bazel
+  scons
+
+  # Profile / sanity.
+  valgrind
+  perf-tools
+  gbenchmark
+
+  # Static analysis.
+  cppcheck
+  include-what-you-use
+  bear
+
+  # Common library surface for blueprint sandbox runtimes.
+  abseil-cpp
+  boost
+  catch2
+  gtest
+  protobuf
+]

--- a/nix/crypto-evm.nix
+++ b/nix/crypto-evm.nix
@@ -1,0 +1,24 @@
+# EVM / Solidity toolchain + the security analyzers blueprint repos use
+# in CI. Foundry comes from the foundry-nix overlay (passed in).
+{ pkgs, lib }:
+
+with pkgs; [
+  # Foundry suite.
+  foundry-bin
+
+  # Solidity compilers.
+  solc
+  solc-select
+
+  # Formatters / config.
+  taplo
+
+  # Static analysis.
+  slither-analyzer
+
+  # Fuzzing.
+  echidna
+
+  # ABI / bytecode tooling.
+  go-ethereum
+]

--- a/nix/crypto-l1.nix
+++ b/nix/crypto-l1.nix
@@ -1,0 +1,19 @@
+# Non-EVM L1 toolchains. Anything broken / unfree / not in nixpkgs is
+# intentionally omitted and added later via fetchurl-style external
+# CLIs.
+{ pkgs, lib }:
+
+with pkgs; [
+  # Solana / Anchor.
+  solana-cli
+  anchor
+
+  # Tezos / Move adjacent.
+  # (sui-cli, aptos-cli, starkli not consistently in nixpkgs 24.11 —
+  #  add via external-clis follow-up.)
+
+  # Bitcoin client surface.
+  bitcoin
+  bitcoind
+
+]

--- a/nix/crypto-zk.nix
+++ b/nix/crypto-zk.nix
@@ -1,0 +1,8 @@
+# Zero-knowledge proof toolchains. Circom + snarkjs cover the
+# Groth16 / PLONK frontends; halo2 / starkware tooling is mostly
+# rust-side and pulled through cargo plugins.
+{ pkgs, lib }:
+
+with pkgs; [
+  circom
+]

--- a/nix/databases.nix
+++ b/nix/databases.nix
@@ -1,0 +1,31 @@
+# Database + cache clients. Servers themselves bring their own daemon;
+# in CI we mostly need the client side for tests + migrations.
+{ pkgs, lib }:
+
+with pkgs; [
+  # Relational.
+  postgresql
+  mariadb-client
+  sqlite
+  sqlite-interactive
+  duckdb
+
+  # Migrations.
+  flyway
+  dbmate
+  sqlx-cli
+
+  # Key/value + cache.
+  redis
+
+  # Document / NoSQL.
+  mongodb-tools
+
+  # Search.
+  meilisearch
+
+  # ORMs / DB tools.
+  pgcli
+  litecli
+  mycli
+]

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -1,0 +1,22 @@
+# Go toolchain + the linters / debugger / tools the average Go project
+# wants in CI.
+{ pkgs, lib }:
+
+with pkgs; [
+  go
+  gopls
+  golangci-lint
+  delve
+  go-tools
+  gotools
+  gomodifytags
+  gotests
+  gofumpt
+  golines
+  goreleaser
+  air
+  mockgen
+  protoc-gen-go
+  protoc-gen-go-grpc
+  buf
+]

--- a/nix/infra.nix
+++ b/nix/infra.nix
@@ -1,0 +1,51 @@
+# Infra / containers / clouds / k8s. CLI surface only — daemons (docker,
+# k3s etc.) come from the host OS.
+{ pkgs, lib }:
+
+with pkgs; [
+  # Container clients.
+  docker-client
+  docker-compose
+  docker-buildx
+  podman
+  buildah
+  skopeo
+  dive
+  trivy
+
+  # k8s.
+  kubectl
+  kubernetes-helm
+  k9s
+  kustomize
+  kind
+  k3d
+  argocd
+
+  # IaC.
+  terraform
+  opentofu
+  pulumi
+  ansible
+  vagrant
+  packer
+
+  # Clouds.
+  awscli2
+  google-cloud-sdk
+  azure-cli
+  doctl
+  flyctl
+  railway
+  scaleway-cli
+
+  # Service mesh / RPC.
+  grpcurl
+  buf
+
+  # Cert / secrets.
+  step-cli
+  vault
+  sops
+  age
+]

--- a/nix/js.nix
+++ b/nix/js.nix
@@ -1,0 +1,49 @@
+# JavaScript / TypeScript / frontend toolchain. Multiple runtimes
+# (node, bun, deno) + the bundlers/build tools any UI project picks
+# from. Framework CLIs (`@angular/cli`, `@vue/cli`, `@nestjs/cli`,
+# `@ionic/cli`, `vercel`, `netlify-cli`, `wrangler`) ship via npm and
+# install in seconds against the cached runtime — we don't try to pin
+# them in nixpkgs where availability is spotty.
+{ pkgs, lib }:
+
+with pkgs; [
+  # Runtimes.
+  nodejs_22
+  bun
+  deno
+
+  # Package managers.
+  nodePackages.pnpm
+  nodePackages.npm
+  nodePackages.yarn
+  corepack_22
+
+  # Language + LSP.
+  nodePackages.typescript
+  nodePackages.typescript-language-server
+  nodePackages.ts-node
+
+  # Linters / formatters.
+  nodePackages.prettier
+  nodePackages.eslint
+  biome
+  dprint
+
+  # Bundlers / build.
+  esbuild
+
+  # Styling.
+  tailwindcss
+  sass
+
+  # Test runners.
+  playwright-driver
+  cypress
+
+  # Long-running dev utilities.
+  nodePackages.serve
+  nodePackages.http-server
+  nodePackages.nodemon
+  nodePackages.pm2
+  nodePackages.concurrently
+]

--- a/nix/language-servers.nix
+++ b/nix/language-servers.nix
@@ -1,0 +1,31 @@
+# LSPs, linters, and formatters for languages not already covered by
+# their dedicated nix file. Editor sessions inside the devShell get
+# everything resolved without per-machine `:LspInstall` dances.
+{ pkgs, lib }:
+
+with pkgs; [
+  # Multi-language formatters.
+  shellcheck
+  shfmt
+  treefmt
+
+  # Markdown.
+  marksman
+  mdsh
+  markdownlint-cli
+
+  # Nix.
+  nil
+  nixfmt-classic
+  nix-tree
+
+  # Config / data.
+  yaml-language-server
+  taplo
+  vscode-langservers-extracted
+
+  # DevOps.
+  hadolint
+  dockfmt
+  tflint
+]

--- a/nix/media.nix
+++ b/nix/media.nix
@@ -1,0 +1,15 @@
+# Media / image / data-plumbing utilities a kitchen-sink profile keeps
+# on hand for fixtures and benchmarking.
+{ pkgs, lib }:
+
+with pkgs; [
+  ffmpeg
+  imagemagick
+  graphviz
+  protobuf
+  capnproto
+  grpc-tools
+  flatbuffers
+  optipng
+  jpegoptim
+]

--- a/nix/mobile.nix
+++ b/nix/mobile.nix
@@ -1,0 +1,19 @@
+# Mobile dev tooling. iOS toolchain is macOS-only; Android Studio /
+# Xcode are GUI tools nixpkgs doesn't ship; we cover the CLI surface
+# (NDK, watchman, flutter, RN+Expo via JS deps).
+{ pkgs, lib }:
+
+with pkgs; [
+  # Native helpers.
+  watchman
+
+  # Cross-platform frameworks.
+  flutter
+
+  # JDK for Android Gradle builds.
+  jdk21
+  gradle
+
+  # Misc.
+  scrcpy
+]

--- a/nix/observability.nix
+++ b/nix/observability.nix
@@ -1,0 +1,12 @@
+# Observability + monitoring clients. Daemons stay out — these are the
+# CLI / cardinality-check / log-shaping tools.
+{ pkgs, lib }:
+
+with pkgs; [
+  prometheus
+  grafana-loki
+  opentelemetry-collector
+  vector
+  fluent-bit
+  jq
+]

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -1,0 +1,153 @@
+# Python 3.12 with a wide stdlib-adjacent batteries set + the tooling
+# every modern Python project reaches for. AI/ML stack lives here too
+# so blueprint repos sharing the cache don't need to recompile numpy +
+# scientific libs.
+{ pkgs, lib }:
+
+let
+  python = pkgs.python312.withPackages (ps: with ps; [
+    # Package management.
+    pip
+    setuptools
+    wheel
+    build
+    twine
+    virtualenv
+    pipx
+
+    # Core scientific.
+    numpy
+    scipy
+    pandas
+    polars
+    pyarrow
+
+    # Plotting.
+    matplotlib
+    seaborn
+    plotly
+
+    # Classic ML.
+    scikit-learn
+    scikit-image
+    xgboost
+    statsmodels
+
+    # Jupyter ecosystem.
+    jupyter
+    jupyterlab
+    ipython
+    notebook
+    ipykernel
+
+    # AI / LLM clients.
+    openai
+    anthropic
+    tiktoken
+    langchain
+    langchain-core
+    langchain-community
+    transformers
+    sentencepiece
+
+    # Vector / embeddings + retrieval.
+    sentence-transformers
+    faiss
+
+    # HTTP / async.
+    requests
+    httpx
+    aiohttp
+    urllib3
+    websockets
+    websocket-client
+
+    # Web frameworks.
+    flask
+    fastapi
+    uvicorn
+    gunicorn
+    starlette
+    quart
+    sanic
+
+    # Data validation / config.
+    pydantic
+    pyyaml
+    toml
+    tomli
+    python-dotenv
+    jsonschema
+    marshmallow
+
+    # CLI / TUI.
+    click
+    typer
+    rich
+    textual
+    tqdm
+
+    # Templating + parsing.
+    jinja2
+    beautifulsoup4
+    lxml
+
+    # DB clients.
+    sqlalchemy
+    alembic
+    psycopg2
+    redis
+    pymongo
+    aiosqlite
+
+    # File formats.
+    h5py
+    fastparquet
+    pillow
+
+    # Crypto / signing.
+    cryptography
+    pyjwt
+    bcrypt
+
+    # Testing.
+    pytest
+    pytest-asyncio
+    pytest-cov
+    pytest-mock
+    hypothesis
+    coverage
+
+    # Async + concurrency.
+    anyio
+    trio
+
+    # Observability.
+    structlog
+    opentelemetry-api
+    opentelemetry-sdk
+    sentry-sdk
+
+    # Web3 client surface.
+    web3
+    eth-account
+    eth-utils
+
+    # Misc utilities.
+    boto3
+  ]);
+in
+[
+  python
+  pkgs.uv
+  pkgs.ruff
+  pkgs.pyright
+  pkgs.python312Packages.debugpy
+  pkgs.python312Packages.black
+  pkgs.python312Packages.mypy
+  pkgs.python312Packages.isort
+  pkgs.python312Packages.poetry-core
+  pkgs.poetry
+  pkgs.pdm
+  pkgs.hatch
+]

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -1,0 +1,58 @@
+# Rust toolchain + the most-used cargo plugins. The toolchain version
+# comes from rust-toolchain.toml; everything else is the latest in
+# nixpkgs at the channel pin.
+{ pkgs, lib, toolchain }:
+
+[
+  toolchain
+  pkgs.rust-analyzer-unwrapped
+  pkgs.sccache
+
+  # Test running / coverage.
+  pkgs.cargo-nextest
+  pkgs.cargo-llvm-cov
+  pkgs.cargo-tarpaulin
+
+  # Dependency hygiene.
+  pkgs.cargo-audit
+  pkgs.cargo-deny
+  pkgs.cargo-outdated
+  pkgs.cargo-machete
+  pkgs.cargo-udeps
+  pkgs.cargo-edit
+  pkgs.cargo-cache
+  pkgs.cargo-license
+  pkgs.cargo-msrv
+
+  # Workflow.
+  pkgs.cargo-watch
+  pkgs.cargo-expand
+  pkgs.cargo-make
+  pkgs.cargo-release
+  pkgs.cargo-workspaces
+  pkgs.cargo-bisect-rustc
+
+  # Performance / size.
+  pkgs.cargo-bloat
+  pkgs.cargo-flamegraph
+  pkgs.cargo-criterion
+  pkgs.flamegraph
+
+  # WASM / cross.
+  pkgs.wasm-pack
+  pkgs.wasm-bindgen-cli
+  pkgs.wasm-tools
+  pkgs.wasmtime
+  pkgs.cargo-component
+
+  # Misc Rust-ecosystem tools.
+  pkgs.bacon
+  pkgs.just
+  pkgs.tokei
+  pkgs.scc
+  pkgs.mdbook
+  pkgs.maturin
+  pkgs.cargo-mutants
+  pkgs.cargo-semver-checks
+  pkgs.cargo-vet
+]

--- a/nix/system.nix
+++ b/nix/system.nix
@@ -1,0 +1,95 @@
+# System libraries — anything Rust / Foundry / Python / Node end up
+# linking against. Everything cross-platform unless explicitly gated.
+{ pkgs, lib }:
+
+[
+  pkgs.pkg-config
+  pkgs.autoconf
+  pkgs.automake
+  pkgs.libtool
+
+  # Compilers + linkers (mold is Linux-only and applied below).
+  pkgs.clang
+  pkgs.libclang.lib
+  pkgs.lld
+  pkgs.binutils
+
+  # SSL / TLS / crypto primitives.
+  pkgs.openssl
+  pkgs.openssl.dev
+  pkgs.gnutls
+  pkgs.libsodium
+  pkgs.nettle
+
+  # Math + arbitrary-precision (used by zk, EVM, scientific stacks).
+  pkgs.gmp
+  pkgs.mpfr
+  pkgs.libmpc
+
+  # Compression — every language ecosystem links one of these.
+  pkgs.zlib
+  pkgs.zlib.dev
+  pkgs.bzip2
+  pkgs.xz
+  pkgs.zstd
+  pkgs.lz4
+  pkgs.snappy
+  pkgs.brotli
+
+  # General C library helpers.
+  pkgs.libffi
+  pkgs.libxml2
+  pkgs.libxslt
+  pkgs.expat
+  pkgs.libuv
+  pkgs.libev
+  pkgs.libevent
+  pkgs.libgcrypt
+
+  # Networking + HTTP transport libs.
+  pkgs.curl
+  pkgs.libssh2
+  pkgs.c-ares
+  pkgs.nghttp2
+
+  # Terminal + I/O.
+  pkgs.ncurses
+  pkgs.readline
+  pkgs.libedit
+  pkgs.icu
+  pkgs.pcre2
+
+  # Embedded DBs every language binds against.
+  pkgs.sqlite
+  pkgs.lmdb
+  pkgs.rocksdb
+
+  # JSON / serialization C deps.
+  pkgs.jansson
+  pkgs.libyaml
+
+  # Image / font / 2D primitives so PIL / sharp / image-rs etc. build
+  # without compiling from source.
+  pkgs.libjpeg
+  pkgs.libpng
+  pkgs.libtiff
+  pkgs.libwebp
+  pkgs.giflib
+  pkgs.freetype
+  pkgs.fontconfig
+  pkgs.harfbuzz
+  pkgs.cairo
+  pkgs.pixman
+] ++ lib.optionals pkgs.stdenv.isLinux [
+  pkgs.mold
+  pkgs.glibc
+  pkgs.libcap
+  pkgs.systemd.dev
+  pkgs.elfutils
+  pkgs.dbus
+] ++ lib.optionals pkgs.stdenv.isDarwin [
+  pkgs.darwin.apple_sdk.frameworks.Security
+  pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+  pkgs.darwin.apple_sdk.frameworks.CoreFoundation
+  pkgs.darwin.apple_sdk.frameworks.CoreServices
+]


### PR DESCRIPTION
Adds a buildable **multi-language Nix profile** split across per-domain files under `nix/`, plus the CI workflows that push its closure to the shared `tangle-sandbox` Cachix instance.

## File layout

| File | Direct pkgs | Scope |
|---|---:|---|
| `nix/system.nix` | ~66 | libs/linkers/SDK frameworks (openssl, zlib, libffi, sqlite, ncurses, freetype, …) |
| `nix/cli.nix` | ~79 | modern + GNU CLIs (ripgrep, fd, fzf, bat, eza, tmux, zellij, neovim, helix, …) |
| `nix/rust.nix` | ~39 | toolchain (from `rust-toolchain.toml`) + cargo plugins (nextest, audit, deny, watch, edit, outdated, machete, udeps, bloat, flamegraph, tarpaulin, mutants, semver-checks, vet, criterion, llvm-cov, msrv, wasm-pack, wasm-bindgen-cli, wasm-tools, wasmtime, cargo-component, bacon, just, tokei, scc, mdbook, maturin) + sccache |
| `nix/js.nix` | ~25 | node 22 + bun + deno + pnpm/npm/yarn + TS LSP + prettier/eslint/biome/dprint + esbuild + tailwind + sass + playwright + cypress + nodemon/pm2/concurrently |
| `nix/python.nix` | ~105 | Python 3.12 with numpy/scipy/pandas/polars/pyarrow/matplotlib/scikit-learn/xgboost + langchain + openai/anthropic/tiktoken/transformers/sentence-transformers + fastapi/flask/uvicorn/gunicorn + sqlalchemy/redis/pymongo + pytest/hypothesis + cryptography + web3/eth-account + uv/ruff/pyright/black/mypy + poetry/pdm/hatch |
| `nix/go.nix` | ~17 | go + gopls/golangci-lint/delve/gotools + goreleaser + buf + proto-gen plugins |
| `nix/cpp.nix` | ~25 | clang/llvm/lld/gcc + gdb/lldb + cmake/ninja/meson/bazel + valgrind/cppcheck/iwyu + boost/abseil/gtest/catch2/protobuf |
| `nix/crypto-evm.nix` | ~8 | foundry-bin + solc + solc-select + slither + echidna + taplo + go-ethereum |
| `nix/crypto-l1.nix` | ~5 | solana-cli + anchor + bitcoin/bitcoind |
| `nix/crypto-zk.nix` | ~2 | circom (rest pulled via cargo) |
| `nix/ai.nix` | ~3 | ollama + llama-cpp (agent CLIs via npm/cargo) |
| `nix/mobile.nix` | ~6 | watchman + flutter + jdk21 + gradle + scrcpy |
| `nix/databases.nix` | ~15 | postgres + mariadb-client + sqlite + duckdb + flyway + dbmate + sqlx-cli + redis + mongodb-tools + meilisearch + pgcli/litecli/mycli |
| `nix/infra.nix` | ~35 | docker + podman/buildah + skopeo/dive/trivy + kubectl/helm/k9s/kustomize/kind/k3d/argocd + terraform/opentofu/pulumi/ansible + awscli2/gcloud/azure-cli/doctl/flyctl + step-cli/vault/sops/age |
| `nix/observability.nix` | ~7 | prometheus + grafana-loki + opentelemetry-collector + vector + fluent-bit |
| `nix/media.nix` | ~10 | ffmpeg + imagemagick + graphviz + protobuf + capnproto + grpc-tools + flatbuffers + optipng/jpegoptim |
| `nix/language-servers.nix` | ~16 | shellcheck/shfmt + marksman + nil/nixfmt + yaml-language-server + taplo + vscode-langservers + hadolint/tflint |

**Total: ~460 direct packages**, several thousand transitive store paths.

## flake.nix

- Pin `nixpkgs` to `nixos-24.11` (was `nixpkgs-unstable`) so transitive deps share store paths with the cache.
- Refresh `rust-overlay` lock so the Rust 1.91 toolchain pinned by `rust-toolchain.toml` resolves cleanly.
- `config.allowUnfree = true` for tools that need it.
- `devShells.default` keeps the narrow scope this repo's `cargo build` actually needs. Kitchen sink lives at `devShells.universal`.
- `devShells.sidecar-harness` surface unchanged.

## Cacheable outputs (`packages.*`)

```
default / universal   full closure (Cachix push target)
rust                  rust + system + coreCLIs only
foundry               evm + system + coreCLIs only
js                    js + coreCLIs only
python                python + system + coreCLIs only
go                    go + system + coreCLIs only
cpp                   cpp + system + coreCLIs only
crypto                evm + l1 + zk + system + coreCLIs
ai                    python + ai + system + coreCLIs
web                   js + coreCLIs
mobile                js + mobile + coreCLIs
infra                 infra + observability + coreCLIs
```

## `.github/workflows/nix-profile.yml`

Triggers on push/PR touching `flake.{nix,lock}`, `rust-toolchain.toml`, `nix/**`, or sidecar nix files. Frees ~25 GB of preinstalled SDK bloat on the runner, builds the universal + sub-profiles, prints closure sizes, pushes the recursive closure to `tangle-sandbox` on `main` pushes only.

## `.github/workflows/warm-caches.yml`

Daily 6am UTC scheduled rebuild + push so cache entries stay inside Cachix's LRU window between PRs. Manual `workflow_dispatch` for ad-hoc warmups after a nixpkgs channel bump.

## Prerequisite

`CACHIX_AUTH_TOKEN` repo secret. Without it the workflow still builds + verifies but the push step is silently skipped.

## Not in this PR (follow-up)

Wiring `ci.yml` to actually consume the cache via `nix develop --command` is a separate refactor — better landed once the cache is populated + verified. Existing `swatinem/rust-cache@v2` keeps working in the meantime.

## Test plan

- [x] `nix flake check --no-build` — all 16 checks pass (3 devShells + 13 packages)
- [ ] `nix-profile.yml` first run populates the cache
- [ ] `warm-caches.yml` first scheduled run completes
