### PR TITLE
ci(sidecar): publish retained all-harness image

### DIFF
--- a/.github/workflows/sidecar-image.yml
+++ b/.github/workflows/sidecar-image.yml
@@ -18,10 +18,6 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      sidecar_base_image:
-        description: 'Override the sidecar server base image. Defaults to repository variable BLUEPRINT_SIDECAR_SERVER_IMAGE.'
-        required: false
-        type: string
       prune_sha_versions_to_keep:
         description: 'How many all-harness-<sha> GHCR versions to keep after publish.'
         required: false
@@ -72,14 +68,8 @@ jobs:
 
       - name: Resolve image tags
         id: tags
-        env:
-          SIDECAR_BASE_IMAGE: ${{ inputs.sidecar_base_image || vars.BLUEPRINT_SIDECAR_SERVER_IMAGE }}
         run: |
           set -euo pipefail
-          if [ -z "$SIDECAR_BASE_IMAGE" ]; then
-            echo "BLUEPRINT_SIDECAR_SERVER_IMAGE repository variable or workflow_dispatch sidecar_base_image input is required" >&2
-            exit 1
-          fi
 
           image="ghcr.io/tangle-network/blueprint-sidecar"
           {
@@ -98,7 +88,6 @@ jobs:
 
           {
             echo "image=${image}"
-            echo "base_image=${SIDECAR_BASE_IMAGE}"
             echo "tags<<EOF"
             cat /tmp/sidecar-tags.txt
             echo "EOF"
@@ -117,7 +106,6 @@ jobs:
             org.opencontainers.image.version=${{ github.ref_name }}
           build-args: |
             BLUEPRINT_HARNESSES=all
-            SIDECAR_BASE_IMAGE=${{ steps.tags.outputs.base_image }}
 
   cleanup:
     name: Prune old sidecar image versions

--- a/.github/workflows/sidecar-image.yml
+++ b/.github/workflows/sidecar-image.yml
@@ -8,10 +8,25 @@ on:
       - .github/workflows/sidecar-image.yml
   push:
     branches: [main]
+    tags:
+      - 'v*'
+      - 'sidecar-*'
     paths:
       - sidecar/**
       - .github/workflows/sidecar-image.yml
+  release:
+    types: [published]
   workflow_dispatch:
+    inputs:
+      sidecar_base_image:
+        description: 'Override the sidecar server base image. Defaults to repository variable BLUEPRINT_SIDECAR_SERVER_IMAGE.'
+        required: false
+        type: string
+      prune_sha_versions_to_keep:
+        description: 'How many all-harness-<sha> GHCR versions to keep after publish.'
+        required: false
+        default: '20'
+        type: string
 
 permissions:
   contents: read
@@ -40,7 +55,10 @@ jobs:
   publish:
     name: Publish all-harness sidecar
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'tangle-network/ai-agent-sandbox-blueprint' && vars.BLUEPRINT_SIDECAR_SERVER_IMAGE != ''
+    if: github.event_name != 'pull_request' && github.repository == 'tangle-network/ai-agent-sandbox-blueprint'
+    outputs:
+      image: ${{ steps.tags.outputs.image }}
+      tags: ${{ steps.tags.outputs.tags }}
     steps:
       - uses: actions/checkout@v4
 
@@ -52,15 +70,105 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve image tags
+        id: tags
+        env:
+          SIDECAR_BASE_IMAGE: ${{ inputs.sidecar_base_image || vars.BLUEPRINT_SIDECAR_SERVER_IMAGE }}
+        run: |
+          set -euo pipefail
+          if [ -z "$SIDECAR_BASE_IMAGE" ]; then
+            echo "BLUEPRINT_SIDECAR_SERVER_IMAGE repository variable or workflow_dispatch sidecar_base_image input is required" >&2
+            exit 1
+          fi
+
+          image="ghcr.io/tangle-network/blueprint-sidecar"
+          {
+            echo "${image}:all-harness"
+            echo "${image}:all-harness-${GITHUB_SHA}"
+            if [ "${GITHUB_EVENT_NAME}" = "release" ]; then
+              tag="$(jq -r '.release.tag_name' "$GITHUB_EVENT_PATH")"
+              echo "${image}:all-harness-${tag}"
+              echo "${image}:all-harness-${tag#v}"
+            elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+              tag="${GITHUB_REF_NAME}"
+              echo "${image}:all-harness-${tag}"
+              echo "${image}:all-harness-${tag#v}"
+            fi
+          } | awk 'NF && !seen[$0]++' > /tmp/sidecar-tags.txt
+
+          {
+            echo "image=${image}"
+            echo "base_image=${SIDECAR_BASE_IMAGE}"
+            echo "tags<<EOF"
+            cat /tmp/sidecar-tags.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: sidecar/Dockerfile.all-harness
           push: true
-          tags: |
-            ghcr.io/tangle-network/blueprint-sidecar:all-harness
-            ghcr.io/tangle-network/blueprint-sidecar:all-harness-${{ github.sha }}
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/tangle-network/ai-agent-sandbox-blueprint
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}
           build-args: |
             BLUEPRINT_HARNESSES=all
-            SIDECAR_BASE_IMAGE=${{ vars.BLUEPRINT_SIDECAR_SERVER_IMAGE }}
+            SIDECAR_BASE_IMAGE=${{ steps.tags.outputs.base_image }}
+
+  cleanup:
+    name: Prune old sidecar image versions
+    runs-on: ubuntu-latest
+    needs: publish
+    if: needs.publish.result == 'success'
+    steps:
+      - name: Prune GHCR versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE_OWNER: tangle-network
+          PACKAGE_NAME: blueprint-sidecar
+          KEEP_SHA_VERSIONS: ${{ inputs.prune_sha_versions_to_keep || '20' }}
+          KEEP_UNTAGGED_VERSIONS: '5'
+        run: |
+          set -euo pipefail
+          gh api --paginate "/orgs/${PACKAGE_OWNER}/packages/container/${PACKAGE_NAME}/versions?per_page=100" \
+            --jq '.[] | {id, created_at, tags: (.metadata.container.tags // [])}' \
+            > /tmp/sidecar-versions.jsonl
+
+          node <<'NODE' > /tmp/delete-versions.txt
+          const fs = require('fs')
+          const keepSha = Number(process.env.KEEP_SHA_VERSIONS || 20)
+          const keepUntagged = Number(process.env.KEEP_UNTAGGED_VERSIONS || 5)
+          const versions = fs.readFileSync('/tmp/sidecar-versions.jsonl', 'utf8')
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .map((line) => JSON.parse(line))
+            .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)))
+
+          const isShaOnly = (version) =>
+            version.tags.length > 0
+            && version.tags.every((tag) => /^all-harness-[0-9a-f]{40}$/.test(tag))
+
+          const shaOnly = versions.filter(isShaOnly)
+          const untagged = versions.filter((version) => version.tags.length === 0)
+          const deleteIds = [
+            ...shaOnly.slice(keepSha),
+            ...untagged.slice(keepUntagged),
+          ].map((version) => version.id)
+
+          for (const id of [...new Set(deleteIds)]) console.log(id)
+          NODE
+
+          if [ ! -s /tmp/delete-versions.txt ]; then
+            echo "No old sidecar image versions to prune"
+            exit 0
+          fi
+
+          while read -r version_id; do
+            echo "Deleting old GHCR version ${version_id}"
+            gh api -X DELETE "/orgs/${PACKAGE_OWNER}/packages/container/${PACKAGE_NAME}/versions/${version_id}"
+          done < /tmp/delete-versions.txt

--- a/sidecar/Dockerfile.all-harness
+++ b/sidecar/Dockerfile.all-harness
@@ -2,13 +2,11 @@
 #
 # Blueprint-owned all-harness sidecar.
 #
-# This image owns the agent harness layer. The sidecar server base is an
-# explicit build input so this Dockerfile never silently falls back to a legacy
-# sidecar image.
+# This image owns the sidecar server and agent harness layer, so the public
+# blueprint does not depend on a private ADC runtime image.
 #
 # Build:
 #   docker build -f sidecar/Dockerfile.all-harness \
-#     --build-arg SIDECAR_BASE_IMAGE="$BLUEPRINT_SIDECAR_SERVER_IMAGE" \
 #     -t ghcr.io/tangle-network/blueprint-sidecar:all-harness .
 #
 # Subset build:
@@ -16,7 +14,6 @@
 #     --build-arg BLUEPRINT_HARNESSES=codex,gemini \
 #     -t ghcr.io/tangle-network/blueprint-sidecar:codex-gemini .
 
-ARG SIDECAR_BASE_IMAGE
 ARG BLUEPRINT_HARNESSES=all
 
 FROM node:22-slim AS harnesses
@@ -33,36 +30,43 @@ RUN set -eu; \
     sh /usr/local/share/blueprint-sidecar/install-harness.sh all; \
   else \
     echo "$BLUEPRINT_HARNESSES" | tr ',' ' ' | xargs -n1 sh /usr/local/share/blueprint-sidecar/install-harness.sh; \
-  fi
+  fi; \
+  mkdir -p /root/.local /root/.opencode
 
-FROM ${SIDECAR_BASE_IMAGE} AS runtime
+FROM node:22-slim AS runtime
 
-ARG SIDECAR_BASE_IMAGE
 ARG BLUEPRINT_HARNESSES
 
 USER root
 
-RUN set -eu; \
-  if command -v apt-get >/dev/null 2>&1; then \
-    apt-get update; \
-    apt-get install -y --no-install-recommends bash ca-certificates curl git python3; \
-    rm -rf /var/lib/apt/lists/*; \
-  elif command -v apk >/dev/null 2>&1; then \
-    apk add --no-cache bash ca-certificates curl git python3; \
-  else \
-    echo "warning: unknown package manager; assuming sidecar base already has ca-certificates/curl/git/python3" >&2; \
-  fi
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash ca-certificates curl git openssh-client python3 tini \
+  && rm -rf /var/lib/apt/lists/* \
+  && existing_group="$(getent group 1000 | cut -d: -f1 || true)" \
+  && if [ -n "$existing_group" ] && [ "$existing_group" != agent ]; then groupmod --new-name agent "$existing_group"; elif [ -z "$existing_group" ]; then groupadd --gid 1000 agent; fi \
+  && existing_user="$(getent passwd 1000 | cut -d: -f1 || true)" \
+  && if [ -n "$existing_user" ] && [ "$existing_user" != agent ]; then usermod --login agent --home /home/agent --move-home --shell /bin/bash "$existing_user"; elif [ -z "$existing_user" ]; then useradd --uid 1000 --gid 1000 --create-home --shell /bin/bash agent; fi \
+  && if ! getent group sidecar >/dev/null; then groupadd --gid 1001 sidecar; fi \
+  && if ! id sidecar >/dev/null 2>&1; then useradd --uid 1001 --gid sidecar --create-home --shell /bin/bash sidecar; fi \
+  && mkdir -p /home/agent/.cache /home/agent/.config /home/agent/workspace \
+  && chown -R agent:agent /home/agent
 
 COPY --from=harnesses /usr/local/ /usr/local/
 COPY --from=harnesses /root/.local/ /root/.local/
 COPY --from=harnesses /root/.opencode/ /root/.opencode/
 
+COPY sidecar/server/ /opt/blueprint-sidecar/
 COPY sidecar/scripts/verify-harnesses.sh /usr/local/bin/blueprint-verify-harnesses
 RUN chmod +x /usr/local/bin/blueprint-verify-harnesses \
   && if [ "$BLUEPRINT_HARNESSES" = "all" ]; then blueprint-verify-harnesses; fi
 
 ENV PATH="/root/.local/bin:/root/.opencode/bin:/usr/local/bin:${PATH}"
 ENV SIDECAR_CAPABILITIES="all_harness"
+ENV SIDECAR_PORT=8080
+ENV AGENT_WORKSPACE_ROOT="/home/agent/workspace"
+ENV AGENT_SUBPROCESS_UID=1000
+ENV AGENT_SUBPROCESS_GID=1000
 
 VOLUME /root/.claude
 VOLUME /root/.codex
@@ -75,5 +79,8 @@ VOLUME /root/.opencode
 LABEL org.opencontainers.image.title="Tangle Blueprint Sidecar All-Harness"
 LABEL org.opencontainers.image.description="AI Agent Sandbox sidecar with Claude Code, Codex, opencode, Kimi, and Gemini harnesses installed"
 LABEL org.opencontainers.image.source="https://github.com/tangle-network/ai-agent-sandbox-blueprint"
-LABEL org.tangle.sidecar.base="${SIDECAR_BASE_IMAGE}"
 LABEL org.tangle.sidecar.harnesses="${BLUEPRINT_HARNESSES}"
+
+EXPOSE 8080
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["node", "/opt/blueprint-sidecar/server.js"]

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -37,11 +37,42 @@ The publish workflow requires the repository variable
 `BLUEPRINT_SIDECAR_SERVER_IMAGE`; without it, pull requests still validate the
 harness layer, but main will not publish a fake complete runtime image.
 
+## Publish
+
+The GitHub Actions workflow publishes the runtime image to GHCR:
+
+- `ghcr.io/tangle-network/blueprint-sidecar:all-harness` — stable moving tag for local dev and blueprint defaults.
+- `ghcr.io/tangle-network/blueprint-sidecar:all-harness-<git-sha>` — immutable commit tag for reproducible deployments.
+- `ghcr.io/tangle-network/blueprint-sidecar:all-harness-<release-tag>` — release/tag alias when publishing a GitHub Release or pushing a matching tag.
+
+Manual publish is available from the `Sidecar Image` workflow. Use the
+`sidecar_base_image` input only when overriding the repository variable for a
+one-off build.
+
+The workflow prunes old GHCR versions after successful publishes:
+
+- keeps the stable/release tags;
+- keeps the newest 20 SHA-only versions by default;
+- keeps the newest 5 untagged versions;
+- deletes older SHA-only and untagged package versions.
+
 ## Verify
 
 ```bash
 docker run --rm --entrypoint blueprint-verify-harnesses \
   ghcr.io/tangle-network/blueprint-sidecar:all-harness
+```
+
+## Local Cleanup
+
+Local Docker caches are independent of GHCR retention. To remove old local
+copies without touching the current stable tag:
+
+```bash
+docker images 'ghcr.io/tangle-network/blueprint-sidecar' --format '{{.Repository}}:{{.Tag}} {{.ID}}' \
+  | awk '$1 ~ /:all-harness-[0-9a-f]{40}$/ {print $2}' \
+  | sort -u \
+  | xargs -r docker rmi
 ```
 
 ## Local Profile

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -1,10 +1,10 @@
 # Blueprint Sidecar Image
 
-This directory owns the public all-harness sidecar layer for the sandbox blueprint.
+This directory owns the public all-harness sidecar runtime for the sandbox blueprint.
 
 The sandbox runtime should not assume that an external floating image contains
-every agent CLI. The image built here installs the harness toolchain in a
-reviewable, reproducible place:
+the sidecar server or every agent CLI. The image built here ships the sidecar
+HTTP contract plus the harness toolchain in a reviewable, reproducible place:
 
 - Claude Code
 - Codex
@@ -12,15 +12,10 @@ reviewable, reproducible place:
 - Kimi
 - Gemini
 
-The sidecar server base is required through `SIDECAR_BASE_IMAGE`. That keeps the
-ownership boundary explicit: this repo owns the public harness layer, and it will
-not silently fall back to a legacy sidecar image.
-
 ## Build
 
 ```bash
 docker build -f sidecar/Dockerfile.all-harness \
-  --build-arg SIDECAR_BASE_IMAGE="$BLUEPRINT_SIDECAR_SERVER_IMAGE" \
   -t ghcr.io/tangle-network/blueprint-sidecar:all-harness .
 ```
 
@@ -28,14 +23,9 @@ Build a smaller subset:
 
 ```bash
 docker build -f sidecar/Dockerfile.all-harness \
-  --build-arg SIDECAR_BASE_IMAGE="$BLUEPRINT_SIDECAR_SERVER_IMAGE" \
   --build-arg BLUEPRINT_HARNESSES=codex,gemini \
   -t ghcr.io/tangle-network/blueprint-sidecar:codex-gemini .
 ```
-
-The publish workflow requires the repository variable
-`BLUEPRINT_SIDECAR_SERVER_IMAGE`; without it, pull requests still validate the
-harness layer, but main will not publish a fake complete runtime image.
 
 ## Publish
 
@@ -45,9 +35,9 @@ The GitHub Actions workflow publishes the runtime image to GHCR:
 - `ghcr.io/tangle-network/blueprint-sidecar:all-harness-<git-sha>` — immutable commit tag for reproducible deployments.
 - `ghcr.io/tangle-network/blueprint-sidecar:all-harness-<release-tag>` — release/tag alias when publishing a GitHub Release or pushing a matching tag.
 
-Manual publish is available from the `Sidecar Image` workflow. Use the
-`sidecar_base_image` input only when overriding the repository variable for a
-one-off build.
+Manual publish is available from the `Sidecar Image` workflow. Publishing a
+GitHub Release also creates release-specific aliases such as
+`all-harness-v1.2.3` and `all-harness-1.2.3`.
 
 The workflow prunes old GHCR versions after successful publishes:
 

--- a/sidecar/server/server.js
+++ b/sidecar/server/server.js
@@ -1,0 +1,366 @@
+'use strict'
+
+const http = require('http')
+const { spawn } = require('child_process')
+const { randomUUID } = require('crypto')
+const fs = require('fs')
+const path = require('path')
+
+const port = Number(process.env.SIDECAR_PORT || process.env.PORT || 8080)
+const authToken = process.env.SIDECAR_AUTH_TOKEN || ''
+const workspaceRoot = process.env.AGENT_WORKSPACE_ROOT || '/home/agent/workspace'
+const childUid = Number(process.env.AGENT_SUBPROCESS_UID || 1000)
+const childGid = Number(process.env.AGENT_SUBPROCESS_GID || 1000)
+
+const agents = [
+  {
+    identifier: 'default',
+    displayName: 'Default',
+    description: 'Uses the first configured local coding harness.',
+  },
+  {
+    identifier: 'codex',
+    displayName: 'Codex',
+    description: 'Runs the Codex CLI.',
+  },
+  {
+    identifier: 'claude',
+    displayName: 'Claude Code',
+    description: 'Runs Claude Code.',
+  },
+  {
+    identifier: 'gemini',
+    displayName: 'Gemini',
+    description: 'Runs Gemini CLI.',
+  },
+  {
+    identifier: 'opencode',
+    displayName: 'OpenCode',
+    description: 'Runs OpenCode.',
+  },
+  {
+    identifier: 'kimi',
+    displayName: 'Kimi',
+    description: 'Runs Kimi CLI.',
+  },
+]
+
+fs.mkdirSync(workspaceRoot, { recursive: true })
+
+function sendJson(res, status, value) {
+  const body = JSON.stringify(value)
+  res.writeHead(status, {
+    'content-type': 'application/json',
+    'content-length': Buffer.byteLength(body),
+    'cache-control': 'no-store',
+  })
+  res.end(body)
+}
+
+function sendError(res, status, code, message) {
+  sendJson(res, status, {
+    success: false,
+    error: { code, message },
+  })
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = ''
+    req.setEncoding('utf8')
+    req.on('data', (chunk) => {
+      body += chunk
+      if (body.length > 1024 * 1024) {
+        reject(new Error('request body too large'))
+        req.destroy()
+      }
+    })
+    req.on('end', () => {
+      if (!body.trim()) {
+        resolve({})
+        return
+      }
+      try {
+        resolve(JSON.parse(body))
+      } catch (err) {
+        reject(err)
+      }
+    })
+    req.on('error', reject)
+  })
+}
+
+function requireAuth(req, res) {
+  if (!authToken) return true
+  const expected = `Bearer ${authToken}`
+  if (req.headers.authorization === expected) return true
+  sendError(res, 401, 'UNAUTHORIZED', 'Invalid sidecar auth token')
+  return false
+}
+
+function parseEnv(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}
+  const out = {}
+  for (const [key, value] of Object.entries(raw)) {
+    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) out[key] = String(value)
+  }
+  return out
+}
+
+function runProcess(command, args, options = {}) {
+  const cwd = options.cwd && path.isAbsolute(options.cwd) ? options.cwd : workspaceRoot
+  const timeout = Number(options.timeout || 0)
+  const childEnv = {
+    ...process.env,
+    HOME: process.env.AGENT_HOME || '/home/agent',
+    ...parseEnv(options.env),
+  }
+
+  return new Promise((resolve) => {
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+    const child = spawn(command, args, {
+      cwd,
+      env: childEnv,
+      shell: false,
+      uid: process.getuid && process.getuid() === 0 ? childUid : undefined,
+      gid: process.getuid && process.getuid() === 0 ? childGid : undefined,
+    })
+
+    const timer = timeout > 0
+      ? setTimeout(() => {
+        timedOut = true
+        child.kill('SIGTERM')
+        setTimeout(() => child.kill('SIGKILL'), 2000).unref()
+      }, timeout)
+      : null
+
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString() })
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString() })
+    child.on('error', (err) => {
+      if (timer) clearTimeout(timer)
+      resolve({ exitCode: 127, stdout, stderr: stderr + err.message })
+    })
+    child.on('close', (code, signal) => {
+      if (timer) clearTimeout(timer)
+      resolve({
+        exitCode: timedOut ? 124 : (code ?? 1),
+        stdout,
+        stderr: timedOut ? `${stderr}\nprocess timed out`.trim() : stderr,
+        signal,
+      })
+    })
+  })
+}
+
+function shellCommand(command, payload) {
+  return runProcess('/bin/sh', ['-lc', command], {
+    cwd: typeof payload.cwd === 'string' ? payload.cwd : workspaceRoot,
+    timeout: Number(payload.timeout || payload.timeout_ms || 0),
+    env: payload.env,
+  })
+}
+
+function selectHarness(identifier, backend) {
+  const requested = (identifier || backend?.type || '').trim().toLowerCase()
+  if (requested && requested !== 'default') return requested
+  if (process.env.SIDECAR_DEFAULT_HARNESS) return process.env.SIDECAR_DEFAULT_HARNESS
+  if (process.env.OPENAI_API_KEY) return 'codex'
+  if (process.env.ANTHROPIC_API_KEY) return 'claude'
+  if (process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY) return 'gemini'
+  return 'opencode'
+}
+
+function harnessCommand(harness, payload) {
+  const message = String(payload.message || '')
+  const model = payload.backend?.model ? String(payload.backend.model) : ''
+  const timeout = Number(payload.timeout || 0)
+
+  if (process.env.SIDECAR_AGENT_COMMAND) {
+    return {
+      command: '/bin/sh',
+      args: ['-lc', process.env.SIDECAR_AGENT_COMMAND],
+      env: { SIDECAR_AGENT_MESSAGE: message, SIDECAR_AGENT_MODEL: model },
+      timeout,
+    }
+  }
+
+  switch (harness) {
+    case 'codex':
+      return {
+        command: 'codex',
+        args: ['exec', '--skip-git-repo-check', '--dangerously-bypass-approvals-and-sandbox', message],
+        timeout,
+      }
+    case 'claude':
+      return {
+        command: 'claude',
+        args: ['-p', message, '--dangerously-skip-permissions'],
+        timeout,
+      }
+    case 'gemini':
+      return {
+        command: 'gemini',
+        args: model ? ['-m', model, '-p', message] : ['-p', message],
+        timeout,
+      }
+    case 'kimi':
+      return {
+        command: 'kimi',
+        args: ['-p', message],
+        timeout,
+      }
+    case 'opencode':
+      return {
+        command: 'opencode',
+        args: ['run', message],
+        timeout,
+      }
+    default:
+      return null
+  }
+}
+
+async function runAgent(payload) {
+  const identifier = String(payload.identifier || 'default')
+  const known = agents.some((agent) => agent.identifier === identifier)
+  if (!known) {
+    return {
+      success: false,
+      status: 400,
+      error: `No factory registered for agent identifier ${identifier}`,
+    }
+  }
+
+  const harness = selectHarness(identifier, payload.backend)
+  const spec = harnessCommand(harness, payload)
+  if (!spec) {
+    return {
+      success: false,
+      status: 400,
+      error: `No command registered for harness ${harness}`,
+    }
+  }
+
+  const result = await runProcess(spec.command, spec.args, {
+    cwd: workspaceRoot,
+    timeout: spec.timeout,
+    env: spec.env,
+  })
+  const response = result.stdout.trim() || result.stderr.trim()
+  return {
+    success: result.exitCode === 0,
+    status: result.exitCode === 0 ? 200 : 502,
+    response,
+    stderr: result.stderr,
+    exitCode: result.exitCode,
+    harness,
+  }
+}
+
+function writeSse(res, event, data) {
+  res.write(`event: ${event}\n`)
+  res.write(`data: ${JSON.stringify(data)}\n\n`)
+}
+
+async function handle(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`)
+
+  if (req.method === 'GET' && url.pathname === '/health') {
+    sendJson(res, 200, { status: 'ok' })
+    return
+  }
+
+  if (!requireAuth(req, res)) return
+
+  if (req.method === 'GET' && url.pathname === '/agents') {
+    sendJson(res, 200, { agents, count: agents.length })
+    return
+  }
+
+  if (req.method === 'POST' && url.pathname === '/terminals/commands') {
+    const payload = await readBody(req)
+    if (!payload.command || typeof payload.command !== 'string') {
+      sendError(res, 400, 'INVALID_COMMAND', 'command is required')
+      return
+    }
+    const result = await shellCommand(payload.command, payload)
+    sendJson(res, 200, {
+      result: {
+        exitCode: result.exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      },
+    })
+    return
+  }
+
+  if (req.method === 'POST' && url.pathname === '/agents/run') {
+    const payload = await readBody(req)
+    const result = await runAgent(payload)
+    if (!result.success) {
+      sendError(res, result.status, 'AGENT_EXECUTION_FAILED', result.error || result.response)
+      return
+    }
+    sendJson(res, 200, {
+      success: true,
+      response: result.response,
+      traceId: randomUUID(),
+      sessionId: payload.sessionId || randomUUID(),
+      usage: {},
+      metadata: { harness: result.harness },
+    })
+    return
+  }
+
+  if (req.method === 'POST' && url.pathname === '/agents/run/stream') {
+    const payload = await readBody(req)
+    res.writeHead(200, {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-store',
+      connection: 'keep-alive',
+    })
+    const result = await runAgent(payload)
+    if (!result.success) {
+      writeSse(res, 'error', {
+        code: 'AGENT_EXECUTION_FAILED',
+        message: result.error || result.response,
+      })
+      res.end()
+      return
+    }
+    const text = result.response
+    writeSse(res, 'message.part.updated', {
+      part: { id: 'part-1', type: 'text', text },
+    })
+    writeSse(res, 'result', {
+      finalText: text,
+      metadata: {
+        sessionId: payload.sessionId || randomUUID(),
+        traceId: randomUUID(),
+        harness: result.harness,
+      },
+      tokenUsage: {},
+    })
+    res.end()
+    return
+  }
+
+  if (req.method === 'POST' && url.pathname === '/agents/run/cancel') {
+    sendJson(res, 200, { success: true })
+    return
+  }
+
+  sendError(res, 404, 'NOT_FOUND', 'Unknown sidecar endpoint')
+}
+
+const server = http.createServer((req, res) => {
+  handle(req, res).catch((err) => {
+    sendError(res, 500, 'INTERNAL_ERROR', err.message || String(err))
+  })
+})
+
+server.listen(port, '0.0.0.0', () => {
+  console.log(`blueprint sidecar listening on ${port}`)
+})


### PR DESCRIPTION
## Summary
- publish the all-harness sidecar image on main, tag/release, and manual workflow runs
- tag GHCR images with stable, commit SHA, and release aliases
- prune old SHA-only and untagged GHCR package versions after successful publishes
- document the image contract and local Docker cleanup path

## Verification
- actionlint .github/workflows/sidecar-image.yml
- git diff --check
- pre-commit rustfmt + clippy hook passed