### PR TITLE
feat(metadata): declare deployment modes

### DIFF
--- a/metadata/blueprint-metadata.json
+++ b/metadata/blueprint-metadata.json
@@ -73,6 +73,27 @@
         "allowChainSwitch": true,
         "allowPopups": false
       }
-    }
+    },
+    "modes": [
+      {
+        "id": "cloud",
+        "label": "Cloud",
+        "description": "Many operators, capacity-weighted scheduling, shared infra. Default sandbox flavor.",
+        "blueprintId": 10,
+        "tagline": "Recommended"
+      },
+      {
+        "id": "instance",
+        "label": "Dedicated Instance",
+        "description": "Per-service singleton — one dedicated operator + isolated box per service. Better isolation, higher cost.",
+        "blueprintId": 11
+      },
+      {
+        "id": "tee",
+        "label": "TEE Instance",
+        "description": "Dedicated Instance + mandatory TEE attestation (SGX/SEV/TDX) before service activation. For confidential workloads.",
+        "blueprintId": 12
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Adds a `modes` array to `blueprintUi` in `metadata/blueprint-metadata.json` so the dapp can render a single product card with mode-aware curated surfaces, instead of showing the same product N times once per operational mode it is registered under.

Each mode binds a human-readable id/label/description to the concrete on-chain `blueprintId`, letting the catalog UI pivot between flavors without a catalog-side hack.

For the AI Agent Sandbox the declared modes are:

- `cloud` (blueprintId `10`, tagline "Recommended") — many operators, capacity-weighted scheduling, shared infra. Default sandbox flavor.
- `instance` (blueprintId `11`) — per-service singleton, one dedicated operator + isolated box per service.
- `tee` (blueprintId `12`) — Dedicated Instance + mandatory TEE attestation (SGX / SEV / TDX) before activation.

## Notes

- Only `modes` was added. No other field in `blueprintUi` was touched, reformatted, or reordered.
- JSON validated with `python3 -m json.tool` round-trip.
- No version bump and no contract changes; this is metadata-only.

## Test plan

- [x] `python3 -c "import json; json.load(open('metadata/blueprint-metadata.json'))"` passes.
- [x] Parsed `blueprintUi.modes` has 3 entries with ids `['cloud', 'instance', 'tee']` and blueprintIds `[10, 11, 12]`.
- [ ] Dapp consumer (catalog renderer) picks up the new array and collapses duplicate cards.