### PR TITLE
Expose AI Agent Sandbox app metadata

### DIFF
--- a/metadata/blueprint-metadata.json
+++ b/metadata/blueprint-metadata.json
@@ -11,13 +11,18 @@
   "blueprintUi": {
     "displayName": "AI Agent Sandbox",
     "description": "Provision attested AI agent sandboxes with sidecar capabilities, session-scoped budgets, and live execution traces.",
+    "slug": "ai-agent-sandbox",
     "requestedSlug": "ai-agent-sandbox",
     "publisher": {
       "name": "Tangle Network",
       "namespace": "tangle",
-      "verified": false
+      "verified": true,
+      "verification": "verified"
     },
     "resources": {
+      "serviceNoun": "sandbox fleet",
+      "resourceNoun": "agent",
+      "resourceRoute": "agents",
       "serviceLabel": "Sandbox fleet",
       "itemLabel": "Agent",
       "itemRoute": "agents"


### PR DESCRIPTION
## Summary
- expose `slug: ai-agent-sandbox` for Cloud app discovery
- mark the Tangle publisher metadata as verified
- add parser-compatible resource nouns/routes while keeping existing display labels

## Verification
- `jq empty metadata/blueprint-metadata.json`
- inspected `blueprintUi` metadata shape with `jq`

Companion dapp support PR: https://github.com/tangle-network/dapp/pull/3217
