### PR TITLE
feat(sandbox-runtime): universal sidecar image reconcile via reconcile_on_startup

### DIFF
--- a/sandbox-runtime/src/reaper.rs
+++ b/sandbox-runtime/src/reaper.rs
@@ -512,6 +512,38 @@ pub async fn reconcile_on_startup() {
             }
         }
     }
+
+    // Sidecar image drift remediation. Every blueprint calls
+    // reconcile_on_startup() at boot, so folding this here means the cascade off
+    // the manager's binary upgrade is universal: when the manager swaps the
+    // operator binary (on-chain BinaryVersion CD loop), the new binary boots,
+    // reconciles, and rolls any sandbox still on a stale image onto the current
+    // SIDECAR_IMAGE — preserving each sandbox's secrets/identity. Without this,
+    // sandboxes stay pinned to their birth image forever (e.g. one that predates
+    // opencode → every agent run fails). Drift detection ⇒ no-op when unchanged.
+    // Policy via SIDECAR_UPGRADE_POLICY (default Auto; `manual` only reports).
+    match crate::runtime::reconcile_sidecar_images(
+        crate::runtime::SidecarUpgradePolicy::from_env(),
+        None,
+    )
+    .await
+    {
+        Ok(report)
+            if !report.upgraded.is_empty()
+                || !report.failed.is_empty()
+                || !report.pending.is_empty() =>
+        {
+            tracing::info!(
+                target_image = %report.target_image,
+                upgraded = report.upgraded.len(),
+                failed = report.failed.len(),
+                pending = report.pending.len(),
+                "reconcile: sidecar image drift remediation complete"
+            );
+        }
+        Ok(_) => {}
+        Err(e) => tracing::error!("reconcile: sidecar image reconcile failed: {e}"),
+    }
 }
 
 /// Resolve the snapshot destination URL for a sandbox.


### PR DESCRIPTION
Follow-up to #90 (the upgrade engine). Folds the sidecar image-drift reconcile into the **shared** `reaper::reconcile_on_startup()` — which every sandbox blueprint bin (sandbox, instance, tee) **and** the trading blueprint already call at boot.

**Why here, not per-blueprint:** #90 added `reconcile_sidecar_images` but nothing called it. Wiring it into each blueprint's `main.rs` would be copy-paste that drifts. `reconcile_on_startup()` is the one canonical startup-reconcile hook they all share, so one edit makes the cascade universal:

```
ship new sidecar image → publishBinaryVersion → manager swaps the operator binary (on-chain policy)
   → new binary boots → reconcile_on_startup() rolls every stale sidecar onto the current image
```

Preserves each sandbox's secrets/token/identity (the engine replays the unsealed env). Drift detection ⇒ no-op when nothing changed (safe per boot). Policy via `SIDECAR_UPGRADE_POLICY` (default Auto; `manual` = report-only, upgrade via the operator endpoint from #90).

`cargo check -p sandbox-runtime` green. Consumers (trading, etc.) inherit it on their next `sandbox-runtime` dep bump — no code change needed since they already call `reconcile_on_startup()`.