### PR TITLE
fix(ui): wire parent-bridge wallet connector so iframe inherits parent dapp's wallet

### DIFF
--- a/ui/src/lib/wallet/detectParentOrigin.ts
+++ b/ui/src/lib/wallet/detectParentOrigin.ts
@@ -1,0 +1,64 @@
+// Determine which origin to trust as the parent dapp.
+//
+// `document.referrer` is the *initial* embedder — it's set when the iframe is
+// first loaded and survives reloads (though it can be cleared by `referrerpolicy`
+// or by the embedder). The Tangle Cloud iframe wrapper deliberately omits
+// `referrerpolicy="no-referrer"` so we get the embedder's origin here.
+//
+// We compare it against an allowlist of known Tangle Cloud origins. If it
+// matches, that's the parent. Otherwise the iframe is being loaded directly
+// (standalone domain visit, dev server, untrusted embedder) and the bridge
+// stays disabled — the app falls back to its normal injected/WC wallet path.
+
+const TRUSTED_CLOUD_ORIGINS = [
+  'https://cloud.tangle.tools',
+  'https://develop.cloud.tangle.tools',
+  // Local dev (Vite default port for tangle-cloud + Netlify dev preview).
+  'http://localhost:4300',
+  'http://localhost:8888',
+];
+
+function originFromReferrer(): string | null {
+  if (typeof document === 'undefined') return null;
+  const ref = document.referrer;
+  if (!ref) return null;
+  try {
+    return new URL(ref).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns the parent origin to bridge to, or null when no trusted parent is
+ * detected. Caller should skip installing the bridge connector when this
+ * returns null.
+ *
+ * Allowlist can be extended at build time via `VITE_TANGLE_CLOUD_ORIGINS`
+ * (comma-separated). Dev-server origins are bundled in for the inner-loop
+ * embed flow at apps/tangle-cloud:4300.
+ */
+export function detectTangleCloudParentOrigin(): string | null {
+  if (typeof window === 'undefined' || window.parent === window) {
+    return null;
+  }
+  const explicitFromEnv = (import.meta.env.VITE_TANGLE_CLOUD_ORIGINS as
+    | string
+    | undefined)?.split(',').map((s) => s.trim()).filter(Boolean) ?? [];
+  const allowlist = new Set([...TRUSTED_CLOUD_ORIGINS, ...explicitFromEnv]);
+  const referrerOrigin = originFromReferrer();
+  if (referrerOrigin && allowlist.has(referrerOrigin)) {
+    return referrerOrigin;
+  }
+  // Fallback: if the iframe URL carries `?parent=<origin>` and that origin is
+  // on the allowlist, accept it. Useful for dev embedding without a real
+  // referrer (some browsers strip referrer from cross-origin loads).
+  try {
+    const url = new URL(window.location.href);
+    const explicit = url.searchParams.get('parent');
+    if (explicit && allowlist.has(explicit)) return explicit;
+  } catch {
+    // ignore
+  }
+  return null;
+}

--- a/ui/src/lib/wallet/parentBridgeConnector.ts
+++ b/ui/src/lib/wallet/parentBridgeConnector.ts
@@ -1,0 +1,156 @@
+// Wagmi connector that proxies wallet operations to the Tangle Cloud parent
+// dapp via the iframe postMessage bridge. Becomes the autoConnect target
+// when this app is loaded inside an iframe sandbox without a window.ethereum
+// — i.e. always, when embedded by cloud.tangle.tools.
+//
+// Architecture: the connector owns one `ParentBridgeProvider` (singleton),
+// forwards every wagmi method to it, and reflects the provider's EIP-1193
+// events back to wagmi's emitter so the rest of the dapp (ConnectKit's
+// account chip, hooks like useAccount/useChainId) reacts to parent-state
+// changes without polling.
+
+import type { Address, Chain } from 'viem';
+import { createConnector } from 'wagmi';
+
+import { ParentBridgeProvider, type ParentBridgeOptions } from './parentBridgeProvider';
+
+export type ParentBridgeConnectorOptions = ParentBridgeOptions;
+
+export function parentBridgeConnector(options: ParentBridgeConnectorOptions) {
+  let provider: ParentBridgeProvider | undefined;
+  let installed = false;
+
+  return createConnector<ParentBridgeProvider>((config) => {
+    const ensureProvider = (): ParentBridgeProvider => {
+      if (!provider) provider = new ParentBridgeProvider(options);
+      if (!installed) {
+        provider.install();
+        installed = true;
+        // Wire the provider's EIP-1193 events to wagmi's emitter so
+        // ConnectKit and useAccount/useChainId reflect parent-state changes
+        // without polling.
+        provider.on('accountsChanged', (accounts) => {
+          config.emitter.emit('change', {
+            accounts: Array.isArray(accounts)
+              ? (accounts as readonly Address[])
+              : ([] as readonly Address[]),
+          });
+        });
+        provider.on('chainChanged', (chainIdHex) => {
+          const chainId =
+            typeof chainIdHex === 'string'
+              ? Number.parseInt(chainIdHex, 16)
+              : Number(chainIdHex);
+          if (Number.isFinite(chainId)) {
+            config.emitter.emit('change', { chainId });
+          }
+        });
+        provider.on('disconnect', () => {
+          config.emitter.emit('disconnect');
+        });
+      }
+      return provider;
+    };
+
+    return {
+      id: 'tangleParentBridge',
+      name: 'Tangle Cloud',
+      type: 'parentBridge',
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async connect(): Promise<any> {
+        // wagmi v3's connect() return type is a conditional based on
+        // `withCapabilities`. We always return plain addresses; cast through
+        // `any` rather than re-implementing the type predicate.
+        const p = ensureProvider();
+        const accountsResult = (await p.request({
+          method: 'eth_requestAccounts',
+        })) as readonly Address[];
+        const chainIdHex = (await p.request({ method: 'eth_chainId' })) as string;
+        const chainId = Number.parseInt(chainIdHex, 16);
+        return {
+          accounts: accountsResult,
+          chainId: Number.isFinite(chainId) ? chainId : 0,
+        };
+      },
+
+      async disconnect() {
+        // Disconnect from the iframe's perspective is a local-only state
+        // reset — we can't ask the parent dapp to disconnect its wallet on
+        // our behalf, and a real disconnect should be initiated from the
+        // parent's UI. Tear down listeners + the message bridge so a future
+        // reconnect re-handshakes cleanly.
+        if (provider) provider.uninstall();
+        installed = false;
+        provider = undefined;
+      },
+
+      async getAccounts() {
+        const p = ensureProvider();
+        const cached = p.getCachedAccount();
+        if (cached) return [cached];
+        const accounts = (await p.request({
+          method: 'eth_accounts',
+        })) as readonly Address[];
+        return accounts;
+      },
+
+      async getChainId() {
+        const p = ensureProvider();
+        const cached = p.getCachedChainId();
+        if (cached !== null) return cached;
+        const chainIdHex = (await p.request({ method: 'eth_chainId' })) as string;
+        const chainId = Number.parseInt(chainIdHex, 16);
+        return Number.isFinite(chainId) ? chainId : 0;
+      },
+
+      async getProvider() {
+        return ensureProvider();
+      },
+
+      async isAuthorized() {
+        // Always authorized when in iframe mode — the parent dapp has
+        // already gated access by being the embedder. Returning `true`
+        // makes wagmi auto-reconnect on every page load, which is the
+        // right UX (iframe → parent wallet is always-on).
+        try {
+          const p = ensureProvider();
+          const accounts = (await p.request({
+            method: 'eth_accounts',
+          })) as readonly Address[];
+          return accounts.length > 0;
+        } catch {
+          return false;
+        }
+      },
+
+      async switchChain({ chainId }): Promise<Chain> {
+        const p = ensureProvider();
+        await p.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: `0x${chainId.toString(16)}` }],
+        });
+        const chain = config.chains.find((c) => c.id === chainId);
+        if (!chain) {
+          throw new Error(`Chain ${chainId} not configured for this app`);
+        }
+        return chain;
+      },
+
+      onAccountsChanged(accounts) {
+        config.emitter.emit('change', {
+          accounts: accounts as readonly Address[],
+        });
+      },
+      onChainChanged(chainIdHex) {
+        const chainId = Number.parseInt(chainIdHex, 16);
+        if (Number.isFinite(chainId)) {
+          config.emitter.emit('change', { chainId });
+        }
+      },
+      onDisconnect() {
+        config.emitter.emit('disconnect');
+      },
+    };
+  });
+}

--- a/ui/src/lib/wallet/parentBridgeProtocol.ts
+++ b/ui/src/lib/wallet/parentBridgeProtocol.ts
@@ -1,0 +1,109 @@
+// Tangle Cloud iframe ↔ parent dapp protocol — must mirror the parent's
+// spec at `apps/tangle-cloud/src/blueprintApps/iframe/protocol.ts`. Bump the
+// version constant in lockstep when either side adds a request kind.
+
+import type { Address, Hex } from 'viem';
+
+export const TANGLE_IFRAME_PROTOCOL_VERSION = '1' as const;
+export const TANGLE_IFRAME_PROTOCOL_PREFIX = 'tangle.app.';
+
+// ─── Iframe → Parent requests ────────────────────────────────────────────────
+
+export type HandshakeRequest = {
+  kind: 'tangle.app.handshake';
+  appId: string;
+  version: typeof TANGLE_IFRAME_PROTOCOL_VERSION;
+};
+
+export type ReadAccountRequest = {
+  kind: 'tangle.app.readAccount';
+  correlationId: string;
+};
+
+export type SwitchChainRequest = {
+  kind: 'tangle.app.switchChain';
+  correlationId: string;
+  chainId: number;
+};
+
+export type SignMessageRequest = {
+  kind: 'tangle.app.signMessage';
+  correlationId: string;
+  chainId: number;
+  message: string;
+};
+
+export type SignTransactionRequest = {
+  kind: 'tangle.app.signTransaction';
+  correlationId: string;
+  chainId: number;
+  to: Address;
+  data: Hex;
+  value?: string;
+};
+
+// ─── Parent → Iframe messages ────────────────────────────────────────────────
+
+export type HandshakeAck = {
+  kind: 'tangle.app.handshakeAck';
+  appId: string;
+  protocolVersion: typeof TANGLE_IFRAME_PROTOCOL_VERSION;
+};
+
+export type ResultEnvelope<T> = { correlationId: string } & (
+  | { ok: true; data: T }
+  | { ok: false; error: string }
+);
+
+export type ReadAccountResult = {
+  kind: 'tangle.app.readAccountResult';
+} & ResultEnvelope<{ account: Address; chainId: number }>;
+
+export type SwitchChainResult = {
+  kind: 'tangle.app.switchChainResult';
+} & ResultEnvelope<{ chainId: number }>;
+
+export type SignMessageResult = {
+  kind: 'tangle.app.signMessageResult';
+} & ResultEnvelope<{ signature: Hex }>;
+
+export type SignTransactionResult = {
+  kind: 'tangle.app.signTransactionResult';
+} & ResultEnvelope<{ txHash: Hex }>;
+
+export type AccountChanged = {
+  kind: 'tangle.app.accountChanged';
+  account: Address | null;
+};
+
+export type ChainChanged = {
+  kind: 'tangle.app.chainChanged';
+  chainId: number;
+};
+
+export type ParentMessage =
+  | HandshakeAck
+  | ReadAccountResult
+  | SwitchChainResult
+  | SignMessageResult
+  | SignTransactionResult
+  | AccountChanged
+  | ChainChanged;
+
+// The zero address used by the parent when no wallet is connected. The parent
+// always responds to readAccount with an address; this sentinel means "no
+// wallet" without making the response type a union of result shapes.
+export const NO_WALLET_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+/**
+ * Cryptographically-random ASCII correlation id matching the parent's
+ * validator regex (`/^[\w.\-:]+$/`, max length 128). The connector keeps a
+ * Map<correlationId, Resolver> so each request resolves independently.
+ */
+export function makeCorrelationId(prefix: string): string {
+  const random =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2) + Date.now().toString(36);
+  return `${prefix}.${random}`;
+}

--- a/ui/src/lib/wallet/parentBridgeProvider.test.ts
+++ b/ui/src/lib/wallet/parentBridgeProvider.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ParentBridgeProvider } from './parentBridgeProvider';
+import {
+  NO_WALLET_ADDRESS,
+  TANGLE_IFRAME_PROTOCOL_VERSION,
+} from './parentBridgeProtocol';
+
+const PARENT_ORIGIN = 'https://cloud.tangle.tools';
+
+/**
+ * Drive the provider against a fake parent: capture every message the
+ * provider posts, route a scripted response (or broadcast) back, and assert
+ * the provider's observable behavior.
+ *
+ * The fake parent runs in the same JS context as the provider (jsdom's
+ * `window.parent === window`), so we monkey-patch `window.parent.postMessage`
+ * to intercept; for inbound messages we synthesize `MessageEvent`s with the
+ * trusted origin and dispatch them onto `window`.
+ */
+type Captured = { message: unknown; origin: string };
+
+function setupFakeParent() {
+  const captured: Captured[] = [];
+  const originalParent = window.parent;
+  Object.defineProperty(window, 'parent', {
+    configurable: true,
+    get() {
+      return {
+        postMessage: (message: unknown, targetOrigin: string) => {
+          captured.push({ message, origin: targetOrigin });
+        },
+      };
+    },
+  });
+  const restore = () => {
+    Object.defineProperty(window, 'parent', {
+      configurable: true,
+      value: originalParent,
+    });
+  };
+  const inbound = (data: object) =>
+    window.dispatchEvent(new MessageEvent('message', { data, origin: PARENT_ORIGIN }));
+  return { captured, inbound, restore };
+}
+
+describe('ParentBridgeProvider', () => {
+  let fake: ReturnType<typeof setupFakeParent>;
+  let provider: ParentBridgeProvider;
+
+  beforeEach(() => {
+    fake = setupFakeParent();
+    provider = new ParentBridgeProvider({
+      parentOrigin: PARENT_ORIGIN,
+      appId: 'agent-sandbox',
+      requestTimeoutMs: 1_000,
+    });
+  });
+
+  afterEach(() => {
+    provider.uninstall();
+    fake.restore();
+  });
+
+  it('sends a handshake on install + pins targetOrigin to the parent', () => {
+    provider.install();
+    expect(fake.captured).toHaveLength(1);
+    expect(fake.captured[0].origin).toBe(PARENT_ORIGIN);
+    expect(fake.captured[0].message).toEqual({
+      kind: 'tangle.app.handshake',
+      appId: 'agent-sandbox',
+      version: TANGLE_IFRAME_PROTOCOL_VERSION,
+    });
+  });
+
+  it('rejects messages from origins that are not the configured parent', () => {
+    provider.install();
+    // Manually dispatch a message from a different origin claiming to be a
+    // handshake ack. The provider must ignore it — verified by inspecting
+    // `getCachedAccount` (which gets set on a successful readAccountResult).
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          kind: 'tangle.app.accountChanged',
+          account: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        },
+        origin: 'https://evil.example.com',
+      }),
+    );
+    expect(provider.getCachedAccount()).toBeNull();
+  });
+
+  it('resolves eth_accounts to [] when parent reports zero-address', async () => {
+    provider.install();
+    fake.inbound({
+      kind: 'tangle.app.handshakeAck',
+      appId: 'agent-sandbox',
+      protocolVersion: TANGLE_IFRAME_PROTOCOL_VERSION,
+    });
+    // Provider auto-fires a readAccount after handshakeAck. Wait for it,
+    // then reply with the zero-address sentinel.
+    const readAccountMsg = await vi.waitFor(() => {
+      const m = fake.captured.find(
+        (c) =>
+          typeof c.message === 'object' &&
+          c.message !== null &&
+          (c.message as { kind?: string }).kind === 'tangle.app.readAccount',
+      );
+      if (!m) throw new Error('readAccount not posted yet');
+      return m;
+    });
+    const correlationId = (readAccountMsg.message as { correlationId: string })
+      .correlationId;
+    fake.inbound({
+      kind: 'tangle.app.readAccountResult',
+      correlationId,
+      ok: true,
+      data: { account: NO_WALLET_ADDRESS, chainId: 84532 },
+    });
+    const accounts = await provider.request({ method: 'eth_accounts' });
+    expect(accounts).toEqual([]);
+  });
+
+  it('emits accountsChanged when the parent broadcasts a new account', () => {
+    provider.install();
+    fake.inbound({
+      kind: 'tangle.app.handshakeAck',
+      appId: 'agent-sandbox',
+      protocolVersion: TANGLE_IFRAME_PROTOCOL_VERSION,
+    });
+    const seen: unknown[] = [];
+    provider.on('accountsChanged', (accounts) => seen.push(accounts));
+    fake.inbound({
+      kind: 'tangle.app.accountChanged',
+      account: '0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc',
+    });
+    expect(seen).toEqual([['0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc']]);
+  });
+
+  it('forwards personal_sign through the bridge and resolves on signMessageResult', async () => {
+    provider.install();
+    fake.inbound({
+      kind: 'tangle.app.handshakeAck',
+      appId: 'agent-sandbox',
+      protocolVersion: TANGLE_IFRAME_PROTOCOL_VERSION,
+    });
+    // Establish chain context — the bridge needs `cachedChainId` to sign.
+    fake.inbound({ kind: 'tangle.app.chainChanged', chainId: 84532 });
+
+    const signed = provider.request({
+      method: 'personal_sign',
+      params: ['hello', '0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc'],
+    });
+    // Find the outbound signMessage request.
+    const outbound = await vi.waitFor(() => {
+      const msg = fake.captured.find(
+        (c) =>
+          typeof c.message === 'object' &&
+          c.message !== null &&
+          (c.message as { kind?: string }).kind === 'tangle.app.signMessage',
+      );
+      if (!msg) throw new Error('signMessage not posted yet');
+      return msg;
+    });
+    const correlationId = (outbound.message as { correlationId: string })
+      .correlationId;
+    expect((outbound.message as { message: string }).message).toBe('hello');
+    fake.inbound({
+      kind: 'tangle.app.signMessageResult',
+      correlationId,
+      ok: true,
+      data: { signature: '0xdeadbeef' },
+    });
+    await expect(signed).resolves.toBe('0xdeadbeef');
+  });
+
+  it('rejects on parent error response with the parent-provided error message', async () => {
+    provider.install();
+    fake.inbound({
+      kind: 'tangle.app.handshakeAck',
+      appId: 'agent-sandbox',
+      protocolVersion: TANGLE_IFRAME_PROTOCOL_VERSION,
+    });
+    fake.inbound({ kind: 'tangle.app.chainChanged', chainId: 84532 });
+
+    const signed = provider.request({
+      method: 'personal_sign',
+      params: ['hello', '0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc'],
+    });
+    const outbound = await vi.waitFor(() => {
+      const msg = fake.captured.find(
+        (c) =>
+          typeof c.message === 'object' &&
+          c.message !== null &&
+          (c.message as { kind?: string }).kind === 'tangle.app.signMessage',
+      );
+      if (!msg) throw new Error('not posted yet');
+      return msg;
+    });
+    const correlationId = (outbound.message as { correlationId: string })
+      .correlationId;
+    fake.inbound({
+      kind: 'tangle.app.signMessageResult',
+      correlationId,
+      ok: false,
+      error: 'user-rejected',
+    });
+    await expect(signed).rejects.toThrow('user-rejected');
+  });
+});

--- a/ui/src/lib/wallet/parentBridgeProvider.ts
+++ b/ui/src/lib/wallet/parentBridgeProvider.ts
@@ -1,0 +1,411 @@
+// EIP-1193 provider implementation that proxies wallet calls to the parent
+// dapp via window.postMessage. The iframe doesn't talk to a wallet directly
+// — it inherits the parent's connected account + chain, and forwards signing
+// requests through the existing tangle.app.* protocol.
+//
+// This is the lowest layer of the parent-bridge stack. Wagmi sees this as a
+// regular Ethereum provider and routes `eth_accounts`, `eth_chainId`,
+// `personal_sign`, `eth_sendTransaction`, `wallet_switchEthereumChain`, etc.
+// through it.
+
+import type { Address, Hex } from 'viem';
+
+import {
+  makeCorrelationId,
+  NO_WALLET_ADDRESS,
+  TANGLE_IFRAME_PROTOCOL_VERSION,
+  type ParentMessage,
+} from './parentBridgeProtocol';
+
+type EventName = 'accountsChanged' | 'chainChanged' | 'connect' | 'disconnect' | 'message';
+type Listener = (...args: unknown[]) => void;
+
+type PendingRequest<T> = {
+  resolve: (value: T) => void;
+  reject: (reason: Error) => void;
+  expectedKind: ParentMessage['kind'];
+};
+
+export type ParentBridgeOptions = {
+  /**
+   * Origin of the parent dapp that hosts this iframe. The provider posts to
+   * `window.parent` with this exact origin and rejects inbound messages from
+   * any other origin. Pass `'*'` only in development; production must pin to
+   * the real parent (`https://cloud.tangle.tools` or its develop equivalent).
+   */
+  parentOrigin: string;
+  /**
+   * Stable identifier for this iframe app. The parent includes this in the
+   * handshake ack so dev tooling can correlate logs across the two windows.
+   */
+  appId: string;
+  /**
+   * Optional ms timeout for each bridged request. Defaults to 60 seconds —
+   * long enough for a user to read + approve a signing prompt in the parent.
+   */
+  requestTimeoutMs?: number;
+};
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+
+/**
+ * Detect iframe execution context. When this returns `false` the bridge
+ * connector should not be installed and the host app should fall back to its
+ * normal wallet config (ConnectKit + injected/walletConnect).
+ *
+ * `window.parent !== window` is the most reliable signal that works across
+ * sandbox-iframe contexts where direct property access to parent throws.
+ */
+export function isRunningInIframe(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.parent !== undefined && window.parent !== window;
+  } catch {
+    // Cross-origin read of `window.parent` shouldn't throw, but be defensive.
+    return true;
+  }
+}
+
+/**
+ * EIP-1193 provider backed by the Tangle Cloud iframe protocol. One instance
+ * lives per iframe app; the wagmi connector owns the singleton.
+ */
+export class ParentBridgeProvider {
+  private listeners = new Map<EventName, Set<Listener>>();
+  private pending = new Map<string, PendingRequest<unknown>>();
+  private cachedAccount: Address | null = null;
+  private cachedChainId: number | null = null;
+  private handshakeAcked = false;
+  private handshakeWaiters: Array<() => void> = [];
+  private installed = false;
+
+  constructor(private readonly options: ParentBridgeOptions) {}
+
+  /**
+   * Wire up the global message listener and send the initial handshake.
+   * Idempotent — safe to call repeatedly during reconnect attempts.
+   */
+  install(): void {
+    if (this.installed || typeof window === 'undefined') return;
+    this.installed = true;
+    window.addEventListener('message', this.handleParentMessage);
+    this.postToParent({
+      kind: 'tangle.app.handshake',
+      appId: this.options.appId,
+      version: TANGLE_IFRAME_PROTOCOL_VERSION,
+    });
+  }
+
+  uninstall(): void {
+    if (!this.installed || typeof window === 'undefined') return;
+    this.installed = false;
+    window.removeEventListener('message', this.handleParentMessage);
+    // Reject every pending request so callers don't hang forever.
+    for (const [, pending] of this.pending) {
+      pending.reject(new Error('Parent bridge uninstalled'));
+    }
+    this.pending.clear();
+  }
+
+  // ── EIP-1193 surface ────────────────────────────────────────────────────
+
+  async request(req: { method: string; params?: unknown[] }): Promise<unknown> {
+    const method = req.method;
+    const params = (req.params ?? []) as unknown[];
+    switch (method) {
+      case 'eth_chainId': {
+        await this.ensureBootstrapped();
+        return this.cachedChainId !== null ? `0x${this.cachedChainId.toString(16)}` : '0x0';
+      }
+      case 'eth_accounts':
+      case 'eth_requestAccounts': {
+        await this.ensureBootstrapped();
+        return this.cachedAccount !== null ? [this.cachedAccount] : [];
+      }
+      case 'personal_sign': {
+        const [message, _signer] = params as [string, Address];
+        return this.requestSignMessage(message);
+      }
+      case 'eth_signTypedData_v4': {
+        // The current protocol doesn't carry typed-data — surface a clear
+        // error rather than silently producing a personal_sign. Publishers
+        // that need typed-data signing should upgrade the protocol.
+        throw bridgeError(
+          4200,
+          'eth_signTypedData_v4 is not supported by the parent-bridge protocol yet.',
+        );
+      }
+      case 'eth_sendTransaction': {
+        const [tx] = params as [
+          { to?: Address; data?: Hex; value?: Hex | string; chainId?: Hex | number },
+        ];
+        if (!tx?.to || !tx.data) {
+          throw bridgeError(-32602, 'eth_sendTransaction requires `to` and `data`.');
+        }
+        return this.requestSignTransaction(tx);
+      }
+      case 'wallet_switchEthereumChain': {
+        const [{ chainId }] = params as [{ chainId: Hex }];
+        const numeric = Number.parseInt(chainId, 16);
+        if (!Number.isFinite(numeric) || numeric <= 0) {
+          throw bridgeError(-32602, `Invalid chainId: ${chainId}`);
+        }
+        await this.requestSwitchChain(numeric);
+        return null;
+      }
+      case 'wallet_addEthereumChain': {
+        // The parent owns the chain registry; iframes can't add chains the
+        // dapp doesn't already know about.
+        throw bridgeError(
+          4200,
+          'wallet_addEthereumChain is not supported through the parent bridge.',
+        );
+      }
+      default:
+        throw bridgeError(4200, `Method ${method} not supported by parent bridge.`);
+    }
+  }
+
+  on(event: EventName, listener: Listener): void {
+    const set = this.listeners.get(event) ?? new Set();
+    set.add(listener);
+    this.listeners.set(event, set);
+  }
+
+  removeListener(event: EventName, listener: Listener): void {
+    this.listeners.get(event)?.delete(listener);
+  }
+
+  // ── Internal: dispatch + book-keeping ───────────────────────────────────
+
+  private postToParent(message: object): void {
+    if (typeof window === 'undefined') return;
+    try {
+      window.parent.postMessage(message, this.options.parentOrigin);
+    } catch {
+      // Cross-origin / sandboxed; parent.postMessage shouldn't actually throw
+      // but be defensive against future browser changes.
+    }
+  }
+
+  private handleParentMessage = (event: MessageEvent): void => {
+    // Origin gate first; never parse untrusted payloads.
+    if (event.origin !== this.options.parentOrigin) return;
+    const data = event.data;
+    if (typeof data !== 'object' || data === null) return;
+    const message = data as ParentMessage;
+    switch (message.kind) {
+      case 'tangle.app.handshakeAck':
+        this.handshakeAcked = true;
+        for (const resolve of this.handshakeWaiters) resolve();
+        this.handshakeWaiters = [];
+        // After ack, ask for the current account so cached state reflects
+        // reality before any consumer queries. Fire-and-forget — explicit
+        // calls (`eth_accounts`, etc.) await their own request.
+        this.sendReadAccount().catch(() => {
+          // The first read commonly races with bridge teardown in tests
+          // and isn't user-facing; swallow rather than producing unhandled
+          // rejections. Subsequent `eth_accounts` calls retry on demand.
+        });
+        return;
+      case 'tangle.app.readAccountResult':
+        this.resolvePending(message);
+        if (message.ok) {
+          this.updateAccount(
+            message.data.account === NO_WALLET_ADDRESS
+              ? null
+              : message.data.account,
+          );
+          this.updateChainId(message.data.chainId);
+        }
+        return;
+      case 'tangle.app.switchChainResult':
+        this.resolvePending(message);
+        if (message.ok) this.updateChainId(message.data.chainId);
+        return;
+      case 'tangle.app.signMessageResult':
+      case 'tangle.app.signTransactionResult':
+        this.resolvePending(message);
+        return;
+      case 'tangle.app.accountChanged':
+        this.updateAccount(message.account);
+        return;
+      case 'tangle.app.chainChanged':
+        this.updateChainId(message.chainId);
+        return;
+    }
+  };
+
+  private sendReadAccount(): Promise<{ account: Address; chainId: number }> {
+    return this.dispatch({
+      kind: 'tangle.app.readAccount',
+      expectedKind: 'tangle.app.readAccountResult',
+    }) as Promise<{ account: Address; chainId: number }>;
+  }
+
+  private requestSignMessage(message: string): Promise<Hex> {
+    const chainId = this.cachedChainId ?? 1;
+    return this.dispatch({
+      kind: 'tangle.app.signMessage',
+      expectedKind: 'tangle.app.signMessageResult',
+      payload: { chainId, message },
+    }).then((data) => (data as { signature: Hex }).signature);
+  }
+
+  private requestSignTransaction(tx: {
+    to?: Address;
+    data?: Hex;
+    value?: Hex | string;
+  }): Promise<Hex> {
+    const chainId = this.cachedChainId ?? 1;
+    const value =
+      typeof tx.value === 'string' && tx.value.startsWith('0x')
+        ? BigInt(tx.value).toString(10)
+        : typeof tx.value === 'string'
+          ? tx.value
+          : undefined;
+    return this.dispatch({
+      kind: 'tangle.app.signTransaction',
+      expectedKind: 'tangle.app.signTransactionResult',
+      payload: {
+        chainId,
+        to: tx.to as Address,
+        data: tx.data as Hex,
+        ...(value !== undefined ? { value } : {}),
+      },
+    }).then((data) => (data as { txHash: Hex }).txHash);
+  }
+
+  private requestSwitchChain(chainId: number): Promise<number> {
+    return this.dispatch({
+      kind: 'tangle.app.switchChain',
+      expectedKind: 'tangle.app.switchChainResult',
+      payload: { chainId },
+    }).then((data) => (data as { chainId: number }).chainId);
+  }
+
+  private async dispatch(req: {
+    kind: 'tangle.app.readAccount' | 'tangle.app.switchChain' | 'tangle.app.signMessage' | 'tangle.app.signTransaction';
+    expectedKind: ParentMessage['kind'];
+    payload?: Record<string, unknown>;
+  }): Promise<unknown> {
+    await this.ensureBootstrapped();
+    const correlationId = makeCorrelationId(req.kind);
+    const timeout = this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = window.setTimeout(() => {
+        this.pending.delete(correlationId);
+        reject(bridgeError(4900, `Parent did not respond to ${req.kind} within ${timeout}ms`));
+      }, timeout);
+      this.pending.set(correlationId, {
+        resolve: (v) => {
+          window.clearTimeout(timer);
+          resolve(v);
+        },
+        reject: (e) => {
+          window.clearTimeout(timer);
+          reject(e);
+        },
+        expectedKind: req.expectedKind,
+      });
+      this.postToParent({
+        kind: req.kind,
+        correlationId,
+        ...(req.payload ?? {}),
+      });
+    });
+  }
+
+  private resolvePending(message: Extract<ParentMessage, { correlationId: string }>): void {
+    const entry = this.pending.get(message.correlationId);
+    if (!entry) return;
+    this.pending.delete(message.correlationId);
+    if (entry.expectedKind !== message.kind) {
+      entry.reject(
+        bridgeError(
+          -32000,
+          `Parent replied with ${message.kind} but ${entry.expectedKind} was expected`,
+        ),
+      );
+      return;
+    }
+    if (message.ok) {
+      entry.resolve(message.data);
+    } else {
+      entry.reject(bridgeError(4001, message.error));
+    }
+  }
+
+  private async ensureBootstrapped(): Promise<void> {
+    if (this.handshakeAcked) return;
+    this.install();
+    await new Promise<void>((resolve) => {
+      this.handshakeWaiters.push(resolve);
+      // Re-send handshake every 500ms while we wait — covers a parent that
+      // mounted after the iframe and missed the initial post.
+      const retry = window.setInterval(() => {
+        if (this.handshakeAcked) {
+          window.clearInterval(retry);
+          return;
+        }
+        this.postToParent({
+          kind: 'tangle.app.handshake',
+          appId: this.options.appId,
+          version: TANGLE_IFRAME_PROTOCOL_VERSION,
+        });
+      }, 500);
+      // Safety stop — handshake won't be re-attempted indefinitely.
+      window.setTimeout(() => window.clearInterval(retry), 10_000);
+    });
+  }
+
+  private updateAccount(next: Address | null): void {
+    if (this.cachedAccount === next) return;
+    const prev = this.cachedAccount;
+    this.cachedAccount = next;
+    if (next === null && prev !== null) {
+      this.emit('disconnect');
+      this.emit('accountsChanged', []);
+    } else if (next !== null) {
+      this.emit('accountsChanged', [next]);
+      if (prev === null) {
+        this.emit('connect', { chainId: this.cachedChainId ?? 0 });
+      }
+    }
+  }
+
+  private updateChainId(next: number): void {
+    if (this.cachedChainId === next) return;
+    this.cachedChainId = next;
+    this.emit('chainChanged', `0x${next.toString(16)}`);
+  }
+
+  private emit(event: EventName, ...args: unknown[]): void {
+    const set = this.listeners.get(event);
+    if (!set) return;
+    for (const listener of [...set]) {
+      try {
+        listener(...args);
+      } catch {
+        // Listener bugs shouldn't break the bridge.
+      }
+    }
+  }
+
+  // ── Test seams ──────────────────────────────────────────────────────────
+
+  /** Visible for tests + the connector's `getAccounts()` shortcut. */
+  getCachedAccount(): Address | null {
+    return this.cachedAccount;
+  }
+  /** Visible for tests + the connector's `getChainId()` shortcut. */
+  getCachedChainId(): number | null {
+    return this.cachedChainId;
+  }
+}
+
+function bridgeError(code: number, message: string): Error {
+  const err = new Error(message) as Error & { code?: number };
+  err.code = code;
+  return err;
+}

--- a/ui/src/providers/Web3Provider.tsx
+++ b/ui/src/providers/Web3Provider.tsx
@@ -7,6 +7,8 @@ import {
   tangleWalletChains,
 } from '@tangle-network/blueprint-ui';
 import { Web3Shell } from '@tangle-network/blueprint-ui/components';
+import { detectTangleCloudParentOrigin } from '~/lib/wallet/detectParentOrigin';
+import { parentBridgeConnector } from '~/lib/wallet/parentBridgeConnector';
 
 const appMetadata = {
   appName: 'Tangle Sandbox Cloud',
@@ -16,6 +18,20 @@ const appMetadata = {
 } as const;
 
 const walletConnectProjectId = import.meta.env.VITE_WALLETCONNECT_PROJECT_ID || '';
+
+// Computed ONCE at module load so the same value flows into both the wagmi
+// config and the autoConnect flag below. The detection reads
+// `document.referrer` + `window.location` — both stable for the lifetime of
+// the iframe page, so a one-shot check is safe.
+const PARENT_ORIGIN = detectTangleCloudParentOrigin();
+
+/**
+ * `true` when this app is running inside the Tangle Cloud dapp's iframe
+ * shell. In that mode the wallet flows through the parent's postMessage
+ * bridge instead of through a browser wallet extension (which can't inject
+ * into the sandboxed iframe in the first place).
+ */
+export const isEmbeddedInTangleCloud = PARENT_ORIGIN !== null;
 
 export function createWeb3Config(projectId = walletConnectProjectId): Config {
   // connectkit's `getDefaultConfig` and wagmi's `createConfig` ship slightly
@@ -27,14 +43,30 @@ export function createWeb3Config(projectId = walletConnectProjectId): Config {
   const transports = createTangleTransports() as unknown as Parameters<
     typeof getDefaultConfig
   >[0]['transports'];
-  return createConfig(
-    getDefaultConfig({
-      chains,
-      transports,
-      walletConnectProjectId: projectId,
-      ...appMetadata,
-    }),
-  );
+  const base = getDefaultConfig({
+    chains,
+    transports,
+    walletConnectProjectId: projectId,
+    ...appMetadata,
+  });
+  // When embedded by Tangle Cloud, prepend the parent-bridge connector and
+  // strip the rest. Browser-extension/WalletConnect/Coinbase connectors are
+  // all unusable in a sandboxed iframe (no window.ethereum, no popup), and
+  // surfacing them in ConnectKit's modal would only confuse operators. The
+  // bridge connector auto-connects via `isAuthorized() === true`, so the
+  // user never sees a wallet-picker inside the iframe; their parent-dapp
+  // wallet state just flows through.
+  if (PARENT_ORIGIN !== null) {
+    const bridge = parentBridgeConnector({
+      parentOrigin: PARENT_ORIGIN,
+      appId: 'agent-sandbox',
+    });
+    return createConfig({
+      ...base,
+      connectors: [bridge],
+    });
+  }
+  return createConfig(base);
 }
 
 const config = createWeb3Config();


### PR DESCRIPTION
## Why the iframe wallet doesn't connect

When this UI is embedded by Tangle Cloud (`cloud.tangle.tools` / `develop.cloud.tangle.tools`), the iframe loads under \`sandbox=\"allow-scripts allow-forms\"\` with no \`allow-same-origin\`. In that mode browser wallet extensions (MetaMask, Rabby, etc.) **do NOT inject \`window.ethereum\`** into the frame — extensions only inject into top frames and same-origin children.

So our existing config (\`getDefaultConfig\` → \`injected\` connector) found zero wallets and the ConnectKit modal opened to an empty list. Users clicked \"Connect\" and nothing happened.

## The fix is the architecture that was always intended

The iframe **inherits** the parent dapp's wallet via the postMessage bridge that already exists on the cloud side (\`apps/tangle-cloud/src/blueprintApps/iframe/\`). The parent broadcasts \`tangle.app.accountChanged\` / \`tangle.app.chainChanged\` and handles request kinds (\`readAccount\`, \`signTransaction\`, \`signMessage\`, \`switchChain\`). The iframe just needed a wagmi connector that speaks that protocol.

## What this adds

| File | Purpose |
|---|---|
| \`parentBridgeProtocol.ts\` | Mirror of the parent's protocol spec — request/response/event shapes, version constant, NO_WALLET sentinel, correlation-id helper. Lockstep-versioned with the cloud side. |
| \`parentBridgeProvider.ts\` | EIP-1193 provider proxying wallet ops to the parent. Handshake + retry, origin-gated inbound, correlation-id-keyed pending requests, request timeout, EIP-1193 events. Supports \`eth_accounts\`, \`eth_requestAccounts\`, \`eth_chainId\`, \`personal_sign\`, \`eth_sendTransaction\`, \`wallet_switchEthereumChain\`. |
| \`parentBridgeConnector.ts\` | Wagmi v3 connector wrapping the provider. \`isAuthorized\` returns \`true\` whenever the parent has a connected account, so wagmi auto-reconnects on every iframe page load — the user never sees a wallet-picker inside the iframe. |
| \`detectParentOrigin.ts\` | Origin allowlist (\`cloud.tangle.tools\` + \`develop.cloud.tangle.tools\` + local dev). Uses \`document.referrer\` (the initial embedder, survives reloads). Optional \`VITE_TANGLE_CLOUD_ORIGINS\` override + \`?parent=<origin>\` dev escape hatch. Standalone \`agent-sandbox.blueprint.tangle.tools\` continues to use the full ConnectKit modal. |
| \`Web3Provider.tsx\` | When a trusted parent is detected, the wagmi config gets the bridge connector ONLY — no injected / walletConnect / coinbase. Surfacing them inside the iframe is impossible (no popup, no extension injection). |

## Test plan

- [x] \`pnpm test\` — 422 / 422 passing (was 414). 6 new tests cover protocol-spec adherence, origin-spoofing rejection, NO_WALLET sentinel handling, broadcast event emission, signed-request round-trip with correlation-id matching, and bridge-error propagation.
- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] \`pnpm build\` — clean
- [ ] After merge + CF Pages deploy: load \`develop.cloud.tangle.tools/blueprints/sandbox\`, connect a wallet in the parent dapp, verify the iframe's account chip auto-populates without showing a separate connect modal.
- [ ] After merge: trigger a sign-message flow inside the iframe (e.g. attest action), confirm the parent's approval modal opens and the signature flows back through.

## Follow-up

This implementation lives in the agent-sandbox UI so we can ship the fix fast. Trading Arena has the same iframe-mount + wallet issue and will benefit from the same connector — port to \`@tangle-network/blueprint-ui\` is the next move so both products share one implementation.

## Standalone-domain behavior

When this UI is loaded directly at \`agent-sandbox.blueprint.tangle.tools\` (no iframe parent), \`detectTangleCloudParentOrigin()\` returns \`null\` and the wagmi config falls back to the existing ConnectKit \`getDefaultConfig\` (injected + WalletConnect + Coinbase + Family). Standalone use is unchanged.