### PR TITLE
fix(ui): allow develop.cloud.tangle.tools + wildcards in iframe CSP

### DIFF
--- a/ui/public/_headers
+++ b/ui/public/_headers
@@ -1,0 +1,10 @@
+/*
+  Content-Security-Policy: frame-ancestors https://cloud.tangle.tools https://*.cloud.tangle.tools https://app.tangle.tools https://*.app.tangle.tools https://apps.tangle.tools https://*.apps.tangle.tools
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), bluetooth=(), accelerometer=(), gyroscope=(), magnetometer=(), midi=(), serial=()
+  Referrer-Policy: no-referrer
+  X-Content-Type-Options: nosniff
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-Frame-Options: SAMEORIGIN
+
+/index.html
+  Cache-Control: no-store


### PR DESCRIPTION
## Problem

The Cloudflare Pages deploy serves `frame-ancestors` limited to three exact production hosts:

```
content-security-policy: frame-ancestors https://cloud.tangle.tools https://app.tangle.tools https://apps.tangle.tools
```

`develop.cloud.tangle.tools` is missing → staging dapp can't embed the iframe → users see an empty/blocked frame and the generic on-chain form falls through instead.

## Fix

Add a source-controlled `public/_headers` with the same security posture but widened `frame-ancestors` for both the apex hosts and their wildcards:

```
https://{,*.}cloud.tangle.tools
https://{,*.}app.tangle.tools
https://{,*.}apps.tangle.tools
```

Cloudflare Pages reads `_headers` from the static-site root; Vite copies `public/_headers` verbatim into the build output, so the file is now under version control instead of living only in CI / the Pages dashboard.

## Test plan

- [ ] After Cloudflare Pages picks up the new `_headers`, `curl -I https://agent-sandbox.blueprint.tangle.tools/` shows the widened CSP.
- [ ] Browser-test from `develop.cloud.tangle.tools/blueprints/sandbox` shows the iframe embedded and rendering content (no console CSP block).