### PR TITLE
feat(ui): ship arena-inspired sandbox console

### DIFF
--- a/.evolve/arena-inspired-sandbox-console-redesign-2026-06-05.md
+++ b/.evolve/arena-inspired-sandbox-console-redesign-2026-06-05.md
@@ -1,0 +1,561 @@
+# Arena-Inspired Sandbox Console Redesign
+
+Date: 2026-06-05
+Status: design directive
+Owner: next UI implementation agent
+Scope: `ui/`, shared UI package boundaries, and Tangle Cloud iframe integration behavior
+
+## Compressed Goal Directive
+
+Build the AI Agent Sandbox UI as a Tangle-native Sandbox Console that borrows Arena's workspace model, density, terminal rhythm, route-native resource navigation, metric strips, tables, and evidence rails. Preserve sandbox/cloud concepts: provisioning, runtime backend, operator capacity, lifecycle, workflows, sessions, ports, SSH, secrets, snapshots, and TEE attestation. Do not copy Hyperliquid colors, trading terms, PnL semantics, market metaphors, or chart theater. The target is a cloud operations terminal for agent sandboxes embedded in Tangle Cloud.
+
+Reference this tracker and the 2026-06-05 Codex tracking message whose BLUF was: "Build the AI Agent Sandbox as a Tangle-native Sandbox Console: copy Arena's full-height terminal workspace, dense tables, route-native resource views, metric strips, and evidence rails; do not copy Hyperliquid colors, trading terms, PnL metaphors, or market-first semantics."
+
+## Why This Exists
+
+The research pass showed that the trading Arena has already solved the product shape that the sandbox UI needs:
+
+- full-height application shell
+- compact left navigation
+- route-native detail sections instead of local tab state
+- one primary work surface per route
+- dense metric strips and tables
+- right-side evidence or identity rail
+- minimal explanatory copy
+- terminal-grade dark surfaces with real separation
+
+The sandbox blueprint already has the correct backend nouns and operator actions, but the current UI still reads as a card dashboard plus wizard. The redesign should change the user's mental model from "browse a blueprint demo" to "operate an agent compute fleet."
+
+## Non-Goals
+
+- Do not port trading concepts literally.
+- Do not use Hyperliquid green as the dominant palette.
+- Do not introduce fake market charts for sandbox data.
+- Do not replace the backend contract, job IDs, operator API, or metadata schema.
+- Do not duplicate non-trivial shared implementations already suitable for `@tangle-network/blueprint-ui` or `@tangle-network/agent-ui`.
+- Do not create a marketing landing page.
+
+## Source Evidence
+
+### Arena Sources
+
+- `../ai-trading-blueprint/.evolve/arena-workspace-redesign-2026-06-01.md`
+- `../ai-trading-blueprint/.evolve/theme-trace-density-final-20260605/*.png`
+- `../ai-trading-blueprint/arena/src/components/layout/ArenaAppShell.tsx`
+- `../ai-trading-blueprint/arena/src/components/bot-detail/AgentWorkspaceShell.tsx`
+- `../ai-trading-blueprint/arena/src/styles/variables.scss`
+- `../ai-trading-blueprint/arena/src/styles/global.scss`
+
+Observed Arena facts:
+
+- `ArenaAppShell` uses a full-height shell with primary nav: Home, Agents, Activity, Observatory, Operators, My Agents, New Agent.
+- `AgentWorkspaceShell` uses route-native sections: `performance`, `portfolio`, `runs`, `chat`, `operations`.
+- The redesign tracker explicitly says Arena should be "a sidebar-driven trading workspace" with global nav, persistent selected-agent context, one primary work surface, and no body scrolling for core desktop workflows.
+- Arena terminal tokens define a dark surface stack, terminal borders, mono data presentation, Tangle purple brand accents, and status/accent colors separated from raw brand color.
+
+### Sandbox Sources
+
+- `README.md`
+- `DESIGN.md`
+- `metadata/blueprint-metadata.json`
+- `ui/src/root.tsx`
+- `ui/src/components/layout/Header.tsx`
+- `ui/src/routes/_index.tsx`
+- `ui/src/routes/create.tsx`
+- `ui/src/routes/sandboxes._index.tsx`
+- `ui/src/routes/sandboxes.$id.tsx`
+- `ui/src/routes/instances._index.tsx`
+- `ui/src/routes/instances.$id.tsx`
+- `ui/src/routes/workflows._index.tsx`
+- `ui/src/routes/workflows.$scope.$workflowId.tsx`
+- `ui/src/routes/workflows.create.tsx`
+- `packages/agent-ui/src/**`
+
+Observed Sandbox facts:
+
+- Current shell uses top header navigation: Dashboard, Sandboxes, Instances, Workflows, Create.
+- Current create route is a 3-step wizard: blueprint, configure, deploy.
+- Current sandbox detail uses local tab state: overview, terminal, chat, SSH, secrets, attestation.
+- Backend supports three modes: Sandbox, Instance, TEE Instance.
+- Runtime backend selection is encoded in `metadata_json.runtime_backend`: Docker, Firecracker, or TEE.
+- Operator API supports ports, exec, prompt, task, stop, resume, snapshot, SSH, secrets, and port proxy.
+- Lifecycle model includes hot, warm, cold, and gone states.
+- TEE flow includes attestation, TEE public key, sealed secrets, and off-chain encrypted secret injection.
+
+### Cloud Sources
+
+- `../dapp/apps/tangle-cloud/src/components/chrome/PageHeader.tsx`
+- `../dapp/apps/tangle-cloud/src/components/chrome/MetricStrip.tsx`
+- `../dapp/apps/tangle-cloud/src/components/tangleCloudTable/TangleCloudTable.tsx`
+- `../dapp/apps/tangle-cloud/src/components/TangleCloudCard.tsx`
+- `../dapp/apps/tangle-cloud/src/components/blueprintApps/BlueprintHostCard.tsx`
+- `../dapp/apps/tangle-cloud/src/components/blueprintApps/IframeBlueprintLayout.tsx`
+
+Cloud lessons:
+
+- For embedded blueprint apps, the iframe app should own the actual product surface.
+- Cloud chrome should stay peripheral.
+- Use compact page chrome only when a route needs a header.
+- Tables and metric strips should be dense and operational, not decorative.
+
+## Core Product Translation
+
+| Trading Arena Concept | Sandbox Console Concept | Fit | Decision |
+|---|---|---:|---|
+| Bot | Sandbox or dedicated agent instance | 5/5 | Direct rename. |
+| Agent leaderboard | Sandbox explorer | 5/5 | Use full-width sortable/filterable table. |
+| Performance chart | Runtime timeline | 4/5 | Show status, CPU, memory, logs, tasks, workflow markers. |
+| Fills tape | Execution tape | 5/5 | Exec/prompt/task/workflow/snapshot/lifecycle events. |
+| Portfolio | Resource inventory | 4/5 | Processes, ports, sessions, storage, snapshots, cost, allocation. |
+| Positions | Active runtime allocations | 4/5 | CPU, memory, disk, ports, workflows, sessions. |
+| Runs | Workflow and task replay | 5/5 | Left run list, center transcript/logs, right evidence rail. |
+| Chat | Agent sessions | 5/5 | Promote current chat/session UI into first-class workspace route. |
+| Operations | Control plane | 5/5 | Lifecycle, network, secrets, auth, attestation, snapshots. |
+| Strategy mandate | Sandbox launch spec | 4/5 | Prompt/template, runtime backend, capabilities, ports, secrets path. |
+| Operator route | Capacity route | 5/5 | Operator health, backend support, active load, TEE support. |
+| Risk readiness | Security/readiness gate | 5/5 | Wallet, service validation, operator capacity, TEE/secrets readiness. |
+| Vault/envelope | Secret and attestation envelope | 4/5 | Sealed secrets, public key, attestation, on-chain verification. |
+| Market observatory | Fleet observability | 4/5 | Operators, capacity, runtime health, global traces. |
+
+## Target Route Model
+
+### Global Routes
+
+| Route | Name | Primary Job |
+|---|---|---|
+| `/` | Fleet Console | Operate the sandbox fleet at a glance. |
+| `/sandboxes` | Sandbox Explorer | Find, compare, and open cloud-mode sandboxes. |
+| `/instances` | Dedicated Instances | Find, compare, and open instance/TEE services. |
+| `/workflows` | Automation | See workflow registry and recent executions across resources. |
+| `/activity` | Execution Tape | Search all exec, prompt, task, workflow, lifecycle, snapshot, auth, and secret events. |
+| `/operators` | Capacity Directory | Inspect operator readiness, backend support, version, load, and TEE support. |
+| `/create` | Launch Console | Compile and deploy a new sandbox, instance, or TEE instance. |
+
+### Sandbox Workspace Routes
+
+| Route | Name | Replaces Current |
+|---|---|---|
+| `/sandboxes/:id/runtime` | Runtime | overview + terminal default route |
+| `/sandboxes/:id/sessions` | Sessions | chat tab |
+| `/sandboxes/:id/automation` | Automation | workflow links + workflow detail fragments |
+| `/sandboxes/:id/network` | Network | ports + SSH tab |
+| `/sandboxes/:id/security` | Security | secrets + attestation tabs |
+| `/sandboxes/:id/storage` | Storage | snapshot modal + lifecycle state |
+
+### Instance Workspace Routes
+
+Mirror the sandbox workspace model:
+
+- `/instances/:id/runtime`
+- `/instances/:id/sessions`
+- `/instances/:id/automation`
+- `/instances/:id/network`
+- `/instances/:id/security`
+- `/instances/:id/storage`
+
+If implementation cost is high, build one generic `ResourceWorkspaceShell` that accepts `scope: "sandbox" | "instance"` and resource-specific API adapters.
+
+## Page Design Directives
+
+### 1. Fleet Console
+
+Goal: make the home route feel like an operations terminal, not a dashboard.
+
+Layout:
+
+- full-height app shell
+- top compact metric strip
+- central fleet runtime timeline or capacity matrix
+- right execution tape
+- bottom dense table of active resources
+
+Metrics:
+
+- active sandboxes
+- running instances
+- workflow executions last 24h
+- operator capacity available
+- failed operations last 24h
+- TEE-ready operators
+
+Table columns:
+
+- name
+- scope
+- status
+- backend
+- operator
+- uptime
+- sessions
+- workflows
+- CPU/memory allocation
+- ports
+- security posture
+- last event
+
+Alternatives ranked:
+
+1. Fleet console with timeline, tape, and active-resource table. Best because it creates an operations cockpit immediately.
+2. Operator health map plus resource table. Strong for fleet supply, weaker for user-owned work.
+3. Current stat cards and recent cards. Acceptable for a demo, weak for repeated operations.
+
+### 2. Sandbox Explorer
+
+Goal: replace card browsing with a table-first resource explorer.
+
+Layout:
+
+- full-width table
+- filter tray for status, backend, operator, TEE, owner, capability, stale state
+- optional selected-resource dossier on wide screens
+- no repeated card rows
+
+Columns:
+
+- resource name
+- sandbox ID
+- status: running/stopped/warm/cold/gone/error
+- backend: docker/firecracker/TEE
+- agent template
+- operator
+- created
+- last event
+- active sessions
+- workflow count
+- exposed ports
+- snapshot state
+- secrets state
+- attestation state
+
+Alternatives ranked:
+
+1. Dense table plus selected dossier. Best for scanning many resources.
+2. Table plus right drawer. Good when dossier is too wide.
+3. Card list with filters. Current-ish, poorer density.
+
+### 3. Launch Console
+
+Goal: replace wizard feel with a compiler for sandbox intent.
+
+Layout:
+
+- left/middle launch spec composer
+- mode segmented control: Sandbox, Instance, TEE Instance
+- runtime backend segmented control: Docker, Firecracker, TEE when valid
+- capability stack: computer use, all-harness, sidecar capabilities
+- ports editor
+- env/secrets plan
+- operator capacity/readiness rail
+- deploy action in the readiness rail
+
+Must preserve:
+
+- existing `useCreateDeploy`
+- `metadata_json.runtime_backend`
+- Firecracker forcing `tee_required=false`
+- TEE forcing `tee_required=true`
+- `all_harness` explicit option while keeping ABI field internal
+- service validation and operator lookup
+
+Alternatives ranked:
+
+1. Launch console. Best because it shows deployability and resource shape before submission.
+2. Resource composer with plan preview. Good, but less decisive.
+3. Current three-step wizard. Safe, but too generic and slow.
+
+### 4. Runtime Workspace
+
+Goal: make an opened sandbox feel like a live machine.
+
+Layout:
+
+- compact selected-resource rail or header strip
+- center terminal/timeline work surface
+- right identity/evidence rail
+- bottom or split execution ledger when space allows
+
+Primary modules:
+
+- runtime timeline with status transitions, CPU/memory/disk, task markers, workflow markers, error markers
+- terminal using existing operator-backed terminal
+- execution ledger
+- lifecycle controls: stop, resume, snapshot, delete, create workflow
+- connection status and circuit breaker state
+
+Alternatives ranked:
+
+1. Runtime timeline + terminal + event ledger. Best because it joins state, action, and evidence.
+2. Terminal-first with metric rail. Good for power users, weaker for fleet health.
+3. Current overview cards plus terminal tab. Fragmented and slower.
+
+### 5. Sessions Workspace
+
+Goal: make agent chat/session work a real product surface.
+
+Layout:
+
+- left session browser from `packages/agent-ui`
+- center transcript
+- right run/evidence rail for the selected session
+- compact composer
+
+Do:
+
+- preserve owner+scope isolation
+- preserve prompt/task payload contract differences
+- show session ID and scope when useful
+
+Do not:
+
+- bury chat behind disabled tabs without a route
+- show giant empty cards
+
+### 6. Automation Workspace
+
+Goal: make workflows feel like scheduled operations, not JSON forms.
+
+Layout:
+
+- workflow registry table
+- execution replay view
+- schedule/status rail
+- action controls: trigger, cancel, edit, create
+
+Map Arena Runs:
+
+- left: workflow/run history
+- center: transcript/log/output
+- right: trigger, schedule, target, operator, tx/evidence
+
+Alternatives ranked:
+
+1. Runs replay shell. Best because it turns automation into audit evidence.
+2. Registry table plus detail drawer. Good first slice.
+3. Current card/detail JSON panels. Too generic.
+
+### 7. Network Workspace
+
+Goal: make ports, proxy, and SSH operationally obvious.
+
+Modules:
+
+- exposed ports table
+- proxy URLs
+- SSH key list
+- connection command
+- add/revoke key forms
+- runtime backend network notes
+- Firecracker DNAT state when available
+
+Alternatives ranked:
+
+1. Network table plus command rail. Best for copy/run workflows.
+2. Split ports and SSH panels. Acceptable.
+3. SSH tab only. Too narrow.
+
+### 8. Security Workspace
+
+Goal: unify secrets, sealed secrets, TEE attestation, auth, and trust state.
+
+Modules:
+
+- secrets editor
+- wipe secrets action
+- TEE public key
+- sealed secret injection
+- attestation report
+- session auth state
+- on-chain service/resource verification
+
+Alternatives ranked:
+
+1. Security control plane. Best because trust state is one mental model.
+2. Separate Secrets and Attestation routes. Acceptable if implementation needs smaller slices.
+3. Current tabs. Hides the relationship between secrets and attestation.
+
+### 9. Storage Workspace
+
+Goal: expose lifecycle and persistence as first-class cloud concepts.
+
+Modules:
+
+- snapshot ledger
+- hot/warm/cold/gone lifecycle state
+- auto-commit policy
+- S3/BYOS3 destination
+- restore/resume path
+- retention timers
+
+Alternatives ranked:
+
+1. Snapshot ledger plus lifecycle rail. Best for operational correctness.
+2. Storage drawer in runtime. Good smaller slice.
+3. Snapshot modal only. Too invisible for a sandbox product.
+
+### 10. Operators / Capacity
+
+Goal: show whether the fleet can run the requested workload.
+
+Columns:
+
+- operator
+- endpoint status
+- active sandboxes
+- available capacity
+- backend support
+- TEE backend support
+- version
+- error rate
+- last heartbeat
+- service ID
+
+Alternatives ranked:
+
+1. Capacity directory table. Best for cloud-native operations.
+2. Operator cards plus filters. Lower density.
+3. Hide operators inside deploy flow. Insufficient for trust.
+
+## Visual System Directive
+
+Use Arena's structural visual grammar, not Arena's literal market skin.
+
+Adopt:
+
+- full-height dark console
+- high-contrast surface stack
+- thin but visible borders
+- mono numerals and IDs
+- compact metric labels
+- dense tables
+- restrained purple brand accents
+- teal/green only as success/ready, not dominant brand
+- amber for waiting/degraded
+- red for destructive/error
+- direct component labels and terse row metadata
+
+Avoid:
+
+- giant cards
+- nested cards
+- hero copy
+- route/status narration that repeats controls
+- decorative gradients or orbs
+- huge default empty states
+- disabled-looking "ready" panels with no live evidence
+
+Token direction:
+
+- keep Tangle dark neutral base from the sandbox/Cloud UI
+- add terminal-specific tokens similar in purpose to Arena's `--arena-terminal-*`
+- name them sandbox-native, for example `--sandbox-console-bg`, `--sandbox-console-surface`, `--sandbox-console-panel`, `--sandbox-console-border`, `--sandbox-console-accent`, `--sandbox-console-brand`
+- keep status tokens separate from brand tokens
+
+## Component Inventory
+
+Likely new or refactored components:
+
+- `SandboxConsoleShell`
+- `ConsoleNavRail`
+- `ConsoleAccountDock`
+- `ResourceWorkspaceShell`
+- `ResourceContextStrip`
+- `ResourceMetricStrip`
+- `ResourceEvidenceRail`
+- `ExecutionTape`
+- `RuntimeTimeline`
+- `ResourceExplorerTable`
+- `LaunchConsole`
+- `ReadinessRail`
+- `CapabilityStack`
+- `NetworkPanel`
+- `SecurityPanel`
+- `StorageLedger`
+- `WorkflowReplay`
+- `OperatorCapacityTable`
+
+Promote shared code when it crosses product boundaries:
+
+- chain/wallet/infra primitives: `@tangle-network/blueprint-ui`
+- session/chat/terminal primitives: `@tangle-network/agent-ui`
+- sandbox-specific shell, runtime copy, route composition: local `ui/`
+
+## Data and API Mapping
+
+Use existing data before adding APIs.
+
+Existing useful contracts:
+
+- on-chain jobs `0..4`
+- internal workflow tick `255`
+- `metadata_json.runtime_backend`
+- `capabilities_json`
+- operator API ports
+- operator API exec
+- operator API prompt
+- operator API task
+- operator API stop/resume
+- operator API snapshot
+- operator API SSH
+- operator API secrets
+- TEE attestation and sealed secrets APIs
+- runtime metrics fields in `DESIGN.md`
+- sandbox lifecycle states
+
+Possible later API gaps:
+
+- unified event stream for Execution Tape
+- resource metric time series for Runtime Timeline
+- operator capacity history
+- snapshot ledger pagination
+- workflow execution history pagination
+
+If an API gap exists in the first implementation slice, render the component from currently indexed events and mark the data source explicitly in code. Do not fake precision.
+
+## Implementation Order
+
+1. Add console shell and left navigation without changing backend behavior.
+2. Convert global home to Fleet Console.
+3. Convert sandbox and instance lists to dense explorers.
+4. Introduce route-native workspace shell for sandbox detail.
+5. Move current terminal/chat/SSH/secrets/attestation views into resource routes.
+6. Rebuild create as Launch Console while preserving deploy hook contracts.
+7. Add Execution Tape and Workflow Replay from available data.
+8. Add Runtime Timeline from real metrics/events only.
+9. Consolidate visual tokens and shared primitives.
+10. Run UI tests, typecheck, and screenshot verification.
+
+## Acceptance Criteria
+
+- Desktop core routes use a full-height shell with no body scroll for the main workflow.
+- Global nav is compact and persistent.
+- Opened resources use route-native sections, not local tab-only state.
+- Home reads as fleet operations, not marketing dashboard.
+- Create reads as launch compiler, not generic ABI wizard.
+- Lists are table-first.
+- Runtime workspace surfaces terminal, state, lifecycle actions, and evidence together.
+- Security makes secrets and attestation one coherent trust model.
+- Storage exposes snapshot and hot/warm/cold lifecycle state.
+- Tangle theme is recognizable without copying Hyperliquid green.
+- No fake charts or unsupported metrics.
+- Existing tests still pass.
+
+## Verification Gate
+
+Minimum for UI-only slices:
+
+- `pnpm --dir ui test`
+- `pnpm --dir ui typecheck`
+- desktop screenshot at 1440x900 for `/`, `/sandboxes`, `/create`, and one resource workspace route
+- mobile screenshot for global nav and create route
+
+For any runtime/operator API change, also run the relevant Rust tests from `CLAUDE.md`.
+
+## Coordination Notes
+
+The initial research pass was read-only. At the time of tracking, the sandbox repo was clean on `fix/dark-card-depth`. Other related repos had active edits by other agents:
+
+- `../ai-trading-blueprint`
+- `../dapp`
+- `../tnt-core`
+
+Do not overwrite those branches. Treat Arena and Cloud as reference sources unless the user explicitly asks for cross-repo edits.

--- a/ui/src/components/console/ConsolePrimitives.tsx
+++ b/ui/src/components/console/ConsolePrimitives.tsx
@@ -1,0 +1,162 @@
+import { Link } from 'react-router';
+import type { ReactNode } from 'react';
+import { Button } from '@tangle-network/blueprint-ui/components';
+import { cn } from '@tangle-network/blueprint-ui';
+
+export type ConsoleMetric = {
+  label: string;
+  value: string;
+  detail?: string;
+  tone?: 'brand' | 'ready' | 'warn' | 'danger' | 'muted';
+};
+
+const metricToneClass: Record<NonNullable<ConsoleMetric['tone']>, string> = {
+  brand: 'text-[var(--sandbox-console-brand)]',
+  ready: 'text-[var(--sandbox-console-success)]',
+  warn: 'text-[var(--sandbox-console-warning)]',
+  danger: 'text-[var(--sandbox-console-danger)]',
+  muted: 'text-[var(--sandbox-console-muted)]',
+};
+
+export function ConsolePage({
+  title,
+  eyebrow,
+  actions,
+  children,
+  className,
+}: {
+  title: string;
+  eyebrow?: string;
+  actions?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={cn('flex h-full min-h-0 flex-col overflow-hidden', className)}>
+      <div className="flex min-h-15 shrink-0 items-center justify-between gap-4 border-b border-[var(--sandbox-console-border)] px-4 py-3 lg:px-6">
+        <div className="min-w-0">
+          {eyebrow ? (
+            <p className="font-data text-[10px] uppercase tracking-[0.16em] text-[var(--sandbox-console-muted)]">
+              {eyebrow}
+            </p>
+          ) : null}
+          <h1 className="truncate font-display text-xl font-semibold leading-tight text-[var(--sandbox-console-text)]">
+            {title}
+          </h1>
+        </div>
+        {actions ? <div className="shrink-0">{actions}</div> : null}
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto p-4 lg:p-6">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+export function ConsoleMetricStrip({ metrics }: { metrics: ConsoleMetric[] }) {
+  return (
+    <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+      {metrics.map((metric) => (
+        <div key={metric.label} className="sandbox-console-panel rounded-md p-3">
+          <p className="font-data text-[10px] uppercase tracking-[0.14em] text-[var(--sandbox-console-muted)]">
+            {metric.label}
+          </p>
+          <div className="mt-2 flex items-baseline justify-between gap-3">
+            <p className={cn('font-data text-2xl font-semibold leading-none', metricToneClass[metric.tone ?? 'muted'])}>
+              {metric.value}
+            </p>
+            {metric.detail ? (
+              <span className="truncate font-data text-[11px] text-[var(--sandbox-console-subtle)]">
+                {metric.detail}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ConsoleSection({
+  title,
+  actionTo,
+  actionLabel,
+  children,
+  className,
+}: {
+  title: string;
+  actionTo?: string;
+  actionLabel?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={cn('sandbox-console-panel overflow-hidden rounded-md', className)}>
+      <div className="flex h-11 items-center justify-between border-b border-[var(--sandbox-console-border)] px-3">
+        <h2 className="font-data text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--sandbox-console-muted)]">
+          {title}
+        </h2>
+        {actionTo && actionLabel ? (
+          <Link to={actionTo}>
+            <Button variant="ghost" size="sm">{actionLabel}</Button>
+          </Link>
+        ) : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export function EmptyConsoleState({
+  icon,
+  title,
+  detail,
+  actionTo,
+  actionLabel,
+}: {
+  icon: string;
+  title: string;
+  detail?: string;
+  actionTo?: string;
+  actionLabel?: string;
+}) {
+  return (
+    <div className="flex min-h-52 flex-col items-center justify-center gap-3 p-6 text-center">
+      <span className={cn('text-3xl text-[var(--sandbox-console-subtle)]', icon)} />
+      <div>
+        <p className="font-display text-sm font-medium text-[var(--sandbox-console-text)]">{title}</p>
+        {detail ? (
+          <p className="mt-1 max-w-md text-sm text-[var(--sandbox-console-muted)]">{detail}</p>
+        ) : null}
+      </div>
+      {actionTo && actionLabel ? (
+        <Link to={actionTo}>
+          <Button variant="outline" size="sm">{actionLabel}</Button>
+        </Link>
+      ) : null}
+    </div>
+  );
+}
+
+export function ConsoleChip({
+  children,
+  tone = 'muted',
+}: {
+  children: ReactNode;
+  tone?: 'brand' | 'ready' | 'warn' | 'danger' | 'muted';
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex h-6 items-center rounded border px-2 font-data text-[10px] uppercase tracking-[0.08em]',
+        tone === 'brand' && 'border-[var(--sandbox-console-brand-border)] bg-[var(--sandbox-console-brand-soft)] text-[var(--sandbox-console-brand)]',
+        tone === 'ready' && 'border-[var(--sandbox-console-success-border)] bg-[var(--sandbox-console-success-soft)] text-[var(--sandbox-console-success)]',
+        tone === 'warn' && 'border-amber-400/20 bg-amber-400/10 text-[var(--sandbox-console-warning)]',
+        tone === 'danger' && 'border-red-400/20 bg-red-400/10 text-[var(--sandbox-console-danger)]',
+        tone === 'muted' && 'border-[var(--sandbox-console-border)] bg-[var(--sandbox-console-surface)] text-[var(--sandbox-console-muted)]',
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/ui/src/components/console/ConsoleShell.tsx
+++ b/ui/src/components/console/ConsoleShell.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { Link, useLocation } from 'react-router';
+import {
+  ChainSwitcher,
+  ThemeToggle,
+} from '@tangle-network/blueprint-ui/components';
+import { cn } from '@tangle-network/blueprint-ui';
+import { TxDropdown } from '~/components/layout/TxDropdown';
+import { WalletButton } from '~/components/layout/WalletButton';
+
+const navItems = [
+  { label: 'Fleet', href: '/', icon: 'i-ph:activity' },
+  { label: 'Sandboxes', href: '/sandboxes', icon: 'i-ph:hard-drives' },
+  { label: 'Instances', href: '/instances', icon: 'i-ph:cube' },
+  { label: 'Automation', href: '/workflows', icon: 'i-ph:flow-arrow' },
+  { label: 'Activity', href: '/activity', icon: 'i-ph:pulse' },
+  { label: 'Capacity', href: '/operators', icon: 'i-ph:hard-drives' },
+  { label: 'Launch', href: '/create', icon: 'i-ph:plus-circle' },
+];
+
+function BrandMark() {
+  return (
+    <span className="flex items-center gap-2">
+      <img src="/favicon.svg" alt="" className="h-8 w-8 shrink-0" />
+      <span className="font-display text-lg font-semibold leading-none text-[var(--sandbox-console-text)]">
+        Tangle
+      </span>
+    </span>
+  );
+}
+
+function isActivePath(pathname: string, href: string) {
+  return href === '/' ? pathname === '/' : pathname.startsWith(href);
+}
+
+export function ConsoleShell({ children }: { children: ReactNode }) {
+  const location = useLocation();
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const mobileMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setMobileNavOpen(false);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (!mobileNavOpen) return;
+
+    function onPointerDown(event: MouseEvent) {
+      if (mobileMenuRef.current && !mobileMenuRef.current.contains(event.target as Node)) {
+        setMobileNavOpen(false);
+      }
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setMobileNavOpen(false);
+    }
+
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [mobileNavOpen]);
+
+  return (
+    <div className="sandbox-console flex h-[100dvh] overflow-hidden bg-[var(--sandbox-console-bg)] text-[var(--sandbox-console-text)]">
+      <aside className="hidden w-[248px] shrink-0 border-r border-[var(--sandbox-console-border)] bg-[var(--sandbox-console-rail)] lg:flex lg:flex-col">
+        <div className="flex h-16 shrink-0 items-center gap-3 border-b border-[var(--sandbox-console-border)] px-4">
+          <Link to="/" className="flex items-center" aria-label="Tangle Sandbox Console">
+            <BrandMark />
+          </Link>
+          <div className="min-w-0">
+            <p className="font-display text-sm font-semibold leading-tight text-[var(--sandbox-console-text)]">
+              Sandbox Console
+            </p>
+            <p className="font-data text-[10px] uppercase tracking-[0.14em] text-[var(--sandbox-console-muted)]">
+              Agent compute
+            </p>
+          </div>
+        </div>
+
+        <nav className="flex-1 space-y-1 overflow-y-auto px-3 py-4">
+          {navItems.map((item) => {
+            const active = isActivePath(location.pathname, item.href);
+            return (
+              <Link
+                key={item.href}
+                to={item.href}
+                className={cn(
+                  'group flex h-10 items-center gap-3 rounded-md border px-3 text-sm font-medium transition-colors',
+                  active
+                    ? 'border-[var(--sandbox-console-brand-border)] bg-[var(--sandbox-console-brand-soft)] text-[var(--sandbox-console-text)]'
+                    : 'border-transparent text-[var(--sandbox-console-muted)] hover:border-[var(--sandbox-console-border)] hover:bg-[var(--sandbox-console-surface)] hover:text-[var(--sandbox-console-text)]',
+                )}
+              >
+                <span className={cn('text-base', item.icon)} />
+                <span>{item.label}</span>
+              </Link>
+            );
+          })}
+        </nav>
+
+        <div className="shrink-0 border-t border-[var(--sandbox-console-border)] p-3">
+          <div className="sandbox-console-panel space-y-3 rounded-md p-3">
+            <div className="grid grid-cols-3 gap-2">
+              <div className="min-w-0">
+                <ChainSwitcher />
+              </div>
+              <TxDropdown />
+              <ThemeToggle />
+            </div>
+            <WalletButton />
+          </div>
+        </div>
+      </aside>
+
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <header className="flex h-14 shrink-0 items-center justify-between border-b border-[var(--sandbox-console-border)] bg-[var(--sandbox-console-bg)] px-3 lg:hidden">
+          <div ref={mobileMenuRef} className="relative">
+            <button
+              type="button"
+              onClick={() => setMobileNavOpen((open) => !open)}
+              className="flex h-9 w-9 items-center justify-center rounded-md border border-[var(--sandbox-console-border)] bg-[var(--sandbox-console-panel)] text-[var(--sandbox-console-text)]"
+              aria-label="Navigation menu"
+            >
+              <span className={cn('text-lg', mobileNavOpen ? 'i-ph:x' : 'i-ph:list')} />
+            </button>
+            {mobileNavOpen ? (
+              <nav className="absolute left-0 top-11 z-50 w-64 overflow-hidden rounded-md border border-[var(--sandbox-console-border)] bg-[var(--sandbox-console-panel)] shadow-[var(--sandbox-console-shadow-lg)]">
+                {navItems.map((item) => {
+                  const active = isActivePath(location.pathname, item.href);
+                  return (
+                    <Link
+                      key={item.href}
+                      to={item.href}
+                      className={cn(
+                        'flex items-center gap-3 border-b border-[var(--sandbox-console-border)] px-3 py-3 text-sm',
+                        active
+                          ? 'bg-[var(--sandbox-console-brand-soft)] text-[var(--sandbox-console-text)]'
+                          : 'text-[var(--sandbox-console-muted)]',
+                      )}
+                    >
+                      <span className={cn('text-base', item.icon)} />
+                      {item.label}
+                    </Link>
+                  );
+                })}
+                <div className="flex items-center gap-2 p-3">
+                  <ChainSwitcher />
+                  <TxDropdown />
+                  <ThemeToggle />
+                </div>
+              </nav>
+            ) : null}
+          </div>
+
+          <Link to="/" className="flex items-center" aria-label="Tangle Sandbox Console">
+            <BrandMark />
+          </Link>
+
+          <WalletButton />
+        </header>
+
+        <main className="min-h-0 flex-1 overflow-hidden">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/console/ResourceExplorerTable.tsx
+++ b/ui/src/components/console/ResourceExplorerTable.tsx
@@ -1,0 +1,136 @@
+import { Link } from 'react-router';
+import { cn } from '@tangle-network/blueprint-ui';
+import { StatusBadge } from '~/components/shared/StatusBadge';
+import { ConsoleChip, EmptyConsoleState } from './ConsolePrimitives';
+
+export type ResourceExplorerRow = {
+  key: string;
+  href: string;
+  name: string;
+  id: string;
+  scope: 'Sandbox' | 'Instance' | 'TEE';
+  status: string;
+  statusLabel?: string;
+  backend: string;
+  image: string;
+  operator?: string;
+  specs: string;
+  sessions: string;
+  workflows: string;
+  network: string;
+  security: string;
+  storage: string;
+  createdAt: number;
+  lastEvent?: number;
+  teeEnabled?: boolean;
+  agentIdentifier?: string;
+};
+
+function formatAge(timestamp: number | undefined) {
+  if (!timestamp) return '--';
+  const deltaMs = Date.now() - timestamp;
+  if (deltaMs < 60_000) return '<1m';
+  const minutes = Math.floor(deltaMs / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+function shorten(value: string | undefined) {
+  if (!value) return '--';
+  if (value.length <= 14) return value;
+  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+}
+
+export function ResourceExplorerTable({
+  rows,
+  emptyTitle,
+  emptyDetail,
+  emptyActionTo,
+  emptyActionLabel,
+}: {
+  rows: ResourceExplorerRow[];
+  emptyTitle: string;
+  emptyDetail: string;
+  emptyActionTo: string;
+  emptyActionLabel: string;
+}) {
+  if (rows.length === 0) {
+    return (
+      <EmptyConsoleState
+        icon="i-ph:hard-drives"
+        title={emptyTitle}
+        detail={emptyDetail}
+        actionTo={emptyActionTo}
+        actionLabel={emptyActionLabel}
+      />
+    );
+  }
+
+  return (
+    <div className="overflow-auto">
+      <table className="min-w-[1120px] w-full border-collapse">
+        <thead>
+          <tr className="border-b border-[var(--sandbox-console-border)] bg-[var(--sandbox-console-surface)]">
+            {['Resource', 'Status', 'Backend', 'Operator', 'Spec', 'Sessions', 'Workflows', 'Network', 'Security', 'Storage', 'Last'].map((label) => (
+              <th
+                key={label}
+                className="px-3 py-2 text-left font-data text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--sandbox-console-muted)]"
+              >
+                {label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr
+              key={row.key}
+              className="group border-b border-[var(--sandbox-console-border)] transition-colors hover:bg-[var(--sandbox-console-surface)]"
+            >
+              <td className="px-3 py-3">
+                <Link to={row.href} className="flex min-w-0 items-center gap-3">
+                  <span
+                    className={cn(
+                      'flex h-8 w-8 shrink-0 items-center justify-center rounded border',
+                      row.teeEnabled
+                        ? 'border-[var(--sandbox-console-brand-border)] bg-[var(--sandbox-console-brand-soft)] text-[var(--sandbox-console-brand)]'
+                        : 'border-[var(--sandbox-console-border)] bg-[var(--sandbox-console-panel)] text-[var(--sandbox-console-muted)]',
+                    )}
+                  >
+                    <span className={cn('text-base', row.teeEnabled ? 'i-ph:shield-check' : 'i-ph:cube')} />
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block truncate font-display text-sm font-semibold text-[var(--sandbox-console-text)]">
+                      {row.name}
+                    </span>
+                    <span className="block truncate font-data text-[11px] text-[var(--sandbox-console-subtle)]">
+                      {row.scope} · {shorten(row.id)}{row.agentIdentifier ? ` · ${row.agentIdentifier}` : ''}
+                    </span>
+                  </span>
+                </Link>
+              </td>
+              <td className="px-3 py-3">
+                <StatusBadge status={row.status} labelOverride={row.statusLabel} />
+              </td>
+              <td className="px-3 py-3">
+                <ConsoleChip tone={row.backend === 'tee' ? 'brand' : row.backend === 'firecracker' ? 'warn' : 'muted'}>
+                  {row.backend}
+                </ConsoleChip>
+              </td>
+              <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-muted)]">{shorten(row.operator)}</td>
+              <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-muted)]">{row.specs}</td>
+              <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-muted)]">{row.sessions}</td>
+              <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-muted)]">{row.workflows}</td>
+              <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-muted)]">{row.network}</td>
+              <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-muted)]">{row.security}</td>
+              <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-muted)]">{row.storage}</td>
+              <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-muted)]">{formatAge(row.lastEvent ?? row.createdAt)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui/src/components/console/ResourceWorkspaceNav.tsx
+++ b/ui/src/components/console/ResourceWorkspaceNav.tsx
@@ -1,0 +1,42 @@
+import { Link } from 'react-router';
+import { cn } from '@tangle-network/blueprint-ui';
+
+export type WorkspaceNavItem = {
+  label: string;
+  href: string;
+  icon: string;
+  disabled?: boolean;
+};
+
+export function ResourceWorkspaceNav({
+  items,
+  activePath,
+}: {
+  items: WorkspaceNavItem[];
+  activePath?: string;
+}) {
+  return (
+    <nav className="mb-4 overflow-x-auto rounded-md border border-[var(--sandbox-console-border)] bg-[var(--sandbox-console-panel)] p-1">
+      <div className="flex min-w-max items-center gap-1">
+        {items.filter((item) => !item.disabled).map((item) => {
+          const active = activePath === item.href || activePath?.startsWith(`${item.href}/`);
+          return (
+            <Link
+              key={item.href}
+              to={item.href}
+              className={cn(
+                'flex h-9 items-center gap-2 rounded px-3 font-data text-[11px] uppercase tracking-[0.08em] transition-colors',
+                active
+                  ? 'bg-[var(--sandbox-console-brand-soft)] text-[var(--sandbox-console-brand)]'
+                  : 'text-[var(--sandbox-console-muted)] hover:bg-[var(--sandbox-console-surface)] hover:text-[var(--sandbox-console-text)]',
+              )}
+            >
+              <span className={cn('text-sm', item.icon)} />
+              {item.label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/ui/src/components/console/ResourceWorkspacePanels.tsx
+++ b/ui/src/components/console/ResourceWorkspacePanels.tsx
@@ -1,0 +1,139 @@
+import { Link } from 'react-router';
+import { Button } from '@tangle-network/blueprint-ui/components';
+import { ConsoleChip, ConsoleSection } from './ConsolePrimitives';
+
+type Tone = 'brand' | 'ready' | 'warn' | 'danger' | 'muted';
+
+export type WorkspaceRailRow = {
+  label: string;
+  value: string;
+  detail?: string;
+  tone?: Tone;
+};
+
+function WorkspaceRow({ row }: { row: WorkspaceRailRow }) {
+  return (
+    <div className="grid gap-1 border-b border-[var(--sandbox-console-border)] px-3 py-3 last:border-b-0">
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-data text-[10px] uppercase tracking-[0.14em] text-[var(--sandbox-console-muted)]">
+          {row.label}
+        </span>
+        <ConsoleChip tone={row.tone ?? 'muted'}>{row.value}</ConsoleChip>
+      </div>
+      {row.detail ? (
+        <p className="truncate font-data text-[11px] text-[var(--sandbox-console-subtle)]">
+          {row.detail}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export function ResourceWorkspaceRail({ rows }: { rows: WorkspaceRailRow[] }) {
+  return (
+    <ConsoleSection title="Resource Context">
+      <div>
+        {rows.map((row) => (
+          <WorkspaceRow key={row.label} row={row} />
+        ))}
+      </div>
+    </ConsoleSection>
+  );
+}
+
+export function AutomationWorkspace({
+  createHref,
+  scope,
+  target,
+  status,
+  hasAgent,
+}: {
+  createHref?: string;
+  scope: string;
+  target: string;
+  status: string;
+  hasAgent: boolean;
+}) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_300px]">
+      <ConsoleSection title="Workflow Lane">
+        <div className="divide-y divide-[var(--sandbox-console-border)]">
+          {[
+            { label: 'Scope', value: scope },
+            { label: 'Target', value: target },
+            { label: 'State', value: status },
+            { label: 'Agent', value: hasAgent ? 'configured' : 'not configured' },
+          ].map((row) => (
+            <div key={row.label} className="grid grid-cols-[120px_minmax(0,1fr)] gap-3 px-3 py-3">
+              <span className="font-data text-[10px] uppercase tracking-[0.14em] text-[var(--sandbox-console-muted)]">
+                {row.label}
+              </span>
+              <span className="truncate font-data text-xs text-[var(--sandbox-console-text)]">
+                {row.value}
+              </span>
+            </div>
+          ))}
+        </div>
+      </ConsoleSection>
+
+      <ConsoleSection title="Execution Readiness">
+        <div className="space-y-3 p-3">
+          <ConsoleChip tone={status === 'running' ? 'ready' : 'warn'}>
+            {status === 'running' ? 'runtime ready' : 'runtime gated'}
+          </ConsoleChip>
+          <ConsoleChip tone={hasAgent ? 'brand' : 'warn'}>
+            {hasAgent ? 'agent sessions' : 'compute only'}
+          </ConsoleChip>
+          {createHref ? (
+            <Link to={createHref} className="block">
+              <Button variant="secondary" size="sm" className="w-full justify-center">
+                <span className="i-ph:flow-arrow text-sm" />
+                Create Workflow
+              </Button>
+            </Link>
+          ) : null}
+        </div>
+      </ConsoleSection>
+    </div>
+  );
+}
+
+export function StorageWorkspace({
+  rows,
+  onSnapshot,
+  snapshotEnabled,
+}: {
+  rows: WorkspaceRailRow[];
+  onSnapshot: () => void;
+  snapshotEnabled: boolean;
+}) {
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_300px]">
+      <ConsoleSection title="Storage Ledger">
+        <div>
+          {rows.map((row) => (
+            <WorkspaceRow key={row.label} row={row} />
+          ))}
+        </div>
+      </ConsoleSection>
+
+      <ConsoleSection title="Snapshot Surface">
+        <div className="space-y-3 p-3">
+          <ConsoleChip tone={snapshotEnabled ? 'ready' : 'warn'}>
+            {snapshotEnabled ? 'snapshot ready' : 'runtime required'}
+          </ConsoleChip>
+          <Button
+            variant="secondary"
+            size="sm"
+            className="w-full justify-center"
+            onClick={onSnapshot}
+            disabled={!snapshotEnabled}
+          >
+            <span className="i-ph:camera text-sm" />
+            Snapshot
+          </Button>
+        </div>
+      </ConsoleSection>
+    </div>
+  );
+}

--- a/ui/src/root.tsx
+++ b/ui/src/root.tsx
@@ -8,11 +8,11 @@ import './styles/global.scss';
 import '~/lib/blueprints'; // side-effect: register all blueprints
 
 import { Outlet, useRouteError, isRouteErrorResponse } from 'react-router';
-import { AppFooter, AppToaster } from '@tangle-network/blueprint-ui/components';
+import { AppToaster } from '@tangle-network/blueprint-ui/components';
 import { Web3Provider } from '~/providers/Web3Provider';
 import { SandboxSyncProvider } from '~/providers/SandboxSyncProvider';
-import { Header } from '~/components/layout/Header';
 import { IframeAppDocument } from '~/components/layout/IframeAppDocument';
+import { ConsoleShell } from '~/components/console/ConsoleShell';
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
@@ -56,13 +56,9 @@ export default function App() {
       <AppToaster tone="cloud" />
       <Web3Provider>
         <SandboxSyncProvider>
-          <div className="flex flex-col min-h-screen bg-cloud-elements-background-depth-1 text-cloud-elements-textPrimary bg-mesh bg-noise">
-            <Header />
-            <main className="flex-1 pt-[var(--header-height)] relative z-1">
-              <Outlet />
-            </main>
-            <AppFooter tone="cloud" brandText="Sandbox Cloud · Tangle Network" />
-          </div>
+          <ConsoleShell>
+            <Outlet />
+          </ConsoleShell>
         </SandboxSyncProvider>
       </Web3Provider>
     </>

--- a/ui/src/routes/_index.tsx
+++ b/ui/src/routes/_index.tsx
@@ -1,20 +1,128 @@
 import { Link } from 'react-router';
+import { useMemo } from 'react';
 import { useStore } from '@nanostores/react';
-import { AnimatedPage, StaggerContainer, StaggerItem } from '@tangle-network/blueprint-ui/components';
-import { Card, CardContent, CardHeader, CardTitle } from '@tangle-network/blueprint-ui/components';
 import { Button } from '@tangle-network/blueprint-ui/components';
-import { StatusBadge } from '~/components/shared/StatusBadge';
+import {
+  ConsoleChip,
+  ConsoleMetricStrip,
+  ConsolePage,
+  ConsoleSection,
+  EmptyConsoleState,
+  type ConsoleMetric,
+} from '~/components/console/ConsolePrimitives';
+import {
+  ResourceExplorerTable,
+  type ResourceExplorerRow,
+} from '~/components/console/ResourceExplorerTable';
 import {
   sandboxListStore,
   runningSandboxes,
   stoppedSandboxes,
   getSandboxRouteKey,
+  type LocalSandbox,
 } from '~/lib/stores/sandboxes';
-import { instanceListStore, runningInstances } from '~/lib/stores/instances';
+import {
+  instanceListStore,
+  runningInstances,
+  type LocalInstance,
+} from '~/lib/stores/instances';
 import { useAvailableCapacity, useWorkflowIds } from '~/lib/hooks/useSandboxReads';
-import { cn } from '@tangle-network/blueprint-ui';
 
-export default function Dashboard() {
+type ConsoleEvent = {
+  key: string;
+  label: string;
+  detail: string;
+  tone: 'brand' | 'ready' | 'warn' | 'danger' | 'muted';
+  timestamp: number;
+};
+
+function formatNumber(value: unknown) {
+  if (value == null) return '--';
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : '--';
+  return String(value);
+}
+
+function formatAge(timestamp: number | undefined) {
+  if (!timestamp) return '--';
+  const deltaMs = Date.now() - timestamp;
+  if (deltaMs < 60_000) return '<1m ago';
+  const minutes = Math.floor(deltaMs / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function getSecurityState(resource: Pick<LocalSandbox | LocalInstance, 'teeEnabled' | 'credentialsAvailable'>) {
+  if (resource.teeEnabled) return 'attested';
+  if (resource.credentialsAvailable) return 'secrets';
+  return 'session';
+}
+
+function getStorageState(status: string) {
+  if (status === 'warm' || status === 'cold') return status;
+  if (status === 'stopped') return 'hot';
+  if (status === 'gone') return 'gone';
+  return 'ephemeral';
+}
+
+function sandboxToRow(sandbox: LocalSandbox): ResourceExplorerRow {
+  return {
+    key: sandbox.localId,
+    href: `/sandboxes/${encodeURIComponent(getSandboxRouteKey(sandbox))}`,
+    name: sandbox.name,
+    id: sandbox.sandboxId ?? sandbox.localId,
+    scope: 'Sandbox',
+    status: sandbox.status,
+    backend: sandbox.teeEnabled ? 'tee' : 'docker',
+    image: sandbox.image,
+    operator: sandbox.operator,
+    specs: `${sandbox.cpuCores}c/${Math.round(sandbox.memoryMb / 1024)}g/${sandbox.diskGb}g`,
+    sessions: sandbox.agentIdentifier ? 'agent' : '--',
+    workflows: '--',
+    network: sandbox.sshPort ? `ssh:${sandbox.sshPort}` : 'ports',
+    security: getSecurityState(sandbox),
+    storage: getStorageState(sandbox.status),
+    createdAt: sandbox.createdAt,
+    lastEvent: sandbox.lastActivityAt,
+    teeEnabled: sandbox.teeEnabled,
+    agentIdentifier: sandbox.agentIdentifier,
+  };
+}
+
+function instanceToRow(instance: LocalInstance): ResourceExplorerRow {
+  return {
+    key: instance.id,
+    href: `/instances/${encodeURIComponent(instance.id)}`,
+    name: instance.name,
+    id: instance.sandboxId ?? instance.id,
+    scope: instance.teeEnabled ? 'TEE' : 'Instance',
+    status: instance.status,
+    backend: instance.teeEnabled ? 'tee' : 'docker',
+    image: instance.image,
+    operator: instance.operator,
+    specs: `${instance.cpuCores}c/${Math.round(instance.memoryMb / 1024)}g/${instance.diskGb}g`,
+    sessions: instance.agentIdentifier ? 'agent' : '--',
+    workflows: '--',
+    network: instance.sshPort ? `ssh:${instance.sshPort}` : 'ports',
+    security: getSecurityState(instance),
+    storage: getStorageState(instance.status),
+    createdAt: instance.createdAt,
+    teeEnabled: instance.teeEnabled,
+    agentIdentifier: instance.agentIdentifier,
+  };
+}
+
+function statusTone(status: string): ConsoleEvent['tone'] {
+  if (status === 'running') return 'ready';
+  if (status === 'creating') return 'brand';
+  if (status === 'stopped' || status === 'warm' || status === 'cold') return 'warn';
+  if (status === 'error') return 'danger';
+  return 'muted';
+}
+
+export default function FleetConsole() {
   const sandboxes = useStore(sandboxListStore);
   const running = useStore(runningSandboxes);
   const stopped = useStore(stoppedSandboxes);
@@ -23,132 +131,143 @@ export default function Dashboard() {
   const { data: capacity } = useAvailableCapacity();
   const { data: workflowIds } = useWorkflowIds(false);
 
-  const statCards = [
-    { label: 'Sandboxes', value: String(running.length), icon: 'i-ph:hard-drives', color: 'text-teal-400', glow: 'glow-border-teal' },
-    { label: 'Instances', value: String(runningInst.length), icon: 'i-ph:cube', color: 'text-blue-400', glow: runningInst.length > 0 ? 'glow-border-blue' : '' },
-    { label: 'Capacity', value: capacity !== undefined ? String(capacity) : '--', icon: 'i-ph:cpu', color: 'text-violet-400', glow: '' },
-    { label: 'Workflows', value: workflowIds ? String(workflowIds.length) : '--', icon: 'i-ph:flow-arrow', color: 'text-amber-400', glow: '' },
+  const resources = useMemo(
+    () => [
+      ...sandboxes.map(sandboxToRow),
+      ...instances.map(instanceToRow),
+    ].sort((left, right) => (right.lastEvent ?? right.createdAt) - (left.lastEvent ?? left.createdAt)),
+    [instances, sandboxes],
+  );
+
+  const visibleResources = resources.slice(0, 8);
+  const teeReady = resources.filter((resource) => resource.teeEnabled).length;
+  const degraded = resources.filter((resource) => ['error', 'stopped', 'warm', 'cold'].includes(resource.status)).length;
+
+  const metrics: ConsoleMetric[] = [
+    {
+      label: 'Running resources',
+      value: String(running.length + runningInst.length),
+      detail: `${resources.length} total`,
+      tone: 'ready',
+    },
+    {
+      label: 'Operator capacity',
+      value: formatNumber(capacity),
+      detail: 'available',
+      tone: 'brand',
+    },
+    {
+      label: 'Automation',
+      value: workflowIds ? String(workflowIds.length) : '--',
+      detail: 'registered',
+      tone: 'warn',
+    },
+    {
+      label: 'Security posture',
+      value: String(teeReady),
+      detail: degraded > 0 ? `${degraded} attention` : 'TEE resources',
+      tone: degraded > 0 ? 'warn' : 'brand',
+    },
   ];
 
-  const recentSandboxes = sandboxes.slice(0, 5);
-  const recentInstances = instances.slice(0, 5);
+  const events = useMemo<ConsoleEvent[]>(
+    () => [
+      ...sandboxes.map((sandbox) => ({
+        key: `sandbox:${sandbox.localId}`,
+        label: sandbox.status === 'running' ? 'Sandbox running' : `Sandbox ${sandbox.status}`,
+        detail: sandbox.name,
+        tone: statusTone(sandbox.status),
+        timestamp: sandbox.lastActivityAt ?? sandbox.createdAt,
+      })),
+      ...instances.map((instance) => ({
+        key: `instance:${instance.id}`,
+        label: instance.status === 'running' ? 'Instance running' : `Instance ${instance.status}`,
+        detail: instance.name,
+        tone: statusTone(instance.status),
+        timestamp: instance.createdAt,
+      })),
+    ].sort((left, right) => right.timestamp - left.timestamp).slice(0, 10),
+    [instances, sandboxes],
+  );
 
   return (
-    <AnimatedPage className="mx-auto max-w-7xl px-4 sm:px-6 py-8">
-      <div className="flex items-center justify-between mb-8">
-        <div>
-          <h1 className="text-2xl font-display font-bold text-cloud-elements-textPrimary">Dashboard</h1>
-          <p className="text-sm text-cloud-elements-textSecondary mt-1">Manage your AI agent infrastructure</p>
-        </div>
+    <ConsolePage
+      title="Fleet Console"
+      eyebrow="Tangle agent compute"
+      actions={(
         <Link to="/create">
-          <Button size="lg">
-            <div className="i-ph:plus text-base" />
-            Deploy
+          <Button>
+            <span className="i-ph:plus text-base" />
+            Launch
           </Button>
         </Link>
-      </div>
+      )}
+    >
+      <div className="grid min-h-full gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="space-y-4">
+          <ConsoleMetricStrip metrics={metrics} />
 
-      {/* Stats */}
-      <StaggerContainer className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-        {statCards.map((stat) => (
-          <StaggerItem key={stat.label}>
-            <Card className={stat.glow}>
-              <CardContent className="p-6">
-                <div className="flex items-center justify-between">
+          <ConsoleSection title="Runtime Matrix">
+            <div className="grid min-h-56 gap-px bg-[var(--sandbox-console-border)] p-px sm:grid-cols-2 xl:grid-cols-4">
+              {[
+                { label: 'cloud sandboxes', value: sandboxes.length, detail: `${running.length} running`, tone: 'ready' as const },
+                { label: 'dedicated instances', value: instances.length, detail: `${runningInst.length} running`, tone: 'brand' as const },
+                { label: 'stopped warm/cold', value: stopped.length, detail: 'resume candidates', tone: 'warn' as const },
+                { label: 'degraded', value: resources.filter((resource) => resource.status === 'error').length, detail: 'errors', tone: 'danger' as const },
+              ].map((cell) => (
+                <div key={cell.label} className="flex min-h-40 flex-col justify-between bg-[var(--sandbox-console-panel)] p-4">
+                  <p className="font-data text-[10px] uppercase tracking-[0.14em] text-[var(--sandbox-console-muted)]">
+                    {cell.label}
+                  </p>
                   <div>
-                    <p className="text-xs font-data uppercase tracking-wider text-cloud-elements-textTertiary">{stat.label}</p>
-                    <p className="text-3xl font-display font-bold mt-1">{stat.value}</p>
+                    <p className="font-data text-4xl font-semibold text-[var(--sandbox-console-text)]">{cell.value}</p>
+                    <ConsoleChip tone={cell.tone}>{cell.detail}</ConsoleChip>
                   </div>
-                  <div className={`${stat.icon} text-2xl ${stat.color}`} />
                 </div>
-              </CardContent>
-            </Card>
-          </StaggerItem>
-        ))}
-      </StaggerContainer>
+              ))}
+            </div>
+          </ConsoleSection>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Recent Sandboxes */}
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle>Recent Sandboxes</CardTitle>
-            {sandboxes.length > 0 && (
-              <Link to="/sandboxes">
-                <Button variant="ghost" size="sm">View All</Button>
-              </Link>
-            )}
-          </CardHeader>
-          <CardContent>
-            {recentSandboxes.length > 0 ? (
-              <div className="space-y-2">
-                {recentSandboxes.map((sb) => (
-                  <Link
-                    key={sb.localId}
-                    to={`/sandboxes/${encodeURIComponent(getSandboxRouteKey(sb))}`}
-                    className="flex items-center justify-between p-3 rounded-lg hover:bg-cloud-elements-item-backgroundHover transition-colors"
-                  >
-                    <div className="flex items-center gap-3 min-w-0">
-                      <div className="i-ph:hard-drives text-lg text-cloud-elements-textTertiary" />
-                      <div className="min-w-0">
-                        <p className="text-sm font-display font-medium text-cloud-elements-textPrimary truncate">{sb.name}</p>
-                        <p className="text-xs font-data text-cloud-elements-textTertiary">{sb.image}</p>
-                      </div>
-                    </div>
-                    <StatusBadge status={sb.status} />
-                  </Link>
-                ))}
-              </div>
-            ) : (
-              <div className="py-8 text-center">
-                <div className="i-ph:hard-drives text-3xl text-cloud-elements-textTertiary mb-2 mx-auto" />
-                <p className="text-sm text-cloud-elements-textTertiary">No sandboxes yet</p>
-              </div>
-            )}
-          </CardContent>
-        </Card>
+          <ConsoleSection title="Active Resource Ledger" actionTo="/sandboxes" actionLabel="Open Explorer">
+            <ResourceExplorerTable
+              rows={visibleResources}
+              emptyTitle="No resources indexed"
+              emptyDetail="Launch a sandbox or instance to populate the fleet ledger."
+              emptyActionTo="/create"
+              emptyActionLabel="Launch Resource"
+            />
+          </ConsoleSection>
+        </div>
 
-        {/* Recent Instances */}
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle>Recent Instances</CardTitle>
-            {instances.length > 0 && (
-              <Link to="/instances">
-                <Button variant="ghost" size="sm">View All</Button>
-              </Link>
-            )}
-          </CardHeader>
-          <CardContent>
-            {recentInstances.length > 0 ? (
-              <div className="space-y-2">
-                {recentInstances.map((inst) => (
-                  <Link
-                    key={inst.id}
-                    to={`/instances/${encodeURIComponent(inst.id)}`}
-                    className="flex items-center justify-between p-3 rounded-lg hover:bg-cloud-elements-item-backgroundHover transition-colors"
-                  >
-                    <div className="flex items-center gap-3 min-w-0">
-                      <div className={cn(inst.teeEnabled ? 'i-ph:shield-check' : 'i-ph:cube', 'text-lg text-cloud-elements-textTertiary')} />
-                      <div className="min-w-0">
-                        <p className="text-sm font-display font-medium text-cloud-elements-textPrimary truncate">{inst.name}</p>
-                        <p className="text-xs font-data text-cloud-elements-textTertiary">{inst.image}</p>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      {inst.teeEnabled && <span className="text-xs text-violet-400 font-data">TEE</span>}
-                      <StatusBadge status={inst.status} />
-                    </div>
-                  </Link>
-                ))}
-              </div>
-            ) : (
-              <div className="py-8 text-center">
-                <div className="i-ph:cube text-3xl text-cloud-elements-textTertiary mb-2 mx-auto" />
-                <p className="text-sm text-cloud-elements-textTertiary">No instances yet</p>
-              </div>
-            )}
-          </CardContent>
-        </Card>
+        <ConsoleSection title="Execution Tape" className="min-h-[420px]">
+          {events.length > 0 ? (
+            <div className="divide-y divide-[var(--sandbox-console-border)]">
+              {events.map((event) => (
+                <div key={event.key} className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 px-3 py-3">
+                  <span className="h-2 w-2 rounded-full bg-[var(--sandbox-console-muted)]" />
+                  <div className="min-w-0">
+                    <p className="truncate font-display text-sm font-medium text-[var(--sandbox-console-text)]">
+                      {event.label}
+                    </p>
+                    <p className="truncate font-data text-[11px] text-[var(--sandbox-console-muted)]">
+                      {event.detail}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <ConsoleChip tone={event.tone}>{formatAge(event.timestamp)}</ConsoleChip>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <EmptyConsoleState
+              icon="i-ph:pulse"
+              title="No execution events"
+              detail="Lifecycle, workflow, and terminal events appear here once resources exist."
+            />
+          )}
+        </ConsoleSection>
       </div>
-    </AnimatedPage>
+    </ConsolePage>
   );
 }

--- a/ui/src/routes/activity._index.tsx
+++ b/ui/src/routes/activity._index.tsx
@@ -1,0 +1,124 @@
+import { useMemo } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+  ConsoleChip,
+  ConsoleMetricStrip,
+  ConsolePage,
+  ConsoleSection,
+  EmptyConsoleState,
+  type ConsoleMetric,
+} from '~/components/console/ConsolePrimitives';
+import { sandboxListStore } from '~/lib/stores/sandboxes';
+import { instanceListStore } from '~/lib/stores/instances';
+import { pendingWorkflowStore } from '~/lib/stores/pendingWorkflows';
+
+type ActivityEvent = {
+  key: string;
+  source: string;
+  action: string;
+  detail: string;
+  status: string;
+  timestamp: number;
+  tone: 'brand' | 'ready' | 'warn' | 'danger' | 'muted';
+};
+
+function statusTone(status: string): ActivityEvent['tone'] {
+  if (status === 'running') return 'ready';
+  if (status === 'creating' || status === 'processing') return 'brand';
+  if (status === 'stopped' || status === 'warm' || status === 'cold' || status === 'timed-out') return 'warn';
+  if (status === 'error') return 'danger';
+  return 'muted';
+}
+
+function formatTime(timestamp: number) {
+  if (!timestamp) return '--';
+  return new Date(timestamp).toLocaleString();
+}
+
+export default function ActivityTape() {
+  const sandboxes = useStore(sandboxListStore);
+  const instances = useStore(instanceListStore);
+  const pendingWorkflows = useStore(pendingWorkflowStore);
+
+  const events = useMemo<ActivityEvent[]>(
+    () => [
+      ...sandboxes.map((sandbox) => ({
+        key: `sandbox:${sandbox.localId}`,
+        source: 'sandbox',
+        action: sandbox.status,
+        detail: sandbox.name,
+        status: sandbox.status,
+        timestamp: sandbox.lastActivityAt ?? sandbox.createdAt,
+        tone: statusTone(sandbox.status),
+      })),
+      ...instances.map((instance) => ({
+        key: `instance:${instance.id}`,
+        source: instance.teeEnabled ? 'tee instance' : 'instance',
+        action: instance.status,
+        detail: instance.name,
+        status: instance.status,
+        timestamp: instance.createdAt,
+        tone: statusTone(instance.status),
+      })),
+      ...pendingWorkflows.map((workflow) => ({
+        key: `workflow:${workflow.key}`,
+        source: workflow.scope,
+        action: workflow.status,
+        detail: workflow.name || `Workflow #${workflow.workflowId}`,
+        status: workflow.status,
+        timestamp: workflow.createdAt,
+        tone: statusTone(workflow.status),
+      })),
+    ].sort((left, right) => right.timestamp - left.timestamp),
+    [instances, pendingWorkflows, sandboxes],
+  );
+
+  const metrics: ConsoleMetric[] = [
+    { label: 'Events', value: String(events.length), detail: 'local index', tone: 'brand' },
+    { label: 'Lifecycle', value: String(events.filter((event) => event.source !== 'workflow').length), detail: 'resources', tone: 'ready' },
+    { label: 'Workflow pending', value: String(pendingWorkflows.length), detail: 'operator visibility', tone: 'warn' },
+    { label: 'Errors', value: String(events.filter((event) => event.status === 'error').length), detail: 'attention', tone: 'danger' },
+  ];
+
+  return (
+    <ConsolePage title="Execution Tape" eyebrow="Fleet activity">
+      <div className="space-y-4">
+        <ConsoleMetricStrip metrics={metrics} />
+        <ConsoleSection title="Events">
+          {events.length > 0 ? (
+            <div className="overflow-auto">
+              <table className="min-w-[820px] w-full border-collapse">
+                <thead>
+                  <tr className="border-b border-[var(--sandbox-console-border)] bg-[var(--sandbox-console-surface)]">
+                    {['Time', 'Source', 'Action', 'Resource', 'Status'].map((label) => (
+                      <th key={label} className="px-3 py-2 text-left font-data text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--sandbox-console-muted)]">
+                        {label}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {events.map((event) => (
+                    <tr key={event.key} className="border-b border-[var(--sandbox-console-border)] hover:bg-[var(--sandbox-console-surface)]">
+                      <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-muted)]">{formatTime(event.timestamp)}</td>
+                      <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-muted)]">{event.source}</td>
+                      <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-text)]">{event.action}</td>
+                      <td className="px-3 py-3 font-display text-sm font-medium text-[var(--sandbox-console-text)]">{event.detail}</td>
+                      <td className="px-3 py-3"><ConsoleChip tone={event.tone}>{event.status}</ConsoleChip></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <EmptyConsoleState
+              icon="i-ph:pulse"
+              title="No execution events"
+              detail="Resource lifecycle and workflow visibility events appear here from the current local index."
+            />
+          )}
+        </ConsoleSection>
+      </div>
+    </ConsolePage>
+  );
+}

--- a/ui/src/routes/create.tsx
+++ b/ui/src/routes/create.tsx
@@ -2,16 +2,21 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 import { useAccount } from 'wagmi';
 import { useStore } from '@nanostores/react';
-import { AnimatedPage } from '@tangle-network/blueprint-ui/components';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@tangle-network/blueprint-ui/components';
 import { Button } from '@tangle-network/blueprint-ui/components';
 import { Badge } from '@tangle-network/blueprint-ui/components';
 import { Input, Select } from '@tangle-network/blueprint-ui/components';
-import { InfrastructureModal, InfraBar } from '~/components/shared/InfrastructureModal';
+import { InfrastructureModal } from '~/components/shared/InfrastructureModal';
 import { JobPriceBadge } from '~/components/shared/JobPriceBadge';
 import { infraStore, updateInfra } from '@tangle-network/blueprint-ui';
 import { BlueprintJobForm, type FormSection } from '@tangle-network/blueprint-ui/components';
 import { Identicon } from '@tangle-network/blueprint-ui/components';
+import {
+  ConsoleChip,
+  ConsoleMetricStrip,
+  ConsolePage,
+  ConsoleSection,
+  type ConsoleMetric,
+} from '~/components/console/ConsolePrimitives';
 
 import { useJobForm } from '@tangle-network/blueprint-ui';
 import { useJobPrice } from '@tangle-network/blueprint-ui';
@@ -23,7 +28,6 @@ import { getAllBlueprints, getBlueprint, type BlueprintDefinition, type JobDefin
 import { updateSandboxStatus } from '~/lib/stores/sandboxes';
 import { updateInstanceStatus } from '~/lib/stores/instances';
 import { ProvisionProgress } from '~/components/shared/ProvisionProgress';
-import { BlueprintBadgeInline } from '~/components/shared/InfraSummaryBits';
 import type { DiscoveredOperator } from '@tangle-network/blueprint-ui';
 import { cn } from '@tangle-network/blueprint-ui';
 import { EnvEditor } from '~/components/shared/EnvEditor';
@@ -35,6 +39,8 @@ import {
   normalizeAgentIdentifier,
   sanitizeBundledAgentIdentifier,
 } from '~/lib/agents';
+
+type ConsoleTone = NonNullable<ConsoleMetric['tone']>;
 
 // ── Blueprint → on-chain ID mapping from env vars ──
 
@@ -75,9 +81,9 @@ function getPostAgentSections(isTee: boolean): FormSection[] {
 type WizardStep = 'blueprint' | 'configure' | 'deploy';
 
 const STEPS: { key: WizardStep; label: string; icon: string }[] = [
-  { key: 'blueprint', label: 'Blueprint', icon: 'i-ph:cube' },
-  { key: 'configure', label: 'Configure', icon: 'i-ph:gear' },
-  { key: 'deploy', label: 'Deploy', icon: 'i-ph:lightning' },
+  { key: 'blueprint', label: 'Mode', icon: 'i-ph:cube' },
+  { key: 'configure', label: 'Spec', icon: 'i-ph:gear' },
+  { key: 'deploy', label: 'Launch', icon: 'i-ph:rocket-launch' },
 ];
 
 function parsePortsInput(value: string): number[] {
@@ -99,6 +105,34 @@ function parseCapabilitiesJson(value: unknown): Set<string> {
   } catch {
     return new Set();
   }
+}
+
+function formatCapacityValue(value: number | bigint | undefined) {
+  if (value == null) return '--';
+  return typeof value === 'bigint' ? value.toString() : String(value);
+}
+
+function runtimeLabel(value: string) {
+  if (value === 'firecracker') return 'Firecracker';
+  if (value === 'tee') return 'TEE';
+  return 'Docker';
+}
+
+function serviceTone({
+  serviceValidating,
+  serviceError,
+  hasValidService,
+  isNewService,
+}: {
+  serviceValidating: boolean;
+  serviceError: string | null;
+  hasValidService: boolean;
+  isNewService: boolean;
+}): ConsoleTone {
+  if (serviceError) return 'danger';
+  if (serviceValidating) return 'warn';
+  if (hasValidService || isNewService) return 'ready';
+  return 'muted';
 }
 
 export default function CreatePage() {
@@ -266,6 +300,7 @@ export default function CreatePage() {
   const isSandbox = deploy.mode === 'sandbox';
   const entityLabel = isSandbox ? 'Sandbox' : 'Instance';
   const currentIdx = STEPS.findIndex((s) => s.key === step);
+  const blueprints = useMemo(() => getAllBlueprints(), []);
 
   // Per-job RFQ pricing
   const operatorRpcUrl = infra.serviceInfo?.operators?.[0]?.rpcAddress;
@@ -305,213 +340,496 @@ export default function CreatePage() {
   }, [resetForm, deployReset, address, validateService]);
 
   const showConnectPanel = !isConnected && !address && !isReconnectingWallet;
+  const parsedPorts = supportsMetadataPorts ? parsePortsInput(portsInput) : [];
+  const launchMetrics: ConsoleMetric[] = [
+    {
+      label: 'Blueprint',
+      value: selectedBlueprint ? entityLabel : 'Select',
+      detail: selectedBlueprint?.name ?? 'catalog',
+      tone: selectedBlueprint ? 'brand' : 'muted',
+    },
+    {
+      label: 'Runtime',
+      value: runtimeLabel(runtimeBackend),
+      detail: step === 'blueprint' ? 'pending' : 'backend',
+      tone: runtimeBackend === 'tee' ? 'warn' : 'ready',
+    },
+    {
+      label: 'Capacity',
+      value: formatCapacityValue(capacity),
+      detail: 'slots',
+      tone: capacity !== undefined && Number(capacity) === 0 ? 'warn' : 'ready',
+    },
+    {
+      label: 'Service',
+      value: serviceValidating
+        ? 'Checking'
+        : serviceError
+          ? 'Blocked'
+          : deploy.isNewService
+            ? 'New'
+            : deploy.hasValidService
+              ? 'Verified'
+              : 'Pending',
+      detail: `#${infra.serviceId || '--'}`,
+      tone: serviceTone({
+        serviceValidating,
+        serviceError,
+        hasValidService: deploy.hasValidService,
+        isNewService: deploy.isNewService,
+      }),
+    },
+  ];
 
   return (
-    <AnimatedPage className="mx-auto max-w-3xl px-4 sm:px-6 py-8">
-      <div className="mb-6">
-        <h1 className="text-2xl font-display font-bold text-cloud-elements-textPrimary">
-          Create {selectedBlueprint ? entityLabel : 'Resource'}
-        </h1>
-        <p className="text-sm text-cloud-elements-textSecondary mt-1">
-          {selectedBlueprint
-            ? selectedBlueprint.description
-            : 'Select a blueprint to provision a new AI agent resource on Tangle Network'}
-        </p>
-      </div>
-
-      {/* Wallet connect prompt — shown when no wallet is connected so the page
-          never lands on an empty, action-less surface inside the iframe. */}
-      {showConnectPanel && (
-        <div className="mb-6">
-          <ConnectWalletPanel
-            description="Provisioning a sandbox or instance requires a connected wallet on Tangle Network. You can browse blueprints below, but deploying will be blocked until you connect."
+    <ConsolePage
+      title="Launch Console"
+      eyebrow="Tangle sandbox compiler"
+      actions={step !== 'blueprint' ? (
+        <Button variant="secondary" onClick={() => setShowInfra(true)}>
+          <span className="i-ph:sliders-horizontal text-base" />
+          Infrastructure
+        </Button>
+      ) : null}
+    >
+      <div className="grid min-h-full gap-4 xl:grid-cols-[260px_minmax(0,1fr)_320px]">
+        <aside className="space-y-4">
+          <LaunchModeRail
+            blueprints={blueprints}
+            selectedBlueprint={selectedBlueprint}
+            onSelect={handleSelectBlueprint}
           />
-        </div>
-      )}
+          <LaunchPhaseRail
+            step={step}
+            currentIdx={currentIdx}
+            onStepChange={(nextStep) => setStep(nextStep)}
+          />
+        </aside>
 
-      {/* Infrastructure bar */}
-      {step !== 'blueprint' && (
-        <>
-          {isSandbox ? (
-            <InfraBar onOpenModal={() => setShowInfra(true)} />
-          ) : (
-            <InstanceInfraBar
-              infra={infra}
-              operators={deploy.operators}
-              operatorsLoading={deploy.operatorsLoading}
-              operatorsError={deploy.operatorsError}
-              operatorCount={deploy.operatorCount}
-              hasValidService={deploy.hasValidService}
-              onOpenModal={() => setShowInfra(true)}
+        <main className="min-w-0 space-y-4">
+          {showConnectPanel && (
+            <ConnectWalletPanel
+              description="Provisioning a sandbox or instance requires a connected wallet on Tangle Network. You can browse blueprints below, but deploying will be blocked until you connect."
             />
           )}
-          <InfrastructureModal open={showInfra} onOpenChange={setShowInfra} />
-        </>
-      )}
 
-      {/* Step Indicator */}
-      <div className="flex items-center gap-2 mb-8">
-        {STEPS.map((s, i) => (
-          <div key={s.key} className="flex items-center gap-2 flex-1">
-            <button
-              onClick={() => i <= currentIdx && setStep(s.key)}
-              className={cn(
-                'flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-display font-medium transition-all w-full',
-                s.key === step
-                  ? 'bg-violet-500/10 text-violet-700 dark:text-violet-400 border border-violet-500/20'
-                  : i < currentIdx
-                    ? 'bg-cloud-elements-background-depth-3 text-cloud-elements-textSecondary border border-cloud-elements-borderColor cursor-pointer'
-                    : 'bg-cloud-elements-background-depth-2 text-cloud-elements-textTertiary border border-transparent cursor-default',
-              )}
-            >
-              <div className={`${s.icon} text-base`} />
-              <span className="hidden sm:inline">{s.label}</span>
-              <span className="sm:hidden">{i + 1}</span>
-            </button>
-            {i < STEPS.length - 1 && <div className="w-4 h-px bg-cloud-elements-dividerColor shrink-0" />}
-          </div>
-        ))}
-      </div>
+          <ConsoleMetricStrip metrics={launchMetrics} />
 
-      {/* Step 1: Blueprint Selection */}
-      {step === 'blueprint' && <BlueprintSelector onSelect={handleSelectBlueprint} />}
+          {step === 'blueprint' && (
+            <ConsoleSection title="Blueprint Catalog">
+              <BlueprintSelector blueprints={blueprints} onSelect={handleSelectBlueprint} />
+            </ConsoleSection>
+          )}
 
-      {/* Step 2: Configure */}
-      {step === 'configure' && createJob && displayJob && (
-        <div className="space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <div className={`${selectedBlueprint?.icon} text-lg`} />
-                {entityLabel} Configuration
-              </CardTitle>
-              <CardDescription>Configure your {entityLabel.toLowerCase()} resources and settings</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <BlueprintJobForm
-                job={displayJob}
-                values={values}
-                onChange={onChange}
-                errors={errors}
-                sections={PRE_AGENT_SECTIONS}
-              />
+          {step === 'configure' && createJob && displayJob && (
+            <div className="space-y-4">
+              <ConsoleSection title={`${entityLabel} Spec`}>
+                <div className="p-4">
+                  <div className="mb-4 flex flex-wrap items-start justify-between gap-3 border-b border-[var(--sandbox-console-border)] pb-4">
+                    <div className="flex min-w-0 items-start gap-3">
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-[var(--sandbox-console-brand-border)] bg-[var(--sandbox-console-brand-soft)]">
+                        <div className={cn('text-xl text-[var(--sandbox-console-brand)]', selectedBlueprint?.icon)} />
+                      </div>
+                      <div className="min-w-0">
+                        <h2 className="truncate font-display text-lg font-semibold text-[var(--sandbox-console-text)]">
+                          {selectedBlueprint?.name ?? entityLabel}
+                        </h2>
+                        <p className="mt-1 text-sm text-[var(--sandbox-console-muted)]">
+                          {selectedBlueprint?.description}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <ConsoleChip tone="brand">service #{infra.serviceId || '--'}</ConsoleChip>
+                      <ConsoleChip tone={runtimeBackend === 'tee' ? 'warn' : 'ready'}>{runtimeLabel(runtimeBackend)}</ConsoleChip>
+                    </div>
+                  </div>
 
-              {supportsAgentConfiguration && (
-                <AgentConfigurationField
-                  image={selectedImage}
-                  value={configuredAgentIdentifier}
-                  usesBundledSelector={usesBundledAgentSelector}
-                  onChange={(next) => onChange('agentIdentifier', next)}
-                />
-              )}
+                  <div className="space-y-1">
+                    <BlueprintJobForm
+                      job={displayJob}
+                      values={values}
+                      onChange={onChange}
+                      errors={errors}
+                      sections={PRE_AGENT_SECTIONS}
+                    />
 
-              <AllHarnessCapabilityField
-                enabled={allHarnessEnabled}
-                onChange={(enabled) => onChange('capabilitiesJson', enabled ? JSON.stringify(['all_harness']) : JSON.stringify([]))}
-              />
+                    {supportsAgentConfiguration && (
+                      <AgentConfigurationField
+                        image={selectedImage}
+                        value={configuredAgentIdentifier}
+                        usesBundledSelector={usesBundledAgentSelector}
+                        onChange={(next) => onChange('agentIdentifier', next)}
+                      />
+                    )}
 
-              {configuredAgentIdentifier && (
-                <div className="mt-4 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2">
-                  <p className="text-xs text-amber-300">
-                    This agent needs AI credentials to chat. You can add them now in Environment Variables below, or inject them later in the Secrets tab.
-                  </p>
+                    <AllHarnessCapabilityField
+                      enabled={allHarnessEnabled}
+                      onChange={(enabled) => onChange('capabilitiesJson', enabled ? JSON.stringify(['all_harness']) : JSON.stringify([]))}
+                    />
+
+                    {configuredAgentIdentifier && (
+                      <div className="mt-4 rounded-md border border-amber-500/20 bg-amber-500/5 px-3 py-2">
+                        <p className="text-xs text-amber-300">
+                          This agent needs AI credentials to chat. You can add them now in Environment Variables below, or inject them later in the Secrets tab.
+                        </p>
+                      </div>
+                    )}
+
+                    <BlueprintJobForm
+                      job={displayJob}
+                      values={values}
+                      onChange={onChange}
+                      errors={errors}
+                      sections={postAgentSections}
+                    />
+
+                    <div className="mt-6 space-y-1.5 border-t border-cloud-elements-dividerColor pt-4">
+                      <label className="text-xs font-display font-medium text-cloud-elements-textSecondary">
+                        Environment Variables
+                      </label>
+                      <EnvEditor
+                        value={String(values.envJson || '{}')}
+                        onChange={(json) => onChange('envJson', json)}
+                      />
+                      <p className="text-[11px] text-cloud-elements-textTertiary">
+                        Key-value pairs injected as environment variables into the sandbox.
+                      </p>
+                    </div>
+
+                    <div className="mt-6 space-y-1.5 border-t border-cloud-elements-dividerColor pt-4">
+                      <label className="text-xs font-display font-medium text-cloud-elements-textSecondary">
+                        Exposed Ports
+                      </label>
+                      <input
+                        type="text"
+                        value={portsInput}
+                        onChange={(e) => setPortsInput(e.target.value)}
+                        disabled={!supportsMetadataPorts}
+                        placeholder={supportsMetadataPorts ? 'e.g. 3000, 8080, 5432' : 'Not supported for Firecracker runtime'}
+                        className={cn(
+                          'w-full rounded-md border border-cloud-elements-borderColor bg-cloud-elements-background-depth-2 px-3 py-2 font-data text-sm text-cloud-elements-textPrimary placeholder:text-cloud-elements-textTertiary transition-colors focus:border-cloud-elements-borderColorActive focus:outline-none',
+                          !supportsMetadataPorts && 'cursor-not-allowed opacity-60',
+                        )}
+                      />
+                      <p className="text-[11px] text-cloud-elements-textTertiary">
+                        {supportsMetadataPorts
+                          ? 'Comma-separated container ports to expose through the operator API proxy.'
+                          : 'Firecracker backend currently does not support metadata_json.ports mappings.'}
+                      </p>
+                    </div>
+                  </div>
                 </div>
-              )}
-
-              <BlueprintJobForm
-                job={displayJob}
-                values={values}
-                onChange={onChange}
-                errors={errors}
-                sections={postAgentSections}
-              />
-
-              {/* Environment variables — key-value editor instead of raw JSON */}
-              <div className="mt-6 pt-4 border-t border-cloud-elements-dividerColor space-y-1.5">
-                <label className="text-xs font-display font-medium text-cloud-elements-textSecondary">
-                  Environment Variables
-                </label>
-                <EnvEditor
-                  value={String(values.envJson || '{}')}
-                  onChange={(json) => onChange('envJson', json)}
-                />
-                <p className="text-[11px] text-cloud-elements-textTertiary">
-                  Key-value pairs injected as environment variables into the sandbox.
-                </p>
+              </ConsoleSection>
+              <div className="flex justify-between">
+                <Button variant="secondary" onClick={() => setStep('blueprint')}>Back</Button>
+                <Button onClick={() => { if (validate()) setStep('deploy'); }} disabled={!createJob || !values.name}>Continue</Button>
               </div>
+            </div>
+          )}
 
-              {/* Extra ports — not an ABI field, merged into metadataJson */}
-              <div className="mt-6 pt-4 border-t border-cloud-elements-dividerColor space-y-1.5">
-                <label className="text-xs font-display font-medium text-cloud-elements-textSecondary">
-                  Exposed Ports
-                </label>
-                <input
-                  type="text"
-                  value={portsInput}
-                  onChange={(e) => setPortsInput(e.target.value)}
-                  disabled={!supportsMetadataPorts}
-                  placeholder={supportsMetadataPorts ? 'e.g. 3000, 8080, 5432' : 'Not supported for Firecracker runtime'}
-                  className={cn(
-                    'w-full px-3 py-2 rounded-lg bg-cloud-elements-background-depth-2 border border-cloud-elements-borderColor text-sm font-data text-cloud-elements-textPrimary placeholder:text-cloud-elements-textTertiary focus:outline-none focus:border-cloud-elements-borderColorActive transition-colors',
-                    !supportsMetadataPorts && 'opacity-60 cursor-not-allowed',
-                  )}
-                />
-                <p className="text-[11px] text-cloud-elements-textTertiary">
-                  {supportsMetadataPorts
-                    ? 'Comma-separated container ports to expose through the operator API proxy.'
-                    : 'Firecracker backend currently does not support metadata_json.ports mappings.'}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-          <div className="flex justify-between">
-            <Button variant="secondary" onClick={() => setStep('blueprint')}>Back</Button>
-            <Button onClick={() => { if (validate()) setStep('deploy'); }} disabled={!createJob || !values.name}>Continue</Button>
-          </div>
-        </div>
-      )}
+          {step === 'deploy' && createJob && displayJob && selectedBlueprint && (
+            <DeployStep
+              blueprint={selectedBlueprint}
+              job={displayJob}
+              values={values}
+              ports={parsedPorts}
+              infra={infra}
+              entityLabel={entityLabel}
+              deploy={deploy}
+              capacity={capacity}
+              provisionEstimate={provisionEstimate}
+              provisionPriceFormatted={provisionPriceFormatted}
+              hasProvisionRfq={hasProvisionRfq}
+              priceLoading={priceLoading}
+              serviceInfo={serviceInfo}
+              serviceValidating={serviceValidating}
+              serviceError={serviceError}
+              onBack={() => { setStep('configure'); deployReset(); }}
+              onDeploy={deploy.deploy}
+              onViewDetail={() => {
+                const key = isSandbox
+                  ? deploy.sandboxDraftKey
+                  : String(values.name || '');
+                if (key) navigate(`/${isSandbox ? 'sandboxes' : 'instances'}/${encodeURIComponent(key)}`);
+                else navigate(isSandbox ? '/sandboxes' : '/instances');
+              }}
+              onOpenInfra={() => setShowInfra(true)}
+              onProvisionReady={(sandboxId, sidecarUrl) => {
+                if (isSandbox) {
+                  if (deploy.sandboxDraftKey) {
+                    updateSandboxStatus(deploy.sandboxDraftKey, 'running', { sandboxId, sidecarUrl });
+                  }
+                } else {
+                  const name = String(values.name || '');
+                  updateInstanceStatus(name, 'running', { sandboxId, sidecarUrl });
+                }
+              }}
+            />
+          )}
+        </main>
 
-      {/* Step 3: Review & Deploy */}
-      {step === 'deploy' && createJob && displayJob && selectedBlueprint && (
-        <DeployStep
-          blueprint={selectedBlueprint}
-          job={displayJob}
-          values={values}
-          ports={supportsMetadataPorts ? parsePortsInput(portsInput) : []}
-          infra={infra}
+        <LaunchReadinessRail
+          step={step}
+          selectedBlueprint={selectedBlueprint}
           entityLabel={entityLabel}
-          deploy={deploy}
+          runtimeBackend={runtimeBackend}
+          infra={infra}
           capacity={capacity}
-          provisionEstimate={provisionEstimate}
-          provisionPriceFormatted={provisionPriceFormatted}
-          hasProvisionRfq={hasProvisionRfq}
-          priceLoading={priceLoading}
-          serviceInfo={serviceInfo}
+          isConnected={isConnected}
+          isReconnectingWallet={isReconnectingWallet}
+          hasValidService={deploy.hasValidService}
+          isNewService={deploy.isNewService}
           serviceValidating={serviceValidating}
           serviceError={serviceError}
-          onBack={() => { setStep('configure'); deployReset(); }}
-          onDeploy={deploy.deploy}
-          onViewDetail={() => {
-            const key = isSandbox
-              ? deploy.sandboxDraftKey
-              : String(values.name || '');
-            if (key) navigate(`/${isSandbox ? 'sandboxes' : 'instances'}/${encodeURIComponent(key)}`);
-            else navigate(isSandbox ? '/sandboxes' : '/instances');
-          }}
+          operatorsCount={deploy.operators.length}
+          operatorCount={deploy.operatorCount}
+          operatorsLoading={deploy.operatorsLoading}
+          operatorsError={deploy.operatorsError}
+          agentIdentifier={configuredAgentIdentifier}
+          ports={parsedPorts}
           onOpenInfra={() => setShowInfra(true)}
-          onProvisionReady={(sandboxId, sidecarUrl) => {
-            if (isSandbox) {
-              if (deploy.sandboxDraftKey) {
-                updateSandboxStatus(deploy.sandboxDraftKey, 'running', { sandboxId, sidecarUrl });
-              }
-            } else {
-              const name = String(values.name || '');
-              updateInstanceStatus(name, 'running', { sandboxId, sidecarUrl });
-            }
-          }}
         />
-      )}
-    </AnimatedPage>
+      </div>
+
+      <InfrastructureModal open={showInfra} onOpenChange={setShowInfra} />
+    </ConsolePage>
+  );
+}
+
+function LaunchModeRail({
+  blueprints,
+  selectedBlueprint,
+  onSelect,
+}: {
+  blueprints: BlueprintDefinition[];
+  selectedBlueprint?: BlueprintDefinition;
+  onSelect: (bp: BlueprintDefinition) => void;
+}) {
+  return (
+    <ConsoleSection title="Launch Modes">
+      <div className="grid gap-px bg-[var(--sandbox-console-border)] p-px">
+        {blueprints.map((bp) => {
+          const isActive = selectedBlueprint?.id === bp.id;
+          return (
+            <button
+              key={bp.id}
+              onClick={() => onSelect(bp)}
+              className={cn(
+                'flex min-h-20 items-start gap-3 bg-[var(--sandbox-console-panel)] p-3 text-left transition-colors hover:bg-[var(--sandbox-console-hover)]',
+                isActive && 'bg-[var(--sandbox-console-brand-soft)]',
+              )}
+            >
+              <span className={cn('mt-0.5 text-lg text-[var(--sandbox-console-brand)]', bp.icon)} />
+              <span className="min-w-0">
+                <span className="block truncate font-display text-sm font-semibold text-[var(--sandbox-console-text)]">
+                  {bp.name}
+                </span>
+                <span className="mt-1 line-clamp-2 block text-xs leading-5 text-[var(--sandbox-console-muted)]">
+                  {bp.description}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </ConsoleSection>
+  );
+}
+
+function LaunchPhaseRail({
+  step,
+  currentIdx,
+  onStepChange,
+}: {
+  step: WizardStep;
+  currentIdx: number;
+  onStepChange: (step: WizardStep) => void;
+}) {
+  return (
+    <ConsoleSection title="Compiler Phases">
+      <div className="divide-y divide-[var(--sandbox-console-border)]">
+        {STEPS.map((phase, index) => {
+          const isCurrent = phase.key === step;
+          const isAvailable = index <= currentIdx;
+          return (
+            <button
+              key={phase.key}
+              onClick={() => {
+                if (isAvailable) onStepChange(phase.key);
+              }}
+              className={cn(
+                'flex h-12 w-full items-center gap-3 px-3 text-left transition-colors',
+                isCurrent ? 'bg-[var(--sandbox-console-brand-soft)]' : 'hover:bg-[var(--sandbox-console-hover)]',
+                !isAvailable && 'cursor-default opacity-50 hover:bg-transparent',
+              )}
+            >
+              <span className={cn('text-base', phase.icon, isCurrent ? 'text-[var(--sandbox-console-brand)]' : 'text-[var(--sandbox-console-muted)]')} />
+              <span className="font-data text-xs uppercase tracking-[0.12em] text-[var(--sandbox-console-text)]">
+                {phase.label}
+              </span>
+              {index < currentIdx ? (
+                <span className="ml-auto i-ph:check text-sm text-[var(--sandbox-console-success)]" />
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    </ConsoleSection>
+  );
+}
+
+function LaunchReadinessRail({
+  step,
+  selectedBlueprint,
+  entityLabel,
+  runtimeBackend,
+  infra,
+  capacity,
+  isConnected,
+  isReconnectingWallet,
+  hasValidService,
+  isNewService,
+  serviceValidating,
+  serviceError,
+  operatorsCount,
+  operatorCount,
+  operatorsLoading,
+  operatorsError,
+  agentIdentifier,
+  ports,
+  onOpenInfra,
+}: {
+  step: WizardStep;
+  selectedBlueprint?: BlueprintDefinition;
+  entityLabel: string;
+  runtimeBackend: string;
+  infra: { blueprintId: string; serviceId: string };
+  capacity?: number | bigint;
+  isConnected: boolean;
+  isReconnectingWallet: boolean;
+  hasValidService: boolean;
+  isNewService: boolean;
+  serviceValidating: boolean;
+  serviceError: string | null;
+  operatorsCount: number;
+  operatorCount: bigint;
+  operatorsLoading: boolean;
+  operatorsError?: Error | null;
+  agentIdentifier: string;
+  ports: number[];
+  onOpenInfra: () => void;
+}) {
+  const operatorSummary = operatorsLoading
+    ? 'Discovering'
+    : operatorsError && operatorCount > 0n
+      ? `${operatorCount.toString()} registered`
+      : operatorsError
+        ? 'Lookup failed'
+        : `${operatorsCount} verified`;
+  const serviceState = serviceValidating
+    ? 'Checking'
+    : serviceError
+      ? 'Blocked'
+      : isNewService
+        ? 'Create on deploy'
+        : hasValidService
+          ? 'Verified'
+          : 'Pending';
+
+  return (
+    <aside className="space-y-4">
+      <ConsoleSection title="Launch Readiness">
+        <div className="divide-y divide-[var(--sandbox-console-border)]">
+          <ReadinessRow
+            label="Mode"
+            value={selectedBlueprint ? entityLabel : 'Unselected'}
+            detail={selectedBlueprint?.name ?? 'Choose a blueprint'}
+            tone={selectedBlueprint ? 'brand' : 'warn'}
+          />
+          <ReadinessRow
+            label="Spec"
+            value={step === 'deploy' ? 'Locked' : step === 'configure' ? 'Editing' : 'Open'}
+            detail={step === 'deploy' ? 'ready for transaction' : 'mutable'}
+            tone={step === 'deploy' ? 'ready' : 'muted'}
+          />
+          <ReadinessRow
+            label="Runtime"
+            value={runtimeLabel(runtimeBackend)}
+            detail={runtimeBackend === 'tee' ? 'attestation path' : 'standard path'}
+            tone={runtimeBackend === 'tee' ? 'warn' : 'ready'}
+          />
+          <ReadinessRow
+            label="Capacity"
+            value={formatCapacityValue(capacity)}
+            detail="available slots"
+            tone={capacity !== undefined && Number(capacity) === 0 ? 'warn' : 'ready'}
+          />
+          <ReadinessRow
+            label="Wallet"
+            value={isConnected ? 'Connected' : isReconnectingWallet ? 'Syncing' : 'Offline'}
+            detail={isConnected ? 'can sign' : 'deploy blocked'}
+            tone={isConnected ? 'ready' : isReconnectingWallet ? 'warn' : 'danger'}
+          />
+          <ReadinessRow
+            label="Service"
+            value={serviceState}
+            detail={`blueprint ${infra.blueprintId || '--'} / service ${infra.serviceId || '--'}`}
+            tone={serviceTone({ serviceValidating, serviceError, hasValidService, isNewService })}
+          />
+          <ReadinessRow
+            label="Operators"
+            value={operatorSummary}
+            detail={isNewService ? 'service quorum' : 'operator service'}
+            tone={operatorsError ? 'warn' : 'brand'}
+          />
+          <ReadinessRow
+            label="Agent mode"
+            value={agentIdentifier || 'Compute only'}
+            detail={agentIdentifier ? 'chat enabled' : 'no bundled agent'}
+            tone={agentIdentifier ? 'brand' : 'muted'}
+          />
+          <ReadinessRow
+            label="Network"
+            value={ports.length > 0 ? `${ports.length} port${ports.length === 1 ? '' : 's'}` : 'Default'}
+            detail={ports.length > 0 ? ports.join(', ') : 'operator proxy'}
+            tone={ports.length > 0 ? 'brand' : 'muted'}
+          />
+        </div>
+        <div className="border-t border-[var(--sandbox-console-border)] p-3">
+          <Button variant="secondary" size="sm" className="w-full justify-center" onClick={onOpenInfra}>
+            <span className="i-ph:sliders-horizontal text-sm" />
+            Infrastructure
+          </Button>
+        </div>
+      </ConsoleSection>
+    </aside>
+  );
+}
+
+function ReadinessRow({
+  label,
+  value,
+  detail,
+  tone,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  tone: ConsoleTone;
+}) {
+  return (
+    <div className="grid gap-1 px-3 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-data text-[10px] uppercase tracking-[0.14em] text-[var(--sandbox-console-muted)]">
+          {label}
+        </span>
+        <ConsoleChip tone={tone}>{value}</ConsoleChip>
+      </div>
+      <p className="truncate font-data text-[11px] text-[var(--sandbox-console-subtle)]">
+        {detail}
+      </p>
+    </div>
   );
 }
 
@@ -595,54 +913,15 @@ function AllHarnessCapabilityField({
   );
 }
 
-// ── Instance Infra Bar ──
-
-function InstanceInfraBar({
-  infra, operators, operatorsLoading, operatorsError, operatorCount, hasValidService, onOpenModal,
-}: {
-  infra: { blueprintId: string; serviceId: string };
-  operators: DiscoveredOperator[];
-  operatorsLoading: boolean;
-  operatorsError?: Error | null;
-  operatorCount: bigint;
-  hasValidService: boolean;
-  onOpenModal: () => void;
-}) {
-  const operatorSummary = operatorsLoading
-    ? 'Discovering...'
-    : operatorsError
-      ? operatorCount > 0n
-        ? `${operatorCount.toString()} registered (verification failed)`
-        : 'Lookup failed'
-      : `${operators.length} operators`;
-
-  return (
-    <div className="glass-card rounded-lg p-3 flex items-center justify-between mb-6">
-      <div className="flex items-center gap-4">
-        <BlueprintBadgeInline blueprintId={infra.blueprintId} />
-        <div className="flex items-center gap-2">
-          <div className="i-ph:users-three text-sm text-cloud-elements-textTertiary" />
-          <span className="text-xs text-cloud-elements-textTertiary">
-            {operatorSummary}
-          </span>
-        </div>
-        {hasValidService && (
-          <div className="flex items-center gap-2">
-            <div className="i-ph:info text-sm text-cloud-elements-textTertiary" />
-            <span className="text-xs text-cloud-elements-textTertiary">Verified service #{infra.serviceId} available</span>
-          </div>
-        )}
-      </div>
-      <Button variant="ghost" size="sm" onClick={onOpenModal}>Change</Button>
-    </div>
-  );
-}
-
 // ── Blueprint Selector ──
 
-function BlueprintSelector({ onSelect }: { onSelect: (bp: BlueprintDefinition) => void }) {
-  const blueprints = getAllBlueprints();
-
+function BlueprintSelector({
+  blueprints,
+  onSelect,
+}: {
+  blueprints: BlueprintDefinition[];
+  onSelect: (bp: BlueprintDefinition) => void;
+}) {
   const colorMap: Record<string, string> = {
     teal: 'border-teal-500/20 hover:border-teal-500/40',
     blue: 'border-blue-500/20 hover:border-blue-500/40',
@@ -656,13 +935,13 @@ function BlueprintSelector({ onSelect }: { onSelect: (bp: BlueprintDefinition) =
   };
 
   return (
-    <div className="grid gap-4">
+    <div className="grid gap-px bg-[var(--sandbox-console-border)] p-px">
       {blueprints.map((bp) => (
         <button
           key={bp.id}
           onClick={() => onSelect(bp)}
           className={cn(
-            'glass-card rounded-xl p-6 text-left transition-all border-2 cursor-pointer',
+            'bg-[var(--sandbox-console-panel)] p-4 text-left transition-all cursor-pointer',
             'hover:bg-cloud-elements-item-backgroundHover',
             colorMap[bp.color] ?? 'border-cloud-elements-borderColor hover:border-cloud-elements-borderColorActive',
           )}

--- a/ui/src/routes/instances.$id.automation.tsx
+++ b/ui/src/routes/instances.$id.automation.tsx
@@ -1,0 +1,1 @@
+export { default } from './instances.$id';

--- a/ui/src/routes/instances.$id.network.tsx
+++ b/ui/src/routes/instances.$id.network.tsx
@@ -1,0 +1,1 @@
+export { default } from './instances.$id';

--- a/ui/src/routes/instances.$id.runtime.tsx
+++ b/ui/src/routes/instances.$id.runtime.tsx
@@ -1,0 +1,1 @@
+export { default } from './instances.$id';

--- a/ui/src/routes/instances.$id.security.tsx
+++ b/ui/src/routes/instances.$id.security.tsx
@@ -1,0 +1,1 @@
+export { default } from './instances.$id';

--- a/ui/src/routes/instances.$id.sessions.tsx
+++ b/ui/src/routes/instances.$id.sessions.tsx
@@ -1,0 +1,1 @@
+export { default } from './instances.$id';

--- a/ui/src/routes/instances.$id.storage.tsx
+++ b/ui/src/routes/instances.$id.storage.tsx
@@ -1,0 +1,1 @@
+export { default } from './instances.$id';

--- a/ui/src/routes/instances.$id.tsx
+++ b/ui/src/routes/instances.$id.tsx
@@ -27,6 +27,14 @@ import { OperatorTerminalView } from '~/components/shared/OperatorTerminalView';
 import { ConfirmDialog } from '~/components/shared/ConfirmDialog';
 import { SnapshotDialog } from '~/components/shared/SnapshotDialog';
 import { OnChainVerificationCard } from '~/components/shared/OnChainVerificationCard';
+import { ResourceWorkspaceNav } from '~/components/console/ResourceWorkspaceNav';
+import { ConsoleMetricStrip, type ConsoleMetric } from '~/components/console/ConsolePrimitives';
+import {
+  AutomationWorkspace,
+  ResourceWorkspaceRail,
+  StorageWorkspace,
+  type WorkspaceRailRow,
+} from '~/components/console/ResourceWorkspacePanels';
 
 import { useAccount } from 'wagmi';
 import {
@@ -47,7 +55,21 @@ interface SshKey {
   publicKey: string;
 }
 
-type ActionTab = 'overview' | 'terminal' | 'chat' | 'ssh' | 'secrets' | 'attestation';
+type ActionTab = 'overview' | 'terminal' | 'chat' | 'ssh' | 'secrets' | 'attestation' | 'automation' | 'storage';
+
+function getInitialTabFromPath(pathname: string): ActionTab {
+  if (pathname.endsWith('/runtime')) return 'terminal';
+  if (pathname.endsWith('/sessions')) return 'chat';
+  if (pathname.endsWith('/automation')) return 'automation';
+  if (pathname.endsWith('/network')) return 'ssh';
+  if (pathname.endsWith('/security')) return 'secrets';
+  if (pathname.endsWith('/storage')) return 'storage';
+  return 'overview';
+}
+
+function getCurrentPathname() {
+  return typeof window === 'undefined' ? '' : window.location.pathname;
+}
 
 /** Extract human-readable error from operator API Error messages. */
 function parseApiError(err: Error): string {
@@ -65,6 +87,7 @@ function parseApiError(err: Error): string {
 
 export default function InstanceDetail() {
   const { id } = useParams<{ id: string }>();
+  const currentPathname = getCurrentPathname();
   const decodedId = id ? decodeURIComponent(id) : '';
   const instances = useStore(instanceListStore);
   const inst = getInstance(decodedId) ?? instances.find((s) => s.id === decodedId);
@@ -80,7 +103,7 @@ export default function InstanceDetail() {
     }
   }, [inst?.sidecarUrl]);
 
-  const [tab, setTab] = useState<ActionTab>('overview');
+  const [tab, setTab] = useState<ActionTab>(() => getInitialTabFromPath(currentPathname));
   const [systemPrompt, setSystemPrompt] = useState('');
   const [secretsJson, setSecretsJson] = useState('{\n  \n}');
   const [secretsVisible, setSecretsVisible] = useState(false);
@@ -488,10 +511,65 @@ export default function InstanceDetail() {
     { key: 'overview', label: 'Overview', icon: 'i-ph:info' },
     { key: 'terminal', label: 'Terminal', icon: 'i-ph:terminal' },
     { key: 'chat', label: 'Chat', icon: 'i-ph:chat-circle', hidden: !hasAgent },
+    { key: 'automation', label: 'Automation', icon: 'i-ph:flow-arrow' },
     { key: 'ssh' as const, label: 'SSH', icon: 'i-ph:key', hidden: !inst.sshPort },
     { key: 'secrets', label: 'Secrets', icon: 'i-ph:lock-simple', hidden: !!inst.teeEnabled },
+    { key: 'storage', label: 'Storage', icon: 'i-ph:database' },
     ...(inst.teeEnabled ? [{ key: 'attestation' as const, label: 'Attestation', icon: 'i-ph:shield-check' }] : []),
   ];
+
+  const workspaceBasePath = `/instances/${encodeURIComponent(inst.id)}`;
+  const workspaceNavItems = [
+    { label: 'Runtime', href: `${workspaceBasePath}/runtime`, icon: 'i-ph:terminal' },
+    { label: 'Sessions', href: `${workspaceBasePath}/sessions`, icon: 'i-ph:chat-circle', disabled: !hasAgent },
+    { label: 'Automation', href: `${workspaceBasePath}/automation`, icon: 'i-ph:flow-arrow' },
+    { label: 'Network', href: `${workspaceBasePath}/network`, icon: 'i-ph:plugs', disabled: !inst.sshPort },
+    { label: 'Security', href: `${workspaceBasePath}/security`, icon: 'i-ph:shield-check' },
+    { label: 'Storage', href: `${workspaceBasePath}/storage`, icon: 'i-ph:database' },
+  ];
+  const exposedPortCount = ports?.length ?? 0;
+  const statusTone = inst.status === 'running' ? 'ready' : inst.status === 'creating' ? 'brand' : inst.status === 'error' ? 'danger' : 'muted';
+  const workspaceMetrics: ConsoleMetric[] = [
+    {
+      label: 'Status',
+      value: getInstanceStatusLabel(inst),
+      detail: inst.status === 'running' ? 'operator ready' : 'lifecycle',
+      tone: statusTone,
+    },
+    {
+      label: 'Runtime',
+      value: inst.teeEnabled ? 'TEE' : 'Docker',
+      detail: `${inst.cpuCores}c / ${Math.round(inst.memoryMb / 1024)}g / ${inst.diskGb}g`,
+      tone: inst.teeEnabled ? 'warn' : 'brand',
+    },
+    {
+      label: 'Network',
+      value: inst.sshPort ? `ssh:${inst.sshPort}` : exposedPortCount > 0 ? `${exposedPortCount} ports` : 'proxy',
+      detail: operatorUrl.replace(/^https?:\/\//, ''),
+      tone: inst.sshPort || exposedPortCount > 0 ? 'ready' : 'muted',
+    },
+    {
+      label: 'Agent',
+      value: configuredAgentIdentifier || 'none',
+      detail: hasAgent ? 'sessions enabled' : 'compute only',
+      tone: hasAgent ? 'brand' : 'muted',
+    },
+  ];
+  const contextRows: WorkspaceRailRow[] = [
+    { label: 'Instance ID', value: inst.id, detail: getInstanceSandboxDisplayValue(inst), tone: 'brand' },
+    { label: 'Blueprint', value: getBlueprint(bpId)?.name ?? bpId, detail: getInstanceServiceDisplayValue(inst), tone: 'brand' },
+    { label: 'Operator', value: inst.operator ? truncateAddress(inst.operator) : 'unknown', detail: inst.operator ?? 'operator not resolved', tone: inst.operator ? 'ready' : 'muted' },
+    { label: 'Workspace', value: tab, detail: currentPathname, tone: 'muted' },
+  ];
+  const storageRows: WorkspaceRailRow[] = [
+    { label: 'Image', value: inst.image.replace('ghcr.io/tangle-network/', ''), detail: 'source image', tone: 'brand' },
+    { label: 'Disk', value: `${inst.diskGb} GB`, detail: 'allocated volume', tone: 'ready' },
+    { label: 'Lifecycle', value: inst.status, detail: new Date(inst.createdAt).toLocaleString(), tone: statusTone },
+    { label: 'Secrets', value: inst.credentialsAvailable === false ? 'missing' : 'available', detail: inst.teeEnabled ? 'TEE protected' : 'operator encrypted', tone: inst.credentialsAvailable === false ? 'warn' : 'ready' },
+  ];
+  const workflowCreateHref = inst.status === 'running' && inst.serviceId
+    ? `/workflows/create?target=${encodeURIComponent(`instance:${inst.id}`)}`
+    : undefined;
 
   return (
     <AnimatedPage className="mx-auto max-w-5xl px-4 sm:px-6 py-8">
@@ -556,7 +634,14 @@ export default function InstanceDetail() {
         </div>
       )}
 
-      <ResourceTabs tabs={tabs} value={tab} onValueChange={setTab} className="mb-6" />
+      <div className="mb-4">
+        <ConsoleMetricStrip metrics={workspaceMetrics} />
+      </div>
+
+      <div className="mb-4 grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="min-w-0 space-y-4">
+          <ResourceWorkspaceNav items={workspaceNavItems} activePath={currentPathname} />
+          <ResourceTabs tabs={tabs} value={tab} onValueChange={setTab} className="mb-0" />
 
       {agentConfigured && hasAgentValidationResult && !agentIdentifierValid && (
         <div className="mb-4 rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
@@ -638,6 +723,24 @@ export default function InstanceDetail() {
             />
           )}
         </div>
+      )}
+
+      {tab === 'automation' && (
+        <AutomationWorkspace
+          createHref={workflowCreateHref}
+          scope={inst.teeEnabled ? 'tee-instance' : 'instance'}
+          target={inst.id}
+          status={inst.status}
+          hasAgent={hasAgent}
+        />
+      )}
+
+      {tab === 'storage' && (
+        <StorageWorkspace
+          rows={storageRows}
+          onSnapshot={() => setSnapshotOpen(true)}
+          snapshotEnabled={inst.status === 'running'}
+        />
       )}
 
       {/* Terminal */}
@@ -950,6 +1053,9 @@ export default function InstanceDetail() {
           />
         </div>
       )}
+        </div>
+        <ResourceWorkspaceRail rows={contextRows} />
+      </div>
 
       <SnapshotDialog
         open={snapshotOpen}

--- a/ui/src/routes/instances._index.tsx
+++ b/ui/src/routes/instances._index.tsx
@@ -1,58 +1,122 @@
+import { Link } from 'react-router';
+import { useMemo } from 'react';
 import { useStore } from '@nanostores/react';
-import { ProvisionedResourceListCard } from '~/components/shared/ProvisionedResourceListCard';
-import { ProvisionedResourceIndexPage } from '~/components/shared/ProvisionedResourceIndexPage';
-import { instanceListStore, activeInstances } from '~/lib/stores/instances';
+import { Button } from '@tangle-network/blueprint-ui/components';
+import {
+  ConsoleChip,
+  ConsoleMetricStrip,
+  ConsolePage,
+  ConsoleSection,
+  type ConsoleMetric,
+} from '~/components/console/ConsolePrimitives';
+import {
+  ResourceExplorerTable,
+  type ResourceExplorerRow,
+} from '~/components/console/ResourceExplorerTable';
+import {
+  activeInstances,
+  instanceListStore,
+  runningInstances,
+  type LocalInstance,
+} from '~/lib/stores/instances';
 import { getInstanceStatusLabel } from '~/lib/instances/display';
 
-export default function InstanceList() {
+function getSecurityState(instance: LocalInstance) {
+  if (instance.teeEnabled) return 'attested';
+  if (instance.credentialsAvailable) return 'secrets';
+  return 'session';
+}
+
+function getStorageState(status: string) {
+  if (status === 'stopped') return 'hot';
+  if (status === 'gone') return 'gone';
+  return 'ephemeral';
+}
+
+function instanceToRow(instance: LocalInstance): ResourceExplorerRow {
+  return {
+    key: instance.id,
+    href: `/instances/${encodeURIComponent(instance.id)}`,
+    name: instance.name,
+    id: instance.sandboxId ?? instance.id,
+    scope: instance.teeEnabled ? 'TEE' : 'Instance',
+    status: instance.status,
+    statusLabel: getInstanceStatusLabel(instance),
+    backend: instance.teeEnabled ? 'tee' : 'docker',
+    image: instance.image,
+    operator: instance.operator,
+    specs: `${instance.cpuCores}c/${Math.round(instance.memoryMb / 1024)}g/${instance.diskGb}g`,
+    sessions: instance.agentIdentifier ? 'agent' : '--',
+    workflows: '--',
+    network: instance.sshPort ? `ssh:${instance.sshPort}` : 'ports',
+    security: getSecurityState(instance),
+    storage: getStorageState(instance.status),
+    createdAt: instance.createdAt,
+    teeEnabled: instance.teeEnabled,
+    agentIdentifier: instance.agentIdentifier,
+  };
+}
+
+export default function InstanceExplorer() {
   const allInstances = useStore(instanceListStore);
   const active = useStore(activeInstances);
+  const running = useStore(runningInstances);
+
+  const rows = useMemo(
+    () => allInstances.map(instanceToRow)
+      .sort((left, right) => right.createdAt - left.createdAt),
+    [allInstances],
+  );
+
+  const metrics: ConsoleMetric[] = [
+    { label: 'Active', value: String(active.length), detail: 'dedicated', tone: 'ready' },
+    { label: 'Running', value: String(running.length), detail: 'operator-backed', tone: 'ready' },
+    { label: 'TEE instances', value: String(allInstances.filter((instance) => instance.teeEnabled).length), detail: 'sealed secrets', tone: 'brand' },
+    { label: 'Errors', value: String(allInstances.filter((instance) => instance.status === 'error').length), detail: 'attention', tone: 'danger' },
+  ];
 
   return (
-    <ProvisionedResourceIndexPage
-      title="Instances"
-      subtitle={
-        active.length > 0
-          ? `${active.length} active instance${active.length > 1 ? 's' : ''}`
-          : 'Subscription-based AI agent instances'
-      }
-      createTo="/create?blueprint=ai-agent-instance-blueprint"
-      createLabel="New Instance"
-      items={allInstances}
-      getKey={(inst) => inst.id}
-      renderItem={(inst) => (
-        <ProvisionedResourceListCard
-          to={`/instances/${encodeURIComponent(inst.id)}`}
-          name={inst.name}
-          status={inst.status}
-          statusLabel={getInstanceStatusLabel(inst)}
-          teeEnabled={inst.teeEnabled}
-          image={inst.image}
-          specs={`${inst.cpuCores} CPU · ${inst.memoryMb}MB`}
-          createdAt={inst.createdAt}
-          iconClassName={inst.teeEnabled ? 'i-ph:shield-check' : 'i-ph:cube'}
-          iconContainerClassName={
-            inst.status === 'running'
-              ? 'bg-blue-500/10'
-              : inst.status === 'creating'
-                ? 'bg-violet-500/10'
-                : 'bg-cloud-elements-background-depth-3'
-          }
-          iconToneClassName={
-            inst.status === 'running'
-              ? 'text-blue-400'
-              : inst.status === 'creating'
-                ? 'text-violet-400'
-                : 'text-cloud-elements-textTertiary'
-          }
-          teeStyle="text"
-        />
+    <ConsolePage
+      title="Dedicated Instances"
+      eyebrow="Singleton resources"
+      actions={(
+        <Link to="/create?blueprint=ai-agent-instance-blueprint">
+          <Button>
+            <span className="i-ph:plus text-base" />
+            New Instance
+          </Button>
+        </Link>
       )}
-      emptyIconClassName="i-ph:cube"
-      emptyTitle="No instances yet"
-      emptySubtitle="Provision an instance or TEE instance to get started"
-      emptyCreateTo="/create?blueprint=ai-agent-instance-blueprint"
-      emptyCreateLabel="Create Instance"
-    />
+    >
+      <div className="space-y-4">
+        <ConsoleMetricStrip metrics={metrics} />
+        <ConsoleSection title="Instances">
+          <ResourceExplorerTable
+            rows={rows}
+            emptyTitle="No instances indexed"
+            emptyDetail="Provision a dedicated instance or TEE instance to inspect lifecycle, sessions, and trust state here."
+            emptyActionTo="/create?blueprint=ai-agent-instance-blueprint"
+            emptyActionLabel="Launch Instance"
+          />
+        </ConsoleSection>
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="sandbox-console-panel rounded-md p-3">
+            <p className="font-data text-[10px] uppercase tracking-[0.14em] text-[var(--sandbox-console-muted)]">Modes</p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <ConsoleChip>instance</ConsoleChip>
+              <ConsoleChip tone="brand">tee instance</ConsoleChip>
+            </div>
+          </div>
+          <div className="sandbox-console-panel rounded-md p-3">
+            <p className="font-data text-[10px] uppercase tracking-[0.14em] text-[var(--sandbox-console-muted)]">Lifecycle</p>
+            <p className="mt-3 font-data text-xs text-[var(--sandbox-console-secondary)]">auto-provision · report provisioned · operator API</p>
+          </div>
+          <div className="sandbox-console-panel rounded-md p-3">
+            <p className="font-data text-[10px] uppercase tracking-[0.14em] text-[var(--sandbox-console-muted)]">Isolation</p>
+            <p className="mt-3 font-data text-xs text-[var(--sandbox-console-secondary)]">single tenant · optional attestation · sealed secrets</p>
+          </div>
+        </div>
+      </div>
+    </ConsolePage>
   );
 }

--- a/ui/src/routes/operators._index.tsx
+++ b/ui/src/routes/operators._index.tsx
@@ -1,0 +1,132 @@
+import { useMemo } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+  ConsoleChip,
+  ConsoleMetricStrip,
+  ConsolePage,
+  ConsoleSection,
+  EmptyConsoleState,
+  type ConsoleMetric,
+} from '~/components/console/ConsolePrimitives';
+import { sandboxListStore } from '~/lib/stores/sandboxes';
+import { instanceListStore } from '~/lib/stores/instances';
+import { useAvailableCapacity } from '~/lib/hooks/useSandboxReads';
+
+type OperatorRow = {
+  operator: string;
+  resources: number;
+  running: number;
+  tee: number;
+  backends: string;
+  lastSeen: number;
+};
+
+function shorten(value: string) {
+  if (value.length <= 14) return value;
+  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+}
+
+function formatAge(timestamp: number) {
+  const deltaMs = Date.now() - timestamp;
+  if (deltaMs < 60_000) return '<1m';
+  const minutes = Math.floor(deltaMs / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+export default function OperatorCapacity() {
+  const sandboxes = useStore(sandboxListStore);
+  const instances = useStore(instanceListStore);
+  const { data: capacity } = useAvailableCapacity();
+
+  const rows = useMemo<OperatorRow[]>(() => {
+    const byOperator = new Map<string, OperatorRow>();
+    const resources = [
+      ...sandboxes.map((resource) => ({
+        operator: resource.operator,
+        status: resource.status,
+        tee: !!resource.teeEnabled,
+        timestamp: resource.lastActivityAt ?? resource.createdAt,
+      })),
+      ...instances.map((resource) => ({
+        operator: resource.operator,
+        status: resource.status,
+        tee: !!resource.teeEnabled,
+        timestamp: resource.createdAt,
+      })),
+    ];
+
+    for (const resource of resources) {
+      if (!resource.operator) continue;
+      const operator = resource.operator;
+      const current = byOperator.get(operator) ?? {
+        operator,
+        resources: 0,
+        running: 0,
+        tee: 0,
+        backends: 'docker',
+        lastSeen: 0,
+      };
+      current.resources += 1;
+      current.running += resource.status === 'running' ? 1 : 0;
+      current.tee += resource.tee ? 1 : 0;
+      current.backends = resource.tee ? 'docker · tee' : current.backends;
+      current.lastSeen = Math.max(current.lastSeen, resource.timestamp);
+      byOperator.set(operator, current);
+    }
+
+    return Array.from(byOperator.values()).sort((left, right) => right.resources - left.resources);
+  }, [instances, sandboxes]);
+
+  const metrics: ConsoleMetric[] = [
+    { label: 'Available capacity', value: capacity == null ? '--' : String(capacity), detail: 'contract read', tone: 'brand' },
+    { label: 'Known operators', value: String(rows.length), detail: 'from resources', tone: 'ready' },
+    { label: 'Running resources', value: String(rows.reduce((sum, row) => sum + row.running, 0)), detail: 'assigned', tone: 'ready' },
+    { label: 'TEE allocations', value: String(rows.reduce((sum, row) => sum + row.tee, 0)), detail: 'attested', tone: 'brand' },
+  ];
+
+  return (
+    <ConsolePage title="Capacity Directory" eyebrow="Operator route">
+      <div className="space-y-4">
+        <ConsoleMetricStrip metrics={metrics} />
+        <ConsoleSection title="Operators">
+          {rows.length > 0 ? (
+            <div className="overflow-auto">
+              <table className="min-w-[780px] w-full border-collapse">
+                <thead>
+                  <tr className="border-b border-[var(--sandbox-console-border)] bg-[var(--sandbox-console-surface)]">
+                    {['Operator', 'Resources', 'Running', 'TEE', 'Backends', 'Last seen'].map((label) => (
+                      <th key={label} className="px-3 py-2 text-left font-data text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--sandbox-console-muted)]">
+                        {label}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((row) => (
+                    <tr key={row.operator} className="border-b border-[var(--sandbox-console-border)] hover:bg-[var(--sandbox-console-surface)]">
+                      <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-text)]">{shorten(row.operator)}</td>
+                      <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-muted)]">{row.resources}</td>
+                      <td className="px-3 py-3"><ConsoleChip tone="ready">{row.running}</ConsoleChip></td>
+                      <td className="px-3 py-3"><ConsoleChip tone={row.tee > 0 ? 'brand' : 'muted'}>{row.tee}</ConsoleChip></td>
+                      <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-muted)]">{row.backends}</td>
+                      <td className="px-3 py-3 font-data text-xs text-[var(--sandbox-console-muted)]">{formatAge(row.lastSeen)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <EmptyConsoleState
+              icon="i-ph:hard-drives"
+              title="No operators indexed"
+              detail="Operator rows appear once local resources include assigned operators. Contract capacity is still shown above when available."
+            />
+          )}
+        </ConsoleSection>
+      </div>
+    </ConsolePage>
+  );
+}

--- a/ui/src/routes/sandboxes.$id.automation.tsx
+++ b/ui/src/routes/sandboxes.$id.automation.tsx
@@ -1,0 +1,1 @@
+export { default } from './sandboxes.$id';

--- a/ui/src/routes/sandboxes.$id.network.tsx
+++ b/ui/src/routes/sandboxes.$id.network.tsx
@@ -1,0 +1,1 @@
+export { default } from './sandboxes.$id';

--- a/ui/src/routes/sandboxes.$id.runtime.tsx
+++ b/ui/src/routes/sandboxes.$id.runtime.tsx
@@ -1,0 +1,1 @@
+export { default } from './sandboxes.$id';

--- a/ui/src/routes/sandboxes.$id.security.tsx
+++ b/ui/src/routes/sandboxes.$id.security.tsx
@@ -1,0 +1,1 @@
+export { default } from './sandboxes.$id';

--- a/ui/src/routes/sandboxes.$id.sessions.tsx
+++ b/ui/src/routes/sandboxes.$id.sessions.tsx
@@ -1,0 +1,1 @@
+export { default } from './sandboxes.$id';

--- a/ui/src/routes/sandboxes.$id.storage.tsx
+++ b/ui/src/routes/sandboxes.$id.storage.tsx
@@ -1,0 +1,1 @@
+export { default } from './sandboxes.$id';

--- a/ui/src/routes/sandboxes.$id.tsx
+++ b/ui/src/routes/sandboxes.$id.tsx
@@ -37,11 +37,19 @@ import { truncateAddress } from '~/lib/utils/truncate-address';
 import { ConfirmDialog } from '~/components/shared/ConfirmDialog';
 import { SnapshotDialog } from '~/components/shared/SnapshotDialog';
 import { OperatorTerminalView } from '~/components/shared/OperatorTerminalView';
+import { ResourceWorkspaceNav } from '~/components/console/ResourceWorkspaceNav';
+import { ConsoleMetricStrip, type ConsoleMetric } from '~/components/console/ConsolePrimitives';
+import {
+  AutomationWorkspace,
+  ResourceWorkspaceRail,
+  StorageWorkspace,
+  type WorkspaceRailRow,
+} from '~/components/console/ResourceWorkspacePanels';
 
 import { useAccount } from 'wagmi';
 import { normalizeAgentIdentifier } from '~/lib/agents';
 
-type ActionTab = 'overview' | 'terminal' | 'chat' | 'ssh' | 'secrets' | 'attestation';
+type ActionTab = 'overview' | 'terminal' | 'chat' | 'ssh' | 'secrets' | 'attestation' | 'automation' | 'storage';
 
 import { OPERATOR_API_URL, INSTANCE_OPERATOR_API_URL } from '~/lib/config';
 
@@ -54,6 +62,20 @@ interface AgentDescriptor {
   identifier: string;
   displayName?: string;
   description?: string;
+}
+
+function getInitialTabFromPath(pathname: string): ActionTab {
+  if (pathname.endsWith('/runtime')) return 'terminal';
+  if (pathname.endsWith('/sessions')) return 'chat';
+  if (pathname.endsWith('/automation')) return 'automation';
+  if (pathname.endsWith('/network')) return 'ssh';
+  if (pathname.endsWith('/security')) return 'secrets';
+  if (pathname.endsWith('/storage')) return 'storage';
+  return 'overview';
+}
+
+function getCurrentPathname() {
+  return typeof window === 'undefined' ? '' : window.location.pathname;
 }
 
 /** Extract human-readable error from operator API Error messages. */
@@ -93,6 +115,7 @@ function formatDuration(seconds: number): string {
 export default function SandboxDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const currentPathname = getCurrentPathname();
   const decodedKey = id ? decodeURIComponent(id) : '';
   const sandboxes = useStore(sandboxListStore);
   const sb = findSandboxByKey(sandboxes, decodedKey);
@@ -111,7 +134,7 @@ export default function SandboxDetail() {
   const { submitJob } = useSubmitJob();
   const { address } = useAccount();
 
-  const [tab, setTab] = useState<ActionTab>('overview');
+  const [tab, setTab] = useState<ActionTab>(() => getInitialTabFromPath(currentPathname));
   const [systemPrompt, setSystemPrompt] = useState('');
   // SSH state
   const [sshPublicKey, setSshPublicKey] = useState('');
@@ -589,10 +612,65 @@ export default function SandboxDetail() {
     { key: 'overview', label: 'Overview', icon: 'i-ph:info' },
     { key: 'terminal', label: 'Terminal', icon: 'i-ph:terminal', disabled: !hasProvisionedSandbox || !isRunning },
     { key: 'chat', label: 'Chat', icon: 'i-ph:chat-circle', disabled: !hasProvisionedSandbox || !isRunning, hidden: !hasAgent },
+    { key: 'automation', label: 'Automation', icon: 'i-ph:flow-arrow', disabled: !hasProvisionedSandbox || !isRunning },
     { key: 'ssh', label: 'SSH', icon: 'i-ph:key', disabled: !hasProvisionedSandbox || !isRunning, hidden: !sb.sshPort },
     { key: 'secrets', label: 'Secrets', icon: 'i-ph:lock-simple', disabled: !hasProvisionedSandbox || !isRunning },
+    { key: 'storage', label: 'Storage', icon: 'i-ph:database', disabled: !hasProvisionedSandbox },
     { key: 'attestation', label: 'Attestation', icon: 'i-ph:shield-check', hidden: !hasProvisionedSandbox || !sb.teeEnabled },
   ];
+
+  const workspaceBasePath = `/sandboxes/${encodeURIComponent(routeKey)}`;
+  const workspaceNavItems = [
+    { label: 'Runtime', href: `${workspaceBasePath}/runtime`, icon: 'i-ph:terminal' },
+    { label: 'Sessions', href: `${workspaceBasePath}/sessions`, icon: 'i-ph:chat-circle', disabled: !hasAgent },
+    { label: 'Automation', href: `${workspaceBasePath}/automation`, icon: 'i-ph:flow-arrow' },
+    { label: 'Network', href: `${workspaceBasePath}/network`, icon: 'i-ph:plugs', disabled: !sb.sshPort },
+    { label: 'Security', href: `${workspaceBasePath}/security`, icon: 'i-ph:shield-check' },
+    { label: 'Storage', href: `${workspaceBasePath}/storage`, icon: 'i-ph:database' },
+  ];
+  const exposedPortCount = ports?.length ?? 0;
+  const statusTone = isRunning ? 'ready' : isCreating ? 'brand' : isStopped ? 'warn' : sb.status === 'error' ? 'danger' : 'muted';
+  const workspaceMetrics: ConsoleMetric[] = [
+    {
+      label: 'Status',
+      value: sb.status,
+      detail: isRunning ? 'operator ready' : isCreating ? 'provisioning' : 'lifecycle',
+      tone: statusTone,
+    },
+    {
+      label: 'Runtime',
+      value: sb.teeEnabled ? 'TEE' : 'Docker',
+      detail: `${sb.cpuCores}c / ${Math.round(sb.memoryMb / 1024)}g / ${sb.diskGb}g`,
+      tone: sb.teeEnabled ? 'warn' : 'brand',
+    },
+    {
+      label: 'Network',
+      value: sb.sshPort ? `ssh:${sb.sshPort}` : exposedPortCount > 0 ? `${exposedPortCount} ports` : 'proxy',
+      detail: operatorUrl.replace(/^https?:\/\//, ''),
+      tone: sb.sshPort || exposedPortCount > 0 ? 'ready' : 'muted',
+    },
+    {
+      label: 'Agent',
+      value: configuredAgentIdentifier || 'none',
+      detail: hasAgent ? 'sessions enabled' : 'compute only',
+      tone: hasAgent ? 'brand' : 'muted',
+    },
+  ];
+  const contextRows: WorkspaceRailRow[] = [
+    { label: 'Sandbox ID', value: sb.sandboxId ? 'provisioned' : 'pending', detail: sb.sandboxId ?? sb.localId, tone: sb.sandboxId ? 'ready' : 'warn' },
+    { label: 'Blueprint', value: formatBlueprintLabel(sb.blueprintId), detail: `service ${formatServiceId(sb.serviceId)}`, tone: 'brand' },
+    { label: 'Operator', value: sb.operator ? truncateAddress(sb.operator) : 'unknown', detail: sb.operator ?? 'operator not resolved', tone: sb.operator ? 'ready' : 'muted' },
+    { label: 'Workspace', value: tab, detail: currentPathname, tone: 'muted' },
+  ];
+  const storageRows: WorkspaceRailRow[] = [
+    { label: 'Image', value: sb.image.replace('ghcr.io/tangle-network/', ''), detail: 'source image', tone: 'brand' },
+    { label: 'Disk', value: `${sb.diskGb} GB`, detail: 'allocated volume', tone: 'ready' },
+    { label: 'Lifecycle', value: isStopped ? 'warm' : isGone ? 'gone' : sb.status, detail: sb.lastActivityAt ? new Date(sb.lastActivityAt).toLocaleString() : 'no activity timestamp', tone: statusTone },
+    { label: 'Secrets', value: sb.credentialsAvailable === false ? 'missing' : 'available', detail: sb.teeEnabled ? 'TEE protected' : 'operator encrypted', tone: sb.credentialsAvailable === false ? 'warn' : 'ready' },
+  ];
+  const workflowCreateHref = isRunning && sb.sandboxId
+    ? `/workflows/create?target=${encodeURIComponent(`sandbox:${sb.sandboxId}`)}`
+    : undefined;
 
   return (
     <AnimatedPage className="mx-auto max-w-5xl px-4 sm:px-6 py-8">
@@ -663,7 +741,14 @@ export default function SandboxDetail() {
         </div>
       </div>
 
-      <ResourceTabs tabs={tabs} value={tab} onValueChange={setTab} className="mb-6" />
+      <div className="mb-4">
+        <ConsoleMetricStrip metrics={workspaceMetrics} />
+      </div>
+
+      <div className="mb-4 grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="min-w-0 space-y-4">
+          <ResourceWorkspaceNav items={workspaceNavItems} activePath={currentPathname} />
+          <ResourceTabs tabs={tabs} value={tab} onValueChange={setTab} className="mb-0" />
 
       {agentConfigured && hasAgentValidationResult && !agentIdentifierValid && (
         <div className="mb-4 rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
@@ -793,6 +878,24 @@ export default function SandboxDetail() {
             />
           )}
         </div>
+      )}
+
+      {tab === 'automation' && (
+        <AutomationWorkspace
+          createHref={workflowCreateHref}
+          scope="sandbox"
+          target={sb.sandboxId ?? sb.localId}
+          status={sb.status}
+          hasAgent={hasAgent}
+        />
+      )}
+
+      {tab === 'storage' && (
+        <StorageWorkspace
+          rows={storageRows}
+          onSnapshot={() => setSnapshotOpen(true)}
+          snapshotEnabled={hasProvisionedSandbox && !isGone}
+        />
       )}
 
       {/* Terminal Tab — operator-backed terminal */}
@@ -1117,6 +1220,9 @@ export default function SandboxDetail() {
           />
         </div>
       )}
+        </div>
+        <ResourceWorkspaceRail rows={contextRows} />
+      </div>
       <SnapshotDialog
         open={snapshotOpen}
         onOpenChange={setSnapshotOpen}

--- a/ui/src/routes/sandboxes._index.tsx
+++ b/ui/src/routes/sandboxes._index.tsx
@@ -1,59 +1,124 @@
+import { Link } from 'react-router';
+import { useMemo } from 'react';
 import { useStore } from '@nanostores/react';
-import { ProvisionedResourceListCard } from '~/components/shared/ProvisionedResourceListCard';
-import { ProvisionedResourceIndexPage } from '~/components/shared/ProvisionedResourceIndexPage';
-import { sandboxListStore, runningSandboxes, getSandboxRouteKey } from '~/lib/stores/sandboxes';
+import { Button } from '@tangle-network/blueprint-ui/components';
+import {
+  ConsoleChip,
+  ConsoleMetricStrip,
+  ConsolePage,
+  ConsoleSection,
+  type ConsoleMetric,
+} from '~/components/console/ConsolePrimitives';
+import {
+  ResourceExplorerTable,
+  type ResourceExplorerRow,
+} from '~/components/console/ResourceExplorerTable';
+import {
+  sandboxListStore,
+  runningSandboxes,
+  stoppedSandboxes,
+  getSandboxRouteKey,
+  type LocalSandbox,
+} from '~/lib/stores/sandboxes';
 
-export default function SandboxList() {
+function getSecurityState(sandbox: LocalSandbox) {
+  if (sandbox.teeEnabled) return 'attested';
+  if (sandbox.credentialsAvailable) return 'secrets';
+  return 'session';
+}
+
+function getStorageState(status: string) {
+  if (status === 'warm' || status === 'cold') return status;
+  if (status === 'stopped') return 'hot';
+  if (status === 'gone') return 'gone';
+  return 'ephemeral';
+}
+
+function sandboxToRow(sandbox: LocalSandbox): ResourceExplorerRow {
+  return {
+    key: sandbox.localId,
+    href: `/sandboxes/${encodeURIComponent(getSandboxRouteKey(sandbox))}`,
+    name: sandbox.name,
+    id: sandbox.sandboxId ?? sandbox.localId,
+    scope: 'Sandbox',
+    status: sandbox.status,
+    backend: sandbox.teeEnabled ? 'tee' : 'docker',
+    image: sandbox.image,
+    operator: sandbox.operator,
+    specs: `${sandbox.cpuCores}c/${Math.round(sandbox.memoryMb / 1024)}g/${sandbox.diskGb}g`,
+    sessions: sandbox.agentIdentifier ? 'agent' : '--',
+    workflows: '--',
+    network: sandbox.sshPort ? `ssh:${sandbox.sshPort}` : 'ports',
+    security: getSecurityState(sandbox),
+    storage: getStorageState(sandbox.status),
+    createdAt: sandbox.createdAt,
+    lastEvent: sandbox.lastActivityAt,
+    teeEnabled: sandbox.teeEnabled,
+    agentIdentifier: sandbox.agentIdentifier,
+  };
+}
+
+export default function SandboxExplorer() {
   const allSandboxes = useStore(sandboxListStore);
   const running = useStore(runningSandboxes);
-  const subtitle = running.length > 0
-    ? `${running.length} active sandbox${running.length > 1 ? 'es' : ''}`
-    : 'All your provisioned sandboxes';
+  const stopped = useStore(stoppedSandboxes);
+
+  const rows = useMemo(
+    () => allSandboxes.map(sandboxToRow)
+      .sort((left, right) => (right.lastEvent ?? right.createdAt) - (left.lastEvent ?? left.createdAt)),
+    [allSandboxes],
+  );
+
+  const metrics: ConsoleMetric[] = [
+    { label: 'Running', value: String(running.length), detail: 'operator-backed', tone: 'ready' },
+    { label: 'Stopped', value: String(stopped.length), detail: 'resume path', tone: 'warn' },
+    { label: 'TEE enabled', value: String(allSandboxes.filter((sandbox) => sandbox.teeEnabled).length), detail: 'attested', tone: 'brand' },
+    { label: 'Errors', value: String(allSandboxes.filter((sandbox) => sandbox.status === 'error').length), detail: 'attention', tone: 'danger' },
+  ];
 
   return (
-    <ProvisionedResourceIndexPage
-      title="Sandboxes"
-      subtitle={subtitle}
-      createTo="/create"
-      createLabel="New Sandbox"
-      items={allSandboxes}
-      getKey={(sb) => sb.localId}
-      renderItem={(sb) => (
-        <ProvisionedResourceListCard
-          to={`/sandboxes/${encodeURIComponent(getSandboxRouteKey(sb))}`}
-          name={sb.name}
-          status={sb.status}
-          teeEnabled={sb.teeEnabled}
-          image={sb.image}
-          specs={`${sb.cpuCores} CPU · ${sb.memoryMb}MB · ${sb.diskGb}GB`}
-          createdAt={sb.createdAt}
-          iconClassName={sb.teeEnabled ? 'i-ph:shield-check' : 'i-ph:hard-drives'}
-          iconContainerClassName={
-            sb.status === 'running'
-              ? 'bg-teal-500/10'
-              : sb.status === 'creating'
-                ? 'bg-blue-500/10'
-                : sb.status === 'stopped'
-                  ? 'bg-amber-500/10'
-                  : 'bg-cloud-elements-background-depth-3'
-          }
-          iconToneClassName={
-            sb.status === 'running'
-              ? 'text-teal-400'
-              : sb.status === 'creating'
-                ? 'text-blue-400'
-                : sb.status === 'stopped'
-                  ? 'text-amber-400'
-                  : 'text-cloud-elements-textTertiary'
-          }
-          teeStyle="pill"
-        />
+    <ConsolePage
+      title="Sandbox Explorer"
+      eyebrow="Cloud fleet"
+      actions={(
+        <Link to="/create">
+          <Button>
+            <span className="i-ph:plus text-base" />
+            New Sandbox
+          </Button>
+        </Link>
       )}
-      emptyIconClassName="i-ph:hard-drives"
-      emptyTitle="No sandboxes found"
-      emptySubtitle="Deploy a sandbox to see it here"
-      emptyCreateTo="/create"
-      emptyCreateLabel="Create Sandbox"
-    />
+    >
+      <div className="space-y-4">
+        <ConsoleMetricStrip metrics={metrics} />
+        <ConsoleSection title="Sandboxes">
+          <ResourceExplorerTable
+            rows={rows}
+            emptyTitle="No sandboxes indexed"
+            emptyDetail="Launch a sandbox to inspect runtime, sessions, network, security, and storage state here."
+            emptyActionTo="/create"
+            emptyActionLabel="Launch Sandbox"
+          />
+        </ConsoleSection>
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="sandbox-console-panel rounded-md p-3">
+            <p className="font-data text-[10px] uppercase tracking-[0.14em] text-[var(--sandbox-console-muted)]">Runtime backends</p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <ConsoleChip>docker</ConsoleChip>
+              <ConsoleChip tone="warn">firecracker</ConsoleChip>
+              <ConsoleChip tone="brand">tee</ConsoleChip>
+            </div>
+          </div>
+          <div className="sandbox-console-panel rounded-md p-3">
+            <p className="font-data text-[10px] uppercase tracking-[0.14em] text-[var(--sandbox-console-muted)]">Operations</p>
+            <p className="mt-3 font-data text-xs text-[var(--sandbox-console-secondary)]">exec · prompt · task · stop · resume · snapshot</p>
+          </div>
+          <div className="sandbox-console-panel rounded-md p-3">
+            <p className="font-data text-[10px] uppercase tracking-[0.14em] text-[var(--sandbox-console-muted)]">Trust envelope</p>
+            <p className="mt-3 font-data text-xs text-[var(--sandbox-console-secondary)]">session auth · secrets · attestation</p>
+          </div>
+        </div>
+      </div>
+    </ConsolePage>
   );
 }

--- a/ui/src/routes/workflows.$scope.$workflowId.tsx
+++ b/ui/src/routes/workflows.$scope.$workflowId.tsx
@@ -27,6 +27,7 @@ import {
   type WorkflowBlueprintId,
   type WorkflowScope,
 } from '~/lib/workflows';
+import { ConsoleMetricStrip, ConsoleSection, type ConsoleMetric } from '~/components/console/ConsolePrimitives';
 import type { Address } from 'viem';
 
 function parseScope(value: string | undefined): WorkflowScope | null {
@@ -317,6 +318,32 @@ export default function WorkflowDetail() {
   const latestExecution = workflow.latestExecution ?? null;
   const lastRunAt = workflow.lastRunAt;
   const status = getWorkflowStatusPresentation(workflow);
+  const replayMetrics: ConsoleMetric[] = [
+    {
+      label: 'Workflow state',
+      value: status.label,
+      detail: workflow.running ? 'running now' : workflow.active ? 'active' : 'inactive',
+      tone: workflow.runnable ? 'ready' : workflow.targetStatus === 'missing' ? 'danger' : 'warn',
+    },
+    {
+      label: 'Trigger',
+      value: workflow.triggerType,
+      detail: workflow.triggerType === 'cron' ? workflow.triggerConfig || 'cron unset' : 'manual',
+      tone: workflow.triggerType === 'cron' ? 'brand' : 'muted',
+    },
+    {
+      label: 'Latest result',
+      value: latestExecution ? (latestExecution.success ? 'Success' : 'Failed') : 'None',
+      detail: latestExecution ? `${latestExecution.durationMs} ms` : 'no execution',
+      tone: latestExecution ? (latestExecution.success ? 'ready' : 'danger') : 'muted',
+    },
+    {
+      label: 'Token usage',
+      value: latestExecution ? String(latestExecution.inputTokens + latestExecution.outputTokens) : '--',
+      detail: latestExecution ? `${latestExecution.inputTokens} in / ${latestExecution.outputTokens} out` : 'unrecorded',
+      tone: latestExecution ? 'brand' : 'muted',
+    },
+  ];
 
   return (
     <AnimatedPage className="mx-auto max-w-5xl px-4 sm:px-6 py-8">
@@ -370,6 +397,10 @@ export default function WorkflowDetail() {
             </Button>
           ) : null}
         </div>
+      </div>
+
+      <div className="mb-6">
+        <ConsoleMetricStrip metrics={replayMetrics} />
       </div>
 
       {!workflow.runnable ? (
@@ -499,14 +530,8 @@ export default function WorkflowDetail() {
 
       {latestExecution ? (
         <div className="grid grid-cols-1 gap-6 mb-6">
-          <Card>
-            <CardHeader>
-              <CardTitle>Latest Execution Output</CardTitle>
-              <CardDescription>
-                Captured from the operator&apos;s most recent workflow execution.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
+          <ConsoleSection title="Latest Execution Replay">
+            <div className="space-y-4 p-4">
               <pre className="overflow-x-auto rounded-lg border border-cloud-elements-dividerColor/30 bg-cloud-elements-background-depth-2 p-4 text-xs font-data text-cloud-elements-textSecondary whitespace-pre-wrap">
                 {latestExecution.result || 'No result output'}
               </pre>
@@ -518,8 +543,8 @@ export default function WorkflowDetail() {
                   </pre>
                 </div>
               ) : null}
-            </CardContent>
-          </Card>
+            </div>
+          </ConsoleSection>
         </div>
       ) : null}
 

--- a/ui/src/routes/workflows._index.tsx
+++ b/ui/src/routes/workflows._index.tsx
@@ -37,6 +37,7 @@ import {
   type WorkflowBlueprintId,
   type WorkflowScope,
 } from '~/lib/workflows';
+import { ConsoleMetricStrip, type ConsoleMetric } from '~/components/console/ConsolePrimitives';
 
 const WORKFLOW_VISIBILITY_POLL_INTERVAL_MS = 3_000;
 const WORKFLOW_VISIBILITY_TIMEOUT_MS = 120_000;
@@ -341,6 +342,32 @@ export default function Workflows() {
       instanceWorkflowSummaries.error,
     ],
   );
+  const workflowMetrics: ConsoleMetric[] = [
+    {
+      label: 'Workflows',
+      value: String(workflows.length),
+      detail: address ? 'owner scoped' : 'wallet gated',
+      tone: workflows.length > 0 ? 'brand' : 'muted',
+    },
+    {
+      label: 'Runnable',
+      value: String(workflows.filter((workflow) => workflow.kind === 'remote' && workflow.data.runnable).length),
+      detail: 'operator ready',
+      tone: 'ready',
+    },
+    {
+      label: 'Pending visibility',
+      value: String(workflows.filter((workflow) => workflow.kind === 'pending').length),
+      detail: 'local receipts',
+      tone: 'warn',
+    },
+    {
+      label: 'Operator errors',
+      value: String(operatorErrors.length),
+      detail: operatorAuthPrompts.length > 0 ? `${operatorAuthPrompts.length} auth` : 'connected',
+      tone: operatorErrors.length > 0 ? 'danger' : operatorAuthPrompts.length > 0 ? 'warn' : 'ready',
+    },
+  ];
 
   const jobValue = (jobId: number): bigint =>
     BigInt(PRICING_TIERS[jobId]?.multiplier ?? 1) * 1_000_000_000_000_000n;
@@ -575,6 +602,10 @@ export default function Workflows() {
             New Workflow
           </Button>
         )}
+      </div>
+
+      <div className="mb-6">
+        <ConsoleMetricStrip metrics={workflowMetrics} />
       </div>
 
       {address && operatorAuthPrompts.length > 0 ? (

--- a/ui/src/styles/global.scss
+++ b/ui/src/styles/global.scss
@@ -43,9 +43,31 @@
   }
 }
 
+#root {
+  min-height: 100vh;
+}
+
 /* Typography */
 .font-display {
   font-family: 'Outfit', system-ui, sans-serif;
+}
+
+.sandbox-console {
+  color-scheme: dark;
+}
+
+:root[data-theme='light'] .sandbox-console {
+  color-scheme: light;
+}
+
+.sandbox-console-panel {
+  background: var(--sandbox-console-panel);
+  border: 1px solid var(--sandbox-console-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
+}
+
+.sandbox-console-table {
+  border-color: var(--sandbox-console-border);
 }
 
 .font-body {

--- a/ui/src/styles/variables.scss
+++ b/ui/src/styles/variables.scss
@@ -89,6 +89,28 @@
   --mesh-teal: rgba(56, 178, 172, 0.04);
   --mesh-violet: rgba(139, 92, 246, 0.04);
   --mesh-blue: rgba(0, 180, 255, 0.03);
+
+  /* Sandbox console tokens */
+  --sandbox-console-bg: #080a10;
+  --sandbox-console-rail: #0d1018;
+  --sandbox-console-surface: #121723;
+  --sandbox-console-panel: #171c2a;
+  --sandbox-console-panel-strong: #202638;
+  --sandbox-console-border: rgba(221, 226, 255, 0.13);
+  --sandbox-console-border-hover: rgba(168, 123, 255, 0.38);
+  --sandbox-console-text: #f3f5ff;
+  --sandbox-console-secondary: #c8ccdc;
+  --sandbox-console-muted: #8d94aa;
+  --sandbox-console-subtle: #626a80;
+  --sandbox-console-brand: #a87bff;
+  --sandbox-console-brand-soft: rgba(142, 89, 255, 0.14);
+  --sandbox-console-brand-border: rgba(168, 123, 255, 0.34);
+  --sandbox-console-success: #38b2ac;
+  --sandbox-console-success-soft: rgba(56, 178, 172, 0.12);
+  --sandbox-console-success-border: rgba(56, 178, 172, 0.28);
+  --sandbox-console-warning: #f2c066;
+  --sandbox-console-danger: #ff5d6c;
+  --sandbox-console-shadow-lg: 0 22px 80px rgba(0, 0, 0, 0.34);
 }
 
 /* Light Theme */
@@ -165,6 +187,27 @@
   --mesh-teal: rgba(44, 122, 123, 0.03);
   --mesh-violet: rgba(100, 60, 200, 0.03);
   --mesh-blue: rgba(0, 100, 180, 0.02);
+
+  --sandbox-console-bg: #f4f6fb;
+  --sandbox-console-rail: #ffffff;
+  --sandbox-console-surface: #eef1f8;
+  --sandbox-console-panel: #ffffff;
+  --sandbox-console-panel-strong: #e7eaf3;
+  --sandbox-console-border: rgba(20, 24, 38, 0.12);
+  --sandbox-console-border-hover: rgba(124, 58, 237, 0.34);
+  --sandbox-console-text: #101421;
+  --sandbox-console-secondary: #34394c;
+  --sandbox-console-muted: #626a80;
+  --sandbox-console-subtle: #858da3;
+  --sandbox-console-brand: #6d28d9;
+  --sandbox-console-brand-soft: rgba(124, 58, 237, 0.10);
+  --sandbox-console-brand-border: rgba(124, 58, 237, 0.28);
+  --sandbox-console-success: #2c7a7b;
+  --sandbox-console-success-soft: rgba(44, 122, 123, 0.10);
+  --sandbox-console-success-border: rgba(44, 122, 123, 0.24);
+  --sandbox-console-warning: #9a6700;
+  --sandbox-console-danger: #c81e34;
+  --sandbox-console-shadow-lg: 0 22px 70px rgba(20, 24, 38, 0.16);
 }
 
 :root {


### PR DESCRIPTION
## Summary
- ships the Tangle-themed Arena-inspired sandbox console UI
- adds Cloud-native console shell primitives, resource tables, workspace tabs, activity/operators pages, and route aliases
- commits the comprehensive design tracking directive at `.evolve/arena-inspired-sandbox-console-redesign-2026-06-05.md`

## Verification
- `pnpm --dir ui typecheck`
- `pnpm --dir ui test` (44 files, 416 tests)
- `pnpm --dir ui build`
- `git merge-tree --write-tree origin/main HEAD`