### PR TITLE
ci: auto-deploy iframe UI to Cloudflare Pages on push to main

### DIFF
--- a/.github/workflows/deploy-iframe.yml
+++ b/.github/workflows/deploy-iframe.yml
@@ -1,0 +1,52 @@
+name: Deploy iframe UI to Cloudflare Pages
+
+# Auto-deploys the React Router SPA at `ui/` to Cloudflare Pages
+# (project: agent-sandbox → https://agent-sandbox.blueprint.tangle.tools).
+#
+# Before this existed the project was wired as "direct upload" in Cloudflare
+# with no git source, so every CSP / dapp-host / runtime-backend change had to
+# be deployed by a human running `wrangler pages deploy` locally — which
+# silently broke when nobody noticed an old commit on main hadn't shipped.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ui/**'
+      - '.github/workflows/deploy-iframe.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-iframe-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build iframe UI
+        run: pnpm -C ui run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ui/build/client --project-name=agent-sandbox --branch=main --commit-hash=${{ github.sha }} --commit-message="${{ github.event.head_commit.message }}"

--- a/ui/public/_headers
+++ b/ui/public/_headers
@@ -1,0 +1,10 @@
+/*
+  Content-Security-Policy: frame-ancestors https://cloud.tangle.tools https://*.cloud.tangle.tools https://app.tangle.tools https://*.app.tangle.tools https://apps.tangle.tools https://*.apps.tangle.tools
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), bluetooth=(), accelerometer=(), gyroscope=(), magnetometer=(), midi=(), serial=()
+  Referrer-Policy: no-referrer
+  X-Content-Type-Options: nosniff
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-Frame-Options: SAMEORIGIN
+
+/index.html
+  Cache-Control: no-store


### PR DESCRIPTION
Closes the manual-deploy gap surfaced today. The agent-sandbox CF Pages project is direct-upload (no git source), so every iframe change had to be deployed manually via `wrangler pages deploy`. PR #80 (CSP widening) merged but didn't reach `agent-sandbox.blueprint.tangle.tools` until I ran wrangler from a local checkout — that's the gap.

## What

GH Actions workflow at `.github/workflows/deploy-iframe.yml`:
- Triggers on push to `main` when `ui/**` changes, or workflow_dispatch.
- pnpm install → `pnpm -C ui run build` → `wrangler pages deploy ui/build/client --project-name=agent-sandbox --branch=main`.
- Uses `cloudflare/wrangler-action@v3` with `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` (secrets already set on this repo).
- Concurrency group cancels superseded runs so we don't ship a stale build over a newer one.

## Test plan

- [ ] Merge → workflow fires → CF Pages picks up the build → `curl -I https://agent-sandbox.blueprint.tangle.tools/` shows the head commit's CSP / hash.