### PR TITLE
fix(metadata): point Base Sepolia iframe contract at deployed Tangle proxy

### DIFF
--- a/metadata/blueprint-metadata.json
+++ b/metadata/blueprint-metadata.json
@@ -47,7 +47,10 @@
       "label": "Open Agent Sandbox",
       "iframe": {
         "appId": "agent-sandbox",
-        "allowedChainIds": [31337, 84532],
+        "allowedChainIds": [
+          31337,
+          84532
+        ],
         "contracts": [
           {
             "chainId": 31337,
@@ -55,7 +58,7 @@
           },
           {
             "chainId": 84532,
-            "address": "0x1be58d12620ecc8ba9d780feec2596510d75a933"
+            "address": "0xC9b0716a187072be0f38A5D972392C6479b9Cfe3"
           }
         ],
         "messages": [


### PR DESCRIPTION
The `blueprintUi.externalApp.iframe.contracts[chainId=84532].address` field carried a stale placeholder (`0x1be58d12…`) from a prior Tangle deployment that no longer exists. Tangle is now live on Base Sepolia at `0xC9b0716a187072be0f38A5D972392C6479b9Cfe3` — update the metadata so iframe grants resolve to the actual deployed contract.

LocalTestnet (chainId 31337) address is unchanged.

Required for Tangle Cloud to resolve the AI Agent Sandbox app surface against the live deployment.