### PR TITLE
fix(ui): respect ?theme=light|dark from parent + legible empty state

### DIFF
--- a/ui/src/components/layout/IframeAppDocument.tsx
+++ b/ui/src/components/layout/IframeAppDocument.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+import { Links, Meta, Scripts, ScrollRestoration } from 'react-router';
+import { buildInlineThemeBootstrap } from '~/lib/theme';
+
+interface IframeAppDocumentProps {
+  children: ReactNode;
+  description: string;
+}
+
+// Local replacement for blueprint-ui's `AppDocument`. The only behavioral
+// difference is the inline bootstrap script: this one honors the parent
+// shell's `?theme=light|dark` URL param so the iframe's first paint matches
+// the embedding dapp (instead of always defaulting to dark and showing a
+// black rectangle on a light-themed parent).
+export function IframeAppDocument({ children, description }: IframeAppDocumentProps) {
+  return (
+    <html lang="en" data-theme="dark" suppressHydrationWarning>
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content={description} />
+        <Meta />
+        <Links />
+        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&family=Outfit:wght@400;500;600;700;800;900&display=swap"
+        />
+        <script dangerouslySetInnerHTML={{ __html: buildInlineThemeBootstrap() }} />
+      </head>
+      <body>
+        {children}
+        <ScrollRestoration />
+        <Scripts />
+      </body>
+    </html>
+  );
+}

--- a/ui/src/components/shared/ConnectWalletPanel.tsx
+++ b/ui/src/components/shared/ConnectWalletPanel.tsx
@@ -1,0 +1,57 @@
+import { ConnectKitButton } from 'connectkit';
+import { Card, CardContent } from '@tangle-network/blueprint-ui/components';
+
+interface ConnectWalletPanelProps {
+  // Optional override for the headline; defaults to the deploy-flow message.
+  title?: string;
+  // Optional override for the one-line explainer.
+  description?: string;
+}
+
+// Theme-aware empty state shown when the iframe loads without a connected
+// wallet. Uses the same cloud-elements design tokens as the rest of the app
+// so it reads cleanly on both dark and light themes — no hardcoded colors.
+export function ConnectWalletPanel({
+  title = 'Connect your wallet to continue',
+  description = 'Provisioning and managing sandboxes requires a connected wallet on Tangle Network.',
+}: ConnectWalletPanelProps) {
+  return (
+    <Card>
+      <CardContent className="p-6">
+        <div className="py-10 text-center">
+          <div className="i-ph:wallet text-4xl text-cloud-elements-textTertiary mb-3 mx-auto" />
+          <p className="text-base font-display font-semibold text-cloud-elements-textPrimary">
+            {title}
+          </p>
+          <p className="text-sm text-cloud-elements-textSecondary mt-1 max-w-md mx-auto">
+            {description}
+          </p>
+          <div className="mt-5 inline-flex">
+            <ConnectKitButton.Custom>
+              {({ show, isConnecting }) => (
+                <button
+                  type="button"
+                  onClick={show}
+                  disabled={isConnecting}
+                  className="px-4 py-2.5 rounded-lg bg-violet-500/10 border border-violet-500/20 text-violet-700 dark:text-violet-400 text-sm font-display font-medium hover:bg-violet-500/20 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+                >
+                  {isConnecting ? (
+                    <span className="flex items-center gap-2">
+                      <span className="w-3 h-3 rounded-full border-2 border-violet-500/40 border-t-violet-600 dark:border-t-violet-400 animate-spin" />
+                      Connecting...
+                    </span>
+                  ) : (
+                    <span className="flex items-center gap-2">
+                      <span className="i-ph:plugs-connected text-base" />
+                      Connect Wallet
+                    </span>
+                  )}
+                </button>
+              )}
+            </ConnectKitButton.Custom>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/src/lib/theme.test.ts
+++ b/ui/src/lib/theme.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { THEME_STORAGE_KEYS, buildInlineThemeBootstrap } from './theme';
+
+// The inline theme bootstrap is shipped as a string and evaluated by the
+// browser before any React code runs. We can't import it as JS, so the test
+// strategy is: build the source, wrap it in a function with stubbed globals
+// (window, localStorage, document, matchMedia), then assert the side-effects.
+
+interface BootstrapHarness {
+  href: string;
+  store: Map<string, string>;
+  prefersDark: boolean;
+}
+
+function runBootstrap(harness: BootstrapHarness): string | null {
+  const setAttr = { value: null as string | null };
+  const fakeStorage = {
+    getItem: (key: string) => harness.store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      harness.store.set(key, value);
+    },
+  };
+  const fakeDoc = {
+    documentElement: {
+      setAttribute: (_name: string, value: string) => {
+        setAttr.value = value;
+      },
+    },
+  };
+  const fakeWindow = {
+    location: { href: harness.href },
+    matchMedia: (query: string) => ({
+      matches: query.includes('dark') ? harness.prefersDark : false,
+    }),
+  };
+  const fakeURL = class {
+    searchParams: URLSearchParams;
+    constructor(href: string) {
+      const idx = href.indexOf('?');
+      this.searchParams = new URLSearchParams(idx >= 0 ? href.slice(idx) : '');
+    }
+  };
+  const src = buildInlineThemeBootstrap();
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const fn = new Function(
+    'window',
+    'document',
+    'localStorage',
+    'URL',
+    src,
+  );
+  fn(fakeWindow, fakeDoc, fakeStorage, fakeURL);
+  return setAttr.value;
+}
+
+describe('buildInlineThemeBootstrap', () => {
+  let store: Map<string, string>;
+
+  beforeEach(() => {
+    store = new Map();
+  });
+
+  afterEach(() => {
+    store.clear();
+  });
+
+  it('honors ?theme=light from URL on first paint', () => {
+    const theme = runBootstrap({
+      href: 'https://agent-sandbox.blueprint.tangle.tools/?theme=light',
+      store,
+      prefersDark: true,
+    });
+    expect(theme).toBe('light');
+    // URL should clobber localStorage so themeStore picks it up
+    expect(store.get(THEME_STORAGE_KEYS[0])).toBe('light');
+  });
+
+  it('honors ?theme=dark from URL on first paint', () => {
+    const theme = runBootstrap({
+      href: 'https://agent-sandbox.blueprint.tangle.tools/?mode=default&blueprintId=12&theme=dark',
+      store,
+      prefersDark: false,
+    });
+    expect(theme).toBe('dark');
+    expect(store.get(THEME_STORAGE_KEYS[0])).toBe('dark');
+  });
+
+  it('URL theme overrides a persisted user preference', () => {
+    // User previously toggled to dark; iframe is reloaded by a light-themed parent.
+    store.set(THEME_STORAGE_KEYS[0], 'dark');
+    const theme = runBootstrap({
+      href: 'https://agent-sandbox.blueprint.tangle.tools/?theme=light',
+      store,
+      prefersDark: true,
+    });
+    expect(theme).toBe('light');
+    expect(store.get(THEME_STORAGE_KEYS[0])).toBe('light');
+  });
+
+  it('ignores invalid ?theme values', () => {
+    const theme = runBootstrap({
+      href: 'https://agent-sandbox.blueprint.tangle.tools/?theme=neon',
+      store,
+      prefersDark: false,
+    });
+    // Invalid → fall back to localStorage (empty) → system pref → light
+    expect(theme).toBe('light');
+  });
+
+  it('falls back to persisted theme when URL has no param', () => {
+    store.set(THEME_STORAGE_KEYS[0], 'light');
+    const theme = runBootstrap({
+      href: 'https://agent-sandbox.blueprint.tangle.tools/',
+      store,
+      prefersDark: true,
+    });
+    expect(theme).toBe('light');
+  });
+
+  it('migrates from legacy storage key when primary is unset', () => {
+    store.set(THEME_STORAGE_KEYS[1], 'light');
+    const theme = runBootstrap({
+      href: 'https://agent-sandbox.blueprint.tangle.tools/',
+      store,
+      prefersDark: true,
+    });
+    expect(theme).toBe('light');
+  });
+
+  it('falls back to system preference when nothing is set', () => {
+    const dark = runBootstrap({
+      href: 'https://agent-sandbox.blueprint.tangle.tools/',
+      store,
+      prefersDark: true,
+    });
+    expect(dark).toBe('dark');
+
+    store.clear();
+    const light = runBootstrap({
+      href: 'https://agent-sandbox.blueprint.tangle.tools/',
+      store,
+      prefersDark: false,
+    });
+    expect(light).toBe('light');
+  });
+
+  it('does not write to localStorage when URL has no theme', () => {
+    // System pref should drive first paint, but must NOT persist — otherwise
+    // a user who never picked a theme would have their preference frozen.
+    runBootstrap({
+      href: 'https://agent-sandbox.blueprint.tangle.tools/',
+      store,
+      prefersDark: true,
+    });
+    expect(store.has(THEME_STORAGE_KEYS[0])).toBe(false);
+    expect(store.has(THEME_STORAGE_KEYS[1])).toBe(false);
+  });
+});

--- a/ui/src/lib/theme.ts
+++ b/ui/src/lib/theme.ts
@@ -1,0 +1,62 @@
+// Theme resolution for the iframe app.
+//
+// The iframe is embedded by the Tangle Cloud dapp shell, which publishes its
+// active theme through a reserved URL contract:
+//
+//   https://agent-sandbox.blueprint.tangle.tools/?theme=light|dark
+//
+// (see apps/tangle-cloud/src/blueprintApps/iframe/README.md in the dapp).
+//
+// The parent's theme is set FRESH on every iframe load, so the URL param wins
+// over any persisted user preference at first paint. Once the user toggles
+// theme inside the iframe, `toggleTheme()` from @tangle-network/blueprint-ui
+// writes to `bp_theme` localStorage; that toggle sticks for the current
+// session but is overridden on the next parent-issued reload.
+//
+// When the iframe is loaded standalone (no `?theme=` in URL), behavior falls
+// back to the existing localStorage + system-pref chain so the standalone
+// domain works the same as before.
+
+export const THEME_STORAGE_KEYS = ['bp_theme', 'sandbox_cloud_theme'] as const;
+export const THEME_URL_PARAM = 'theme';
+
+export type Theme = 'dark' | 'light';
+
+/**
+ * Inline-script source injected into the document head before any React code
+ * evaluates. Setting `data-theme` here avoids a flash of the wrong theme and
+ * lets `themeStore` from blueprint-ui pick up the URL-derived value at
+ * initialization time.
+ *
+ * The script must be self-contained (no imports) and side-effect-only.
+ */
+export function buildInlineThemeBootstrap(): string {
+  const [primaryKey, secondaryKey] = THEME_STORAGE_KEYS;
+  // Stringify constants so they survive the inline boundary unchanged.
+  const PRIMARY = JSON.stringify(primaryKey);
+  const SECONDARY = JSON.stringify(secondaryKey);
+  const PARAM = JSON.stringify(THEME_URL_PARAM);
+  return `
+    (function () {
+      try {
+        var url = new URL(window.location.href);
+        var fromUrl = url.searchParams.get(${PARAM});
+        var theme = null;
+        if (fromUrl === 'light' || fromUrl === 'dark') {
+          theme = fromUrl;
+          // Parent dictates theme on every load — keep persisted value in sync
+          // so themeStore (which reads localStorage first) honors the URL too.
+          try { localStorage.setItem(${PRIMARY}, theme); } catch (e) {}
+        } else {
+          theme = localStorage.getItem(${PRIMARY}) || localStorage.getItem(${SECONDARY});
+        }
+        if (theme !== 'light' && theme !== 'dark') {
+          theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        document.documentElement.setAttribute('data-theme', theme);
+      } catch (e) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      }
+    })();
+  `;
+}

--- a/ui/src/root.tsx
+++ b/ui/src/root.tsx
@@ -8,19 +8,17 @@ import './styles/global.scss';
 import '~/lib/blueprints'; // side-effect: register all blueprints
 
 import { Outlet, useRouteError, isRouteErrorResponse } from 'react-router';
-import { AppDocument, AppFooter, AppToaster } from '@tangle-network/blueprint-ui/components';
+import { AppFooter, AppToaster } from '@tangle-network/blueprint-ui/components';
 import { Web3Provider } from '~/providers/Web3Provider';
 import { SandboxSyncProvider } from '~/providers/SandboxSyncProvider';
 import { Header } from '~/components/layout/Header';
+import { IframeAppDocument } from '~/components/layout/IframeAppDocument';
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <AppDocument
-      description="Tangle Sandbox Cloud - Provision and manage AI agent sandboxes"
-      themeStorageKeys={['bp_theme', 'sandbox_cloud_theme']}
-    >
+    <IframeAppDocument description="Tangle Sandbox Cloud - Provision and manage AI agent sandboxes">
       {children}
-    </AppDocument>
+    </IframeAppDocument>
   );
 }
 

--- a/ui/src/routes/create.tsx
+++ b/ui/src/routes/create.tsx
@@ -27,6 +27,7 @@ import { BlueprintBadgeInline } from '~/components/shared/InfraSummaryBits';
 import type { DiscoveredOperator } from '@tangle-network/blueprint-ui';
 import { cn } from '@tangle-network/blueprint-ui';
 import { EnvEditor } from '~/components/shared/EnvEditor';
+import { ConnectWalletPanel } from '~/components/shared/ConnectWalletPanel';
 import {
   BUNDLED_AGENT_OPTIONS,
   BUNDLED_NO_AGENT_VALUE,
@@ -103,7 +104,8 @@ function parseCapabilitiesJson(value: unknown): Set<string> {
 export default function CreatePage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { address } = useAccount();
+  const { address, isConnected, status: walletStatus } = useAccount();
+  const isReconnectingWallet = walletStatus === 'reconnecting';
   const infra = useStore(infraStore);
   const { validate: validateService, isValidating: serviceValidating, serviceInfo, error: serviceError } = useServiceValidation();
   const { data: capacity } = useAvailableCapacity();
@@ -295,6 +297,8 @@ export default function CreatePage() {
     setStep('configure');
   }, [resetForm, deployReset, address, validateService]);
 
+  const showConnectPanel = !isConnected && !address && !isReconnectingWallet;
+
   return (
     <AnimatedPage className="mx-auto max-w-3xl px-4 sm:px-6 py-8">
       <div className="mb-6">
@@ -307,6 +311,16 @@ export default function CreatePage() {
             : 'Select a blueprint to provision a new AI agent resource on Tangle Network'}
         </p>
       </div>
+
+      {/* Wallet connect prompt — shown when no wallet is connected so the page
+          never lands on an empty, action-less surface inside the iframe. */}
+      {showConnectPanel && (
+        <div className="mb-6">
+          <ConnectWalletPanel
+            description="Provisioning a sandbox or instance requires a connected wallet on Tangle Network. You can browse blueprints below, but deploying will be blocked until you connect."
+          />
+        </div>
+      )}
 
       {/* Infrastructure bar */}
       {step !== 'blueprint' && (


### PR DESCRIPTION
## Summary

Two visible fixes for the iframe app embedded by the Tangle Cloud dapp at `develop.cloud.tangle.tools/blueprints/sandbox`.

### 1. Honor `?theme=light|dark` URL contract

The dapp shell publishes its active theme via the reserved iframe URL contract (dapp #3232):

```
https://agent-sandbox.blueprint.tangle.tools/?mode=default&blueprintId=12&theme=light
```

Before this PR, the iframe always defaulted to its own dark theme. On a vault (light) parent it rendered as a solid black rectangle on a white page.

This PR adds an inline bootstrap script (in `IframeAppDocument`, a local replacement for blueprint-ui's `AppDocument`) that runs **before any React module evaluates** and:

1. Reads `?theme=light|dark` from `window.location.search`.
2. If present, sets `data-theme` AND mirrors the value into `bp_theme` localStorage so `themeStore.initStore()` (in blueprint-ui) picks it up automatically — no need to fork the store.
3. If absent, falls back to the existing `localStorage → legacy-key → system-pref` chain. Standalone use of the iframe at its own domain is unaffected.

User toggle behavior: `toggleTheme()` continues to write to localStorage, so a toggle inside the iframe sticks for the current session. The next parent-issued reload re-asserts the URL theme — matching the "parent's theme is fresh on every iframe load" contract in `apps/tangle-cloud/src/blueprintApps/iframe/README.md`.

### 2. Polish the wallet-disconnected empty state

`/create` previously showed only a small amber inline strip when no wallet was connected. Inside the iframe (which has no top-level wallet CTA visible to a parent user that hasn't dropped focus into the iframe yet) this read as a "black void" of inactionable UI.

Added `ConnectWalletPanel`: a theme-aware card with a wallet icon, heading, one-line explainer, and a `ConnectKitButton.Custom`-driven Connect button. Uses existing `cloud-elements-*` design tokens — no hardcoded `text-white` / `bg-black`. Shown at the top of `/create` whenever the wallet is disconnected (and not reconnecting).

## Tests

- 8 new bootstrap-script unit tests in `ui/src/lib/theme.test.ts` covering:
  - URL theme honored on first paint (both `light` and `dark`)
  - URL overrides a persisted user preference
  - Invalid `?theme=` values fall through to the localStorage chain
  - Legacy `sandbox_cloud_theme` key still migrated
  - System preference used when nothing else is set
  - No URL param means no localStorage write (don't freeze system-pref users)
- All 41 test files / 407 tests pass: `pnpm -C ui run test`
- `pnpm -C ui run typecheck` clean
- `pnpm -C ui run build` clean

## Scope

Only `ui/**` changes. No sandbox-runtime / packages touched. No new dependencies. No backward-compat shims.

## Test plan

- [x] `pnpm -C ui run typecheck`
- [x] `pnpm -C ui run test`
- [x] `pnpm -C ui run build`
- [x] Verify inline bootstrap is present in `build/client/index.html`
- [ ] After merge → CF Pages auto-deploy → screenshot from `develop.cloud.tangle.tools/blueprints/sandbox` in both light and dark themes