### PR TITLE
feat(deploy): fetchable release + on-chain source publish (manager cold-start)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,26 +12,39 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # This repo ships multiple blueprints — build + host every operator binary.
+  # This repo ships the sandbox blueprint trio — build + host every operator binary.
   BINARIES: "ai-agent-sandbox-blueprint ai-agent-instance-blueprint ai-agent-tee-instance-blueprint"
-  TARGET: x86_64-unknown-linux-gnu
+  # Base Sepolia operators currently run x86_64 Linux. Keep the production
+  # publish path on that target so a secondary architecture cannot block the
+  # active binary rollout.
+  RELEASE_TARGETS: "x86_64-unknown-linux-gnu"
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
       - name: System dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libssl-dev pkg-config
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
       - name: Build all blueprint binaries
         run: |
           ARGS=""; for b in $BINARIES; do ARGS="$ARGS --bin $b"; done
           cargo build --release $ARGS
       - name: Package each binary + checksum
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
           FILES=""
           for b in $BINARIES; do
@@ -39,16 +52,208 @@ jobs:
             test -f "$BIN" || { echo "::error::missing $BIN"; exit 1; }
             strip "$BIN" 2>/dev/null || true
             A="${b}-${TARGET}.tar.xz"
-            tar -cJf "$A" -C target/release "$b"
+            tar --sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner \
+              -cJf "$A" -C target/release "$b"
             sha256sum "$A" > "${A}.sha256"; cat "${A}.sha256"
-            FILES="$FILES $A ${A}.sha256"
+            # Hash of the EXTRACTED (stripped) binary. The blueprint-manager's
+            # Remote/Github fetcher unpacks the archive and verifies the binary
+            # file against the on-chain BlueprintBinary.sha256 — that's the
+            # extracted binary, NOT the tarball. setBlueprintSources uses this.
+            sha256sum "$BIN" | awk '{print $1}' > "${b}-${TARGET}.bin.sha256"; cat "${b}-${TARGET}.bin.sha256"
+            FILES="$FILES $A ${A}.sha256 ${b}-${TARGET}.bin.sha256"
           done
           echo "FILES=$FILES" >> "$GITHUB_ENV"
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          TARGET: ${{ matrix.target }}
         run: |
+          set -euo pipefail
           TAG="${{ github.event.inputs.tag || github.ref_name }}"
           gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
-            || gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes "Operator binaries (${TARGET}): $BINARIES"
-          gh release upload "$TAG" $FILES --repo "$GITHUB_REPOSITORY" --clobber
+            || gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes "Operator binaries: $BINARIES"
+
+          upload_asset() {
+            local file="$1"
+            local name
+            name="$(basename "$file")"
+            if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --json assets --jq ".assets[] | select(.name == \"$name\") | .name" \
+              | grep -qx "$name"; then
+              mkdir -p /tmp/existing-release-assets
+              rm -f "/tmp/existing-release-assets/$name"
+              gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+                --pattern "$name" --dir /tmp/existing-release-assets
+              if cmp -s "$file" "/tmp/existing-release-assets/$name"; then
+                echo "asset already exists unchanged: $name"
+              else
+                echo "::error::release asset already exists with different bytes: $name"
+                exit 1
+              fi
+            else
+              gh release upload "$TAG" "$file" --repo "$GITHUB_REPOSITORY"
+            fi
+          }
+
+          for file in $FILES; do
+            upload_asset "$file"
+          done
+
+  # Once the arch leg(s) have uploaded their tarballs + .sha256 sidecars, emit a
+  # per-binary multi-arch manifest (`tangle-binary-manifest/v1`) so the on-chain
+  # BinaryVersion can point at ONE uri that the manager resolves per operator
+  # arch (see tangle-network/blueprint manager `sources/manifest.rs`). Runs once.
+  manifest:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build + upload per-binary multi-arch manifests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          BASE="https://github.com/$GITHUB_REPOSITORY/releases/download/$TAG"
+          mkdir -p /tmp/m
+
+          upload_asset() {
+            local file="$1"
+            local name
+            name="$(basename "$file")"
+            if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --json assets --jq ".assets[] | select(.name == \"$name\") | .name" \
+              | grep -qx "$name"; then
+              mkdir -p /tmp/existing-release-assets
+              rm -f "/tmp/existing-release-assets/$name"
+              gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+                --pattern "$name" --dir /tmp/existing-release-assets
+              if cmp -s "$file" "/tmp/existing-release-assets/$name"; then
+                echo "asset already exists unchanged: $name"
+              else
+                echo "::error::release asset already exists with different bytes: $name"
+                exit 1
+              fi
+            else
+              gh release upload "$TAG" "$file" --repo "$GITHUB_REPOSITORY"
+            fi
+          }
+
+          for b in $BINARIES; do
+            entries=""
+            for triple in $RELEASE_TARGETS; do
+              case "$triple" in *x86_64*) arch=x86_64;; *aarch64*) arch=aarch64;; esac
+              asset="${b}-${triple}.tar.xz"
+              gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "${asset}.sha256" --dir /tmp/m --clobber
+              sha="$(awk '{print $1}' "/tmp/m/${asset}.sha256")"
+              entries="${entries}{\"os\":\"linux\",\"arch\":\"${arch}\",\"url\":\"${BASE}/${asset}\",\"sha256\":\"${sha}\"},"
+            done
+            entries="${entries%,}"
+            printf '{"schema":"tangle-binary-manifest/v1","blueprint":"%s","version":"%s","binaries":[%s]}\n' \
+              "$b" "$TAG" "$entries" > "/tmp/m/${b}-manifest.json"
+            cat "/tmp/m/${b}-manifest.json"
+            upload_asset "/tmp/m/${b}-manifest.json"
+          done
+
+          # cargo-dist dist-manifest.json: the blueprint-manager's Remote/Github
+          # fetcher (sources/{remote,github}.rs) parses a cargo_dist_schema::DistManifest
+          # and refuses to download unless it declares the target binary as an
+          # executable-zip artifact with an executable asset of that name. This is
+          # the INITIAL-fetch path (distinct from the tangle-binary-manifest above,
+          # which drives in-place upgrades). One shared manifest validates every
+          # binary name; setBlueprintSources' dist_url points operators here.
+          arts=""
+          for b in $BINARIES; do
+            arts="${arts}\"${b}\":{\"kind\":\"executable-zip\",\"assets\":[{\"name\":\"${b}\",\"kind\":\"executable\"}]},"
+          done
+          arts="${arts%,}"
+          printf '{"artifacts":{%s}}\n' "$arts" > /tmp/m/dist-manifest.json
+          cat /tmp/m/dist-manifest.json
+          upload_asset /tmp/m/dist-manifest.json
+
+  # After the release assets are published, trigger the on-chain publish in
+  # tnt-core. The current blueprint-manager path falls back to blueprint sources
+  # when the active binary version points at a multi-arch manifest, so publish
+  # the concrete x86_64 archive as the active operator binary and update
+  # cold-start sources to the same tag.
+  #
+  # update_sources_version drives setBlueprintSources for EVERY blueprint this
+  # repo ships — without it a stock blueprint-manager has no usable fetcher and
+  # falls back to a 70-minute cargo source build on operator boxes.
+  # Local/manual equivalent: deploy/publish-blueprint-sources.sh <tag>.
+  #
+  # Dispatches are SEQUENTIAL on purpose: every tnt-core publish run signs with
+  # the same blueprint-owner key, and concurrent runs nonce-race ("replacement
+  # transaction underpriced"). Each dispatch waits for the remote run to finish
+  # before the next one starts.
+  #
+  # The TEE instance blueprint is not confirmed deployed on Base Sepolia. Its
+  # publish is gated on the TEE_INSTANCE_BLUEPRINT_ID repo/org variable; absent
+  # that, only sandbox (10) + instance (11) publish.
+  publish-onchain:
+    needs: [release, manifest]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger tnt-core binary publish (all blueprints, serialized)
+        env:
+          GH_TOKEN: ${{ secrets.TNT_CORE_PUBLISH_TOKEN }}
+          TEE_INSTANCE_BLUEPRINT_ID: ${{ vars.TEE_INSTANCE_BLUEPRINT_ID }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          REPO=tangle-network/tnt-core
+          WORKFLOW=publish-blueprint-binary.yml
+
+          # Blueprint ids: tnt-core deployments/base-sepolia/blueprints.tsv.
+          # sandbox=10, instance=11 (Tangle 0x8299d6 / chain 84532). The TEE
+          # instance id is only published when TEE_INSTANCE_BLUEPRINT_ID is set
+          # (it is not confirmed registered on this chain).
+          PUBLISHES="
+          ai-agent-sandbox-blueprint:10
+          ai-agent-instance-blueprint:11
+          "
+          if [ -n "${TEE_INSTANCE_BLUEPRINT_ID:-}" ]; then
+            PUBLISHES="${PUBLISHES}
+          ai-agent-tee-instance-blueprint:${TEE_INSTANCE_BLUEPRINT_ID}
+          "
+          fi
+
+          FAILED=0
+          for entry in $PUBLISHES; do
+            BIN="${entry%%:*}"
+            ID="${entry##*:}"
+            SINCE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "::group::publish $BIN -> blueprint $ID"
+            gh workflow run "$WORKFLOW" \
+              --repo "$REPO" \
+              --ref main \
+              -f blueprint_repo=tangle-network/ai-agent-sandbox-blueprint \
+              -f tag="$TAG" \
+              -f blueprint_id="$ID" \
+              -f binary_name="$BIN" \
+              -f network=base-sepolia \
+              -f target=x86_64-unknown-linux-gnu \
+              -f manifest=false \
+              -f set_active=true \
+              -f update_sources_version="$TAG"
+
+            # Resolve the run we just dispatched, then block until it finishes
+            # so the next dispatch never races the owner key's nonce.
+            RUN_ID=""
+            for _ in $(seq 1 12); do
+              sleep 5
+              RUN_ID="$(gh run list --repo "$REPO" --workflow "$WORKFLOW" \
+                --created ">$SINCE" --limit 1 --json databaseId \
+                --jq '.[0].databaseId // empty')"
+              [ -n "$RUN_ID" ] && break
+            done
+            test -n "$RUN_ID" || { echo "::error::dispatched run for $BIN not found"; exit 1; }
+
+            if timeout 1800 gh run watch "$RUN_ID" --repo "$REPO" --exit-status; then
+              echo "published $BIN@$TAG -> blueprint $ID (run $RUN_ID)"
+            else
+              echo "::error::on-chain publish failed for $BIN (run $RUN_ID)"
+              FAILED=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "$FAILED"

--- a/deny.toml
+++ b/deny.toml
@@ -56,6 +56,8 @@ ignore = [
     { id = "RUSTSEC-2021-0141", reason = "dotenv unmaintained — dev-dep only; tests use it for fixture loading" },
     { id = "RUSTSEC-2024-0436", reason = "paste unmaintained — pervasive transitive in blueprint-sdk proc-macros; no exploitable runtime path" },
     { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained — transitive via webpki / reqwest; covered by rustls migration plan" },
+    { id = "RUSTSEC-2024-0370", reason = "proc-macro-error unmaintained — pervasive transitive in blueprint-sdk proc-macros; build-time only, no runtime path" },
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained — transitive proc-macro dep (fork of proc-macro-error); build-time only, no runtime path" },
 
 ]
 

--- a/deploy/manifests/base-sepolia/tnt-core.latest.json
+++ b/deploy/manifests/base-sepolia/tnt-core.latest.json
@@ -1,0 +1,106 @@
+{
+  "network": "base-sepolia",
+  "chainId": 84532,
+  "deployer": "0x2420fff17c4213a4075cf5f7b6dc33429aaf22bb",
+  "admin": "0x2420fff17c4213a4075cf5f7b6dc33429aaf22bb",
+  "treasury": "0x2420fff17c4213a4075cf5f7b6dc33429aaf22bb",
+  "timelock": "0x2420fff17c4213a4075cf5f7b6dc33429aaf22bb",
+  "multisig": "0x2420fff17c4213a4075cf5f7b6dc33429aaf22bb",
+  "tangle": "0x8299d60f373f3a4a8c4878e335cb9d840e6e3730",
+  "staking": "0x91b1186f4f31d6e02e481c0af29c7244a3fe417d",
+  "restaking": "0x91b1186f4f31d6e02e481c0af29c7244a3fe417d",
+  "statusRegistry": "0x2a7ceb96a9b18721b5bbb0022b4d358b3c50bcb2",
+  "tntToken": "0x62b3407a22e50183b1055e54d70ee21f59bf865b",
+  "metrics": "0x48725b945a76540d7e5262855566cdb74366bb75",
+  "rewardVaults": "0xbaad23dac876467ea1b1f70f4d6e02e5891d2e04",
+  "inflationPool": "0xedf2a17c4a02f543178a76d0e22d2ef096e66970",
+  "serviceFeeDistributor": "0x36b0431187a05f23bc95a7047a66644bc934f621",
+  "streamingPaymentManager": "0x0000000000000000000000000000000000000000",
+  "credits": "0xb587a927ee90ba5587ca9d90fd1a813eb81fc24b",
+  "epochLength": 604800,
+  "stakeAssets": [
+    {
+      "symbol": "TNT",
+      "token": "0x62b3407a22e50183b1055e54d70ee21f59bf865b",
+      "adapter": "0x0000000000000000000000000000000000000000",
+      "minOperatorStake": "1000000000000000000",
+      "minDelegation": "100000000000000000",
+      "depositCap": "250000000000000000000000",
+      "rewardMultiplierBps": 10000
+    },
+    {
+      "symbol": "WETH",
+      "token": "0x4200000000000000000000000000000000000006",
+      "adapter": "0x0000000000000000000000000000000000000000",
+      "minOperatorStake": "500000000000000000",
+      "minDelegation": "50000000000000000",
+      "depositCap": "10000000000000000000000",
+      "rewardMultiplierBps": 11000
+    },
+    {
+      "symbol": "USDC",
+      "token": "0x036cbd53842c5426634e7929541ec2318f3dcf7e",
+      "adapter": "0x0000000000000000000000000000000000000000",
+      "minOperatorStake": "0",
+      "minDelegation": "0",
+      "depositCap": "5000000000000",
+      "rewardMultiplierBps": 9500
+    }
+  ],
+  "rewardVaultsConfig": [
+    {
+      "asset": "0x62b3407a22e50183b1055e54d70ee21f59bf865b",
+      "depositCap": "250000000000000000000000",
+      "active": true
+    },
+    {
+      "asset": "0x4200000000000000000000000000000000000006",
+      "depositCap": "10000000000000000000000",
+      "active": true
+    }
+  ],
+  "inflationWeights": {
+    "stakingBps": 5500,
+    "operatorsBps": 2500,
+    "customersBps": 1000,
+    "developersBps": 1000,
+    "stakersBps": 0
+  },
+  "guards": {
+    "pauseStaking": false,
+    "pauseTangle": false,
+    "requireAdapters": false,
+    "delegatorDelay": 0,
+    "operatorDelay": 0,
+    "bondLessDelay": 0,
+    "maxBlueprintsPerOperator": 0
+  },
+  "migration": {
+    "deploy": true,
+    "emitArtifacts": true,
+    "useMockVerifier": false,
+    "artifactsPath": "deployments/base-sepolia/releases/20260522-234553/migration.json",
+    "merklePath": "packages/migration-claim/merkle-tree.json",
+    "evmClaimsPath": "packages/migration-claim/evm-claims.json",
+    "treasuryCarveoutPath": "packages/migration-claim/treasury-carveout.json",
+    "foundationCarveoutPath": "packages/migration-claim/foundation-carveout.json",
+    "notes": "base-sepolia validation deployment",
+    "migrationOwner": "0x03a763af11dc58b459a469a9895389f5880b45f4",
+    "sp1VerifierGateway": "0x397a5f7f3dbd538f23de225b51f532c34448da9b",
+    "programVKey": "0x000d74444f16d75f72527687a36c1bd4c49e6799816dac4989be3bc175e86fd7",
+    "merkleRoot": "0x54ec5497e0a2f43ec721c1ec5392cb224cf710b1210b579dcaefea002bb51adb",
+    "substrateAllocation": "51244581812207794935986305",
+    "evmAllocation": "1125776519168932451653760",
+    "treasuryRecipient": "0x03a763af11dc58b459a469a9895389f5880b45f4",
+    "treasuryAmount": "41844468761091374585756819",
+    "foundationRecipient": "0x03a763af11dc58b459a469a9895389f5880b45f4",
+    "foundationAmount": "15040809826744825912214026",
+    "claimDeadline": "1811029564",
+    "unlockedBps": 0,
+    "cliffDuration": 0,
+    "vestingDuration": 0,
+    "tangleMigration": "0x25e02490ff74668543f167aab838c835ed202db7",
+    "zkVerifier": "0x46cee2cb16fc4c6699e9473d2ae545d5470e74a2"
+  },
+  "blueprintAuditors": "0xf4428bbbfa9207b4b91ca5fe8c1d401fd8b1e8e8"
+}

--- a/deploy/publish-blueprint-sources.sh
+++ b/deploy/publish-blueprint-sources.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Publish the on-chain cold-start sources for every blueprint in this repo so a
+# STOCK blueprint-manager fetches the released binary from GitHub Releases
+# (sha256-verified) instead of falling back to a cargo source build.
+#
+# What this writes per blueprint (Types.BlueprintSource, tnt-core >= the
+# 2026-05 facet upgrade that added `setBlueprintSources` + made
+# `getBlueprintDefinition` reflect live sources):
+#
+#   kind    = Native (2)
+#   native  = { fetcher: Http (2),
+#               artifactUri: {"dist_url":   <release dist-manifest.json>,
+#                             "archive_url":<release <bin>-<triple>.tar.xz>,
+#                             "binaries":   []},
+#               entrypoint: <binary name> }
+#   binaries = [{ arch, os: Linux (1), name: <binary>, sha256: <EXTRACTED
+#                 binary hash from the release's .bin.sha256 asset> }]
+#
+# One source per architecture. The manager's RemoteBinaryFetcher
+# (crates/manager/src/sources/remote.rs in tangle-network/blueprint):
+#   1. picks the source whose binaries[] matches the host os/arch,
+#   2. downloads dist_url and requires an executable-zip artifact whose
+#      executable asset name equals the binary name,
+#   3. downloads archive_url, unpacks, and verifies the EXTRACTED binary's
+#      sha256 against the on-chain bytes32 (fail-closed on mismatch).
+# That is why `binaries[].sha256` must be the .bin.sha256 (extracted binary),
+# NOT the tarball hash.
+#
+# Encoding mirrors tnt-core's canonical publish path
+# (.github/workflows/publish-blueprint-binary.yml "Update blueprint cold-start
+# sources" step). cargo-tangle has no sources-update command today; cast +
+# setBlueprintSources is the supported tooling.
+#
+# Usage:
+#   ./deploy/publish-blueprint-sources.sh v0.1.1                   # dry-run
+#   BROADCAST=true BLUEPRINT_OWNER_PRIVATE_KEY=0x... \
+#     ./deploy/publish-blueprint-sources.sh v0.1.1                 # send txs
+#
+# Options / env:
+#   TAG (arg 1)         — release tag in this repo (required).
+#   BROADCAST           — "true" to send transactions. Default: dry-run.
+#   ONLY                — restrict to one binary name (e.g. ai-agent-sandbox-blueprint).
+#   RPC_URL             — default https://sepolia.base.org.
+#   TANGLE_CORE         — Tangle proxy. Default: vendored base-sepolia manifest.
+#   BLUEPRINT_REPO      — default tangle-network/ai-agent-sandbox-blueprint.
+#   TEE_INSTANCE_BLUEPRINT_ID — on-chain id for the TEE instance blueprint. The
+#                         TEE instance is not confirmed deployed on Base Sepolia,
+#                         so it is SKIPPED unless this is set.
+#   BLUEPRINT_OWNER_PRIVATE_KEY — owner key (required with BROADCAST=true).
+#   SKIP_ARCHIVE_VERIFY — "1" to skip downloading + re-hashing the archives
+#                         before broadcast (verification is ON by default).
+#
+# Idempotent: a blueprint whose on-chain sources already carry this tag's
+# archive URLs and binary hashes is skipped.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TAG="${1:?usage: publish-blueprint-sources.sh <tag> (e.g. v0.1.1)}"
+BROADCAST="${BROADCAST:-false}"
+ONLY="${ONLY:-}"
+RPC_URL="${RPC_URL:-https://sepolia.base.org}"
+BLUEPRINT_REPO="${BLUEPRINT_REPO:-tangle-network/ai-agent-sandbox-blueprint}"
+SKIP_ARCHIVE_VERIFY="${SKIP_ARCHIVE_VERIFY:-0}"
+
+if [[ -z "${TANGLE_CORE:-}" ]]; then
+  MANIFEST="$ROOT_DIR/deploy/manifests/base-sepolia/tnt-core.latest.json"
+  [[ -f "$MANIFEST" ]] || { echo "ERROR: TANGLE_CORE unset and no manifest at $MANIFEST" >&2; exit 1; }
+  TANGLE_CORE="$(jq -er '.tangle' "$MANIFEST")"
+fi
+
+# Binary -> on-chain blueprint id. Source of truth: tnt-core
+# deployments/base-sepolia/blueprints.tsv (sandbox=10, instance=11 on Tangle
+# 0x8299d6 / chain 84532). The TEE instance blueprint is not confirmed
+# registered on this chain — it is only published when its id is supplied via
+# TEE_INSTANCE_BLUEPRINT_ID and is otherwise skipped.
+declare -A BLUEPRINT_IDS=(
+  [ai-agent-sandbox-blueprint]=10
+  [ai-agent-instance-blueprint]=11
+)
+if [[ -n "${TEE_INSTANCE_BLUEPRINT_ID:-}" ]]; then
+  BLUEPRINT_IDS[ai-agent-tee-instance-blueprint]="$TEE_INSTANCE_BLUEPRINT_ID"
+fi
+
+# arch discriminators from Types.BlueprintArchitecture (Amd64=5, Arm64=7).
+TRIPLES=(x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu)
+declare -A TRIPLE_ARCH=(
+  [x86_64-unknown-linux-gnu]=5
+  [aarch64-unknown-linux-gnu]=7
+)
+
+BASE_URL="https://github.com/${BLUEPRINT_REPO}/releases/download/${TAG}"
+SOURCES_SIG='blueprintSources(uint64)((uint8,(string,string,string),(uint8,uint8,string,string),(uint8,string,string),(string,string,string),(uint8,uint8,string,bytes32)[])[])'
+SET_SIG='setBlueprintSources(uint64,(uint8,(string,string,string),(uint8,uint8,string,string),(uint8,string,string),(string,string,string),(uint8,uint8,string,bytes32)[])[])'
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "=== Publish blueprint cold-start sources ==="
+echo "  Tag:         $TAG"
+echo "  Repo:        $BLUEPRINT_REPO"
+echo "  Tangle core: $TANGLE_CORE"
+echo "  RPC:         $RPC_URL"
+echo "  Broadcast:   $BROADCAST"
+echo
+
+# The manager refuses to download unless dist-manifest.json declares the
+# binary as an executable-zip artifact with an executable asset of that name.
+DIST_MANIFEST="$WORK_DIR/dist-manifest.json"
+curl -fsSL --retry 3 -o "$DIST_MANIFEST" "$BASE_URL/dist-manifest.json" \
+  || { echo "ERROR: $TAG has no dist-manifest.json release asset" >&2; exit 1; }
+
+if [[ "$BROADCAST" == "true" ]]; then
+  : "${BLUEPRINT_OWNER_PRIVATE_KEY:?ERROR: BLUEPRINT_OWNER_PRIVATE_KEY required with BROADCAST=true}"
+  # cast >=1.7 does not read the signing key from ETH_PRIVATE_KEY; pass it
+  # explicitly to the wallet/send calls instead.
+  export ETH_PRIVATE_KEY="$BLUEPRINT_OWNER_PRIVATE_KEY"
+  SENDER="$(cast wallet address --private-key "$ETH_PRIVATE_KEY")"
+  echo "  Sender:      $SENDER"
+  echo
+fi
+
+publish_one() {
+  local bin="$1" id="$2"
+
+  echo "--- $bin (blueprint $id) ---"
+
+  jq -e --arg b "$bin" \
+    '.artifacts[$b] | select(.kind == "executable-zip") | .assets[] | select(.kind == "executable" and .name == $b)' \
+    "$DIST_MANIFEST" >/dev/null \
+    || { echo "ERROR: dist-manifest.json does not declare executable $bin (manager would refuse the download)" >&2; return 1; }
+
+  local sources="" expected_pairs=() triple sha sha_file uri archive_url
+  for triple in "${TRIPLES[@]}"; do
+    sha_file="$WORK_DIR/${bin}-${triple}.bin.sha256"
+    if ! curl -fsSL --retry 3 -o "$sha_file" "$BASE_URL/${bin}-${triple}.bin.sha256" 2>/dev/null; then
+      echo "  $triple: no .bin.sha256 asset on $TAG — skipping arch"
+      continue
+    fi
+    sha="0x$(tr -d '[:space:]' < "$sha_file")"
+    [[ "${#sha}" -eq 66 ]] || { echo "ERROR: invalid sha256 in ${bin}-${triple}.bin.sha256" >&2; return 1; }
+
+    archive_url="${BASE_URL}/${bin}-${triple}.tar.xz"
+
+    if [[ "$SKIP_ARCHIVE_VERIFY" != "1" ]]; then
+      # Fail-closed: prove the published .bin.sha256 matches the archive's
+      # extracted binary BEFORE writing it on-chain. A wrong hash here bricks
+      # every operator cold-start (manager rejects the verified download).
+      local extract_dir="$WORK_DIR/verify-${bin}-${triple}"
+      mkdir -p "$extract_dir"
+      curl -fsSL --retry 3 -o "$extract_dir/a.tar.xz" "$archive_url" \
+        || { echo "ERROR: missing release archive $archive_url" >&2; return 1; }
+      tar -xJf "$extract_dir/a.tar.xz" -C "$extract_dir"
+      [[ -f "$extract_dir/$bin" ]] || { echo "ERROR: archive $archive_url does not contain $bin" >&2; return 1; }
+      local actual
+      actual="0x$(sha256sum "$extract_dir/$bin" | awk '{print $1}')"
+      [[ "$actual" == "$sha" ]] \
+        || { echo "ERROR: $triple extracted-binary hash $actual != published $sha" >&2; return 1; }
+      echo "  $triple: archive verified (extracted sha256 matches .bin.sha256)"
+    fi
+
+    uri="{\"dist_url\":\"${BASE_URL}/dist-manifest.json\",\"archive_url\":\"${archive_url}\",\"binaries\":[]}"
+    local source="(2,(\"\",\"\",\"\"),(0,0,\"\",\"\"),(2,'${uri}',\"${bin}\"),(\"\",\"\",\"\"),[(${TRIPLE_ARCH[$triple]},1,\"${bin}\",${sha})])"
+    sources="${sources:+${sources},}${source}"
+    expected_pairs+=("$archive_url" "${sha#0x}")
+    echo "  $triple: sha256 ${sha#0x}"
+  done
+
+  [[ -n "$sources" ]] || { echo "ERROR: no linux .bin.sha256 assets found for ${bin}@${TAG}" >&2; return 1; }
+  sources="[${sources}]"
+
+  # Idempotency: skip when the on-chain sources already carry every archive
+  # URL + extracted-binary hash for this tag.
+  local current
+  current="$(cast call "$TANGLE_CORE" "$SOURCES_SIG" "$id" --rpc-url "$RPC_URL")"
+  local up_to_date=1 item
+  for item in "${expected_pairs[@]}"; do
+    [[ "$current" == *"$item"* ]] || { up_to_date=0; break; }
+  done
+  if [[ "$up_to_date" -eq 1 ]]; then
+    echo "  on-chain sources already at $TAG — skipping"
+    return 0
+  fi
+
+  if [[ "$BROADCAST" != "true" ]]; then
+    echo "  DRY-RUN would send:"
+    echo "    ETH_PRIVATE_KEY=<owner> cast send $TANGLE_CORE '$SET_SIG' $id '$sources' --rpc-url $RPC_URL"
+    return 0
+  fi
+
+  # setBlueprintSources is owner-gated; fail fast with a readable error.
+  local owner
+  owner="$(cast call "$TANGLE_CORE" 'getBlueprint(uint64)((address,address,uint64,uint32,uint8,uint8,bool))' "$id" --rpc-url "$RPC_URL" | sed -E 's/^\((0x[0-9a-fA-F]{40}).*/\1/')"
+  if [[ "${owner,,}" != "${SENDER,,}" ]]; then
+    echo "ERROR: blueprint $id owner is $owner, sender is $SENDER" >&2
+    return 1
+  fi
+
+  # Capture output first so a cast failure (revert, RPC error, nonce race)
+  # cannot be masked by the cosmetic grep; then require an explicit success
+  # status in the receipt. A failed publish must fail the release.
+  local send_out
+  # cast >=1.7 does not read the signing key from ETH_PRIVATE_KEY for `cast send`;
+  # pass it explicitly. Kept out of argv otherwise (value comes from the env var).
+  if ! send_out="$(cast send "$TANGLE_CORE" "$SET_SIG" "$id" "$sources" \
+    --private-key "$ETH_PRIVATE_KEY" --rpc-url "$RPC_URL")"; then
+    echo "ERROR: setBlueprintSources tx failed for blueprint $id" >&2
+    return 1
+  fi
+  grep -E 'transactionHash|status|gasUsed' <<<"$send_out" || true
+  if ! grep -qE 'status[[:space:]]+1' <<<"$send_out"; then
+    echo "ERROR: setBlueprintSources reverted on-chain for blueprint $id" >&2
+    return 1
+  fi
+  echo "  published $bin@$TAG -> blueprint $id"
+}
+
+# Fail fast: a failed publish means the chain/nonce state is unknown —
+# continuing could land later blueprints against a stale nonce. The TEE
+# instance binary is only attempted when TEE_INSTANCE_BLUEPRINT_ID supplied
+# its id into BLUEPRINT_IDS above.
+for bin in ai-agent-sandbox-blueprint ai-agent-instance-blueprint ai-agent-tee-instance-blueprint; do
+  [[ -n "$ONLY" && "$ONLY" != "$bin" ]] && continue
+  if [[ -z "${BLUEPRINT_IDS[$bin]:-}" ]]; then
+    echo "--- $bin: no blueprint id (set TEE_INSTANCE_BLUEPRINT_ID to publish) — skipping ---"
+    echo
+    continue
+  fi
+  publish_one "$bin" "${BLUEPRINT_IDS[$bin]}" \
+    || { echo "ERROR: aborting after blueprint $bin failure (remaining blueprints not attempted)" >&2; exit 1; }
+  echo
+done
+
+exit 0


### PR DESCRIPTION
## Problem

A stock blueprint-manager FAILS to start this repo's blueprints on the live operator box. The on-chain sources for sandbox (blueprint **10**) and instance (blueprint **11**) are Testing/native (source-build), so the manager falls back to a cargo build in the wrong workspace and dies with `no bin target named ai-agent-sandbox-blueprint`.

Verified live on Tangle `0x8299d6` (Base Sepolia):

```
blueprintSources(10) -> [(2, ..., (0, "file:///target/release/ai-agent-sandbox-blueprint-bin", ...), ..., [(5,1,"ai-agent-sandbox-blueprint", 0x...deadbeef)])]
blueprintSources(11) -> [(2, ..., (0, "file:///target/release/ai-agent-instance-blueprint-bin", ...), ...)]
```

fetcher=0 (Testing), `file://` URIs, placeholder `deadbeef` hash. No fetchable source exists.

## Fix

Ports the proven `ai-trading-blueprint` treatment (blueprint 13, now working) so a stock manager FETCHES each runtime from GitHub Releases, sha256-verified, instead of source-building.

### `.github/workflows/release.yml`

Now emits, per x86_64 binary (sandbox / instance / tee-instance), in addition to the existing `tar.xz` + `tar.xz.sha256`:

- **`<bin>-x86_64-unknown-linux-gnu.bin.sha256`** — sha256 of the **extracted** binary (what the manager verifies after unpacking; not the tarball hash). This was the whole gap.
- per-binary **`tangle-binary-manifest/v1`** JSON (in-place upgrade path).
- a shared **`dist-manifest.json`** (cargo-dist executable-zip artifacts) — the manager's Remote/Github fetcher refuses to download without it.

Structure matches the trading repo: matrix `release` leg → `manifest` leg → sequential `publish-onchain` leg (dispatches tnt-core `publish-blueprint-binary.yml`, serialized to avoid owner-key nonce races).

### `deploy/publish-blueprint-sources.sh` (new)

Local/manual equivalent of the on-chain publish. Writes `Types.BlueprintSource` (Native + Http fetcher, `artifactUri {dist_url, archive_url}`, `binaries[]` with the extracted `.bin.sha256`) via `cast setBlueprintSources`.

- id map: `ai-agent-sandbox-blueprint=10`, `ai-agent-instance-blueprint=11`.
- TEE instance is parameterizable via `TEE_INSTANCE_BLUEPRINT_ID` and **skipped when unset** (not confirmed deployed on this chain).
- carries the cast >=1.7 fix: `--private-key` passed explicitly (cast no longer reads the key from `ETH_PRIVATE_KEY` for `wallet address` / `send`).
- idempotent skip + fail-closed archive verify (re-hash extracted binary) before broadcast.

### `deploy/manifests/base-sepolia/tnt-core.latest.json` (vendored)

Supplies `TANGLE_CORE` (`0x8299d6…`) when not overridden, mirroring how the trading script resolves it.

## Validation

- `release.yml` parses as valid YAML; `bash -n` clean on the publish script.
- Dry-run `./deploy/publish-blueprint-sources.sh v0.1.1` resolves Tangle core `0x8299d6`, the id map, and RPC, then correctly stops at the dist-manifest gate (v0.1.1 has no release assets yet — expected; the next tagged release produces them).
- Confirmed live on Base Sepolia: blueprints 10 + 11 exist (owner `0x2420…22Bb`), `blueprintSources(uint64)` reads with the script's exact signature, cast is 1.7.1 (so the `--private-key` fix is load-bearing).

No release is tagged and no tx is broadcast here — those are owner actions.