### PR TITLE
ci: native multi-binary release (all blueprints)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,161 +1,54 @@
-# Reusable release workflow for Tangle blueprint operators.
-# Copy this to .github/workflows/release.yml in each blueprint repo.
-#
-# Triggers on version tags (v0.1.0, v1.2.3, etc.).
-# Builds for linux/amd64, linux/arm64, macOS/arm64.
-# Uploads binaries + sha256 checksums as GitHub Release assets.
-#
-# Prerequisites:
-#   - Cargo.toml has [[bin]] with the operator binary name
-#   - rust-toolchain.toml pins the Rust version (e.g. 1.91)
-#
-# Usage:
-#   git tag v0.1.0 && git push origin v0.1.0
-
 name: Release
 
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag: { description: 'Existing tag to (re)build', required: true }
 
 permissions:
   contents: write
 
 env:
   CARGO_TERM_COLOR: always
-  # Use cmake builder for aws-lc-sys to bypass GCC memcmp bug in cross containers
-  AWS_LC_SYS_CMAKE_BUILDER: 1
-  # The binary name from [[bin]] in operator/Cargo.toml.
-  # Override per repo if different.
-  BINARY_NAME: ${{ vars.BINARY_NAME || 'ai-agent-instance-blueprint' }}
+  # This repo ships multiple blueprints — build + host every operator binary.
+  BINARIES: "ai-agent-sandbox-blueprint ai-agent-instance-blueprint ai-agent-tee-instance-blueprint"
+  TARGET: x86_64-unknown-linux-gnu
 
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-            use_cross: true
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
-            use_cross: true
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            use_cross: true
-          - target: aarch64-apple-darwin
-            os: macos-14
-            use_cross: false
-
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libssl-dev pkg-config
-
-      - name: Install system dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: brew install protobuf
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Install cross
-        if: matrix.use_cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
-
-      - name: Build release binary
-        run: |
-          BUILD_CMD="cargo"
-          if [ "${{ matrix.use_cross }}" = "true" ]; then
-            BUILD_CMD="cross"
-          fi
-          $BUILD_CMD build --release --target ${{ matrix.target }}
-
-      - name: Package archive
-        run: |
-          BIN="target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}"
-          ARCHIVE="${{ env.BINARY_NAME }}-${{ matrix.target }}.tar.xz"
-
-          # Strip debug symbols (saves 50-80% size)
-          if command -v llvm-strip &>/dev/null; then
-            llvm-strip "$BIN" 2>/dev/null || true
-          elif command -v strip &>/dev/null; then
-            strip "$BIN" 2>/dev/null || true
-          fi
-
-          tar -cJf "$ARCHIVE" -C "$(dirname "$BIN")" "${{ env.BINARY_NAME }}"
-
-          # Generate checksums
-          sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256"
-          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
-          echo "SHA256_FILE=${ARCHIVE}.sha256" >> "$GITHUB_ENV"
-          echo "Binary size: $(du -h "$BIN" | cut -f1)"
-          echo "Archive size: $(du -h "$ARCHIVE" | cut -f1)"
-          cat "${ARCHIVE}.sha256"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.BINARY_NAME }}-${{ matrix.target }}
-          path: |
-            ${{ env.ARCHIVE }}
-            ${{ env.SHA256_FILE }}
-
   release:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
         with:
-          path: artifacts/
-
-      - name: Create GitHub Release
+          ref: ${{ github.event.inputs.tag && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
+      - name: System dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libssl-dev pkg-config
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build all blueprint binaries
+        run: |
+          ARGS=""; for b in $BINARIES; do ARGS="$ARGS --bin $b"; done
+          cargo build --release $ARGS
+      - name: Package each binary + checksum
+        run: |
+          FILES=""
+          for b in $BINARIES; do
+            BIN="target/release/$b"
+            test -f "$BIN" || { echo "::error::missing $BIN"; exit 1; }
+            strip "$BIN" 2>/dev/null || true
+            A="${b}-${TARGET}.tar.xz"
+            tar -cJf "$A" -C target/release "$b"
+            sha256sum "$A" > "${A}.sha256"; cat "${A}.sha256"
+            FILES="$FILES $A ${A}.sha256"
+          done
+          echo "FILES=$FILES" >> "$GITHUB_ENV"
+      - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="${GITHUB_REF_NAME}"
-
-          # Collect all archives and checksums
-          FILES=$(find artifacts/ -name "*.tar.xz" -o -name "*.sha256" | sort)
-
-          # Generate release notes from tag message or changelog
-          NOTES="## Binary Downloads
-
-          | Platform | Archive | SHA256 |
-          |----------|---------|--------|"
-
-          for f in $(find artifacts/ -name "*.tar.xz" | sort); do
-            BASENAME=$(basename "$f")
-            SHA=$(cat "${f}.sha256" | awk '{print $1}')
-            TARGET=$(echo "$BASENAME" | sed "s/${BINARY_NAME}-//" | sed 's/\.tar\.xz//')
-            NOTES="$NOTES
-          | \`$TARGET\` | \`$BASENAME\` | \`${SHA:0:16}...\` |"
-          done
-
-          NOTES="$NOTES
-
-          ### Verify checksums
-          \`\`\`bash
-          sha256sum -c *.sha256
-          \`\`\`
-
-          ### Install
-          \`\`\`bash
-          curl -sSL https://github.com/${{ github.repository }}/releases/download/$TAG/${BINARY_NAME}-x86_64-unknown-linux-gnu.tar.xz | tar xJ
-          chmod +x ${BINARY_NAME}
-          \`\`\`
-          "
-
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --notes "$NOTES" \
-            $FILES
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
+            || gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes "Operator binaries (${TARGET}): $BINARIES"
+          gh release upload "$TAG" $FILES --repo "$GITHUB_REPOSITORY" --clobber


### PR DESCRIPTION
Builds + hosts every blueprint operator binary: `ai-agent-sandbox-blueprint ai-agent-instance-blueprint ai-agent-tee-instance-blueprint`. Native x86_64-gnu build.