### PR TITLE
feat(runtime): resource admission control — TEE count cap, 503 capacity class, per-sandbox maxima + host memory budget, chain/host capacity cross-check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,29 @@ SIDECAR_PULL_IMAGE=true
 # Optional: Docker daemon socket (defaults to local socket)
 # DOCKER_HOST=unix:///var/run/docker.sock
 
+# ── Admission Control / Capacity ──────────────────────────────────────────────
+
+# Max sandboxes this host admits across all runtimes (Docker, Firecracker, TEE).
+# 0 = no cap. Creations beyond the cap are rejected with 503 Unavailable.
+# SANDBOX_MAX_COUNT=100
+
+# Capacity this operator registers on-chain (abi.encode(uint32) in onRegister).
+# Startup fails if this exceeds SANDBOX_MAX_COUNT — the chain would assign
+# work the host must reject. Unset = no capacity registered.
+# OPERATOR_MAX_CAPACITY=100
+
+# Per-sandbox resource maxima. 0 = no cap (default). A request above a max is
+# rejected with 503 Unavailable; a request of 0 (= unlimited) is clamped to
+# the max so a capped operator never runs an unlimited container.
+# SANDBOX_MAX_CPU_CORES=0
+# SANDBOX_MAX_MEMORY_MB=0
+# SANDBOX_MAX_DISK_GB=0
+
+# Total memory (MB) admissible across all running sandboxes. 0 = disabled.
+# At admission, committed memory (running + incoming; unlimited sandboxes
+# accounted at SANDBOX_MAX_MEMORY_MB when set) over budget → 503 Unavailable.
+# SANDBOX_HOST_MEMORY_BUDGET_MB=0
+
 # ── Operator API ──────────────────────────────────────────────────────────────
 
 # Port for the operator HTTP API (default: 9090)

--- a/ai-agent-sandbox-blueprint-bin/src/main.rs
+++ b/ai-agent-sandbox-blueprint-bin/src/main.rs
@@ -1072,8 +1072,14 @@ mod tests {
     #[test]
     fn capacity_cross_check_fails_when_chain_exceeds_host() {
         let err = validate_chain_vs_host_capacity(Some("50"), Some("10")).unwrap_err();
-        assert!(err.contains("OPERATOR_MAX_CAPACITY=50"), "names chain value: {err}");
-        assert!(err.contains("SANDBOX_MAX_COUNT=10"), "names host value: {err}");
+        assert!(
+            err.contains("OPERATOR_MAX_CAPACITY=50"),
+            "names chain value: {err}"
+        );
+        assert!(
+            err.contains("SANDBOX_MAX_COUNT=10"),
+            "names host value: {err}"
+        );
     }
 
     #[test]

--- a/ai-agent-sandbox-blueprint-bin/src/main.rs
+++ b/ai-agent-sandbox-blueprint-bin/src/main.rs
@@ -525,6 +525,16 @@ async fn main() -> Result<(), blueprint_sdk::Error> {
     let tangle_producer = TangleProducer::new(tangle_client.clone(), service_id);
     let tangle_consumer = ReconciledTangleConsumer::new(tangle_client);
 
+    // A chain capacity above the host admission cap means the chain would
+    // route work this host must reject — fail startup so the operator fixes
+    // the configuration instead of serving capacity rejections.
+    if let Err(msg) = validate_chain_vs_host_capacity(
+        std::env::var("OPERATOR_MAX_CAPACITY").ok().as_deref(),
+        std::env::var("SANDBOX_MAX_COUNT").ok().as_deref(),
+    ) {
+        return Err(blueprint_sdk::Error::Other(msg));
+    }
+
     // Encode operator max capacity as registration inputs for the blueprint contract.
     // The contract's onRegister decodes abi.encode(uint32 capacity) from these inputs.
     let tangle_config = {
@@ -954,9 +964,43 @@ fn workflow_replay_matches_store(
     }
 }
 
+/// Cross-check on-chain capacity vs the host admission cap.
+///
+/// `OPERATOR_MAX_CAPACITY` is what this operator registers on-chain (the
+/// chain may assign that many sandboxes); `SANDBOX_MAX_COUNT` is what the
+/// host runtime will actually admit. Registering more than the host admits
+/// guarantees rejected work, so startup fails when both are set and
+/// chain > host. `SANDBOX_MAX_COUNT=0` (uncapped host) always passes.
+/// Unparseable values are ignored here for parity with their consumers:
+/// registration skips an unparseable `OPERATOR_MAX_CAPACITY` and the runtime
+/// substitutes its default for an unparseable `SANDBOX_MAX_COUNT`.
+fn validate_chain_vs_host_capacity(
+    operator_max_capacity: Option<&str>,
+    sandbox_max_count: Option<&str>,
+) -> Result<(), String> {
+    let (Some(capacity_raw), Some(max_count_raw)) = (operator_max_capacity, sandbox_max_count)
+    else {
+        return Ok(());
+    };
+    let (Ok(capacity), Ok(max_count)) = (
+        capacity_raw.trim().parse::<u32>(),
+        max_count_raw.trim().parse::<usize>(),
+    ) else {
+        return Ok(());
+    };
+    if max_count == 0 || capacity as usize <= max_count {
+        return Ok(());
+    }
+    Err(format!(
+        "OPERATOR_MAX_CAPACITY={capacity} exceeds SANDBOX_MAX_COUNT={max_count}: the chain \
+         would assign up to {capacity} sandboxes but this host rejects creations beyond \
+         {max_count}. Lower OPERATOR_MAX_CAPACITY or raise SANDBOX_MAX_COUNT."
+    ))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{WorkflowEntry, workflow_replay_matches_store};
+    use super::{WorkflowEntry, validate_chain_vs_host_capacity, workflow_replay_matches_store};
     use serde_json::json;
 
     fn active_workflow(id: u64) -> WorkflowEntry {
@@ -1021,5 +1065,41 @@ mod tests {
             &payload,
             Some(&active_workflow(11))
         ));
+    }
+
+    // ── chain-vs-host capacity cross-check ─────────────────────────────
+
+    #[test]
+    fn capacity_cross_check_fails_when_chain_exceeds_host() {
+        let err = validate_chain_vs_host_capacity(Some("50"), Some("10")).unwrap_err();
+        assert!(err.contains("OPERATOR_MAX_CAPACITY=50"), "names chain value: {err}");
+        assert!(err.contains("SANDBOX_MAX_COUNT=10"), "names host value: {err}");
+    }
+
+    #[test]
+    fn capacity_cross_check_passes_equal_or_less() {
+        assert!(validate_chain_vs_host_capacity(Some("10"), Some("10")).is_ok());
+        assert!(validate_chain_vs_host_capacity(Some("5"), Some("10")).is_ok());
+    }
+
+    #[test]
+    fn capacity_cross_check_passes_uncapped_host() {
+        // SANDBOX_MAX_COUNT=0 disables the host cap entirely.
+        assert!(validate_chain_vs_host_capacity(Some("500"), Some("0")).is_ok());
+    }
+
+    #[test]
+    fn capacity_cross_check_requires_both_values() {
+        assert!(validate_chain_vs_host_capacity(None, Some("10")).is_ok());
+        assert!(validate_chain_vs_host_capacity(Some("50"), None).is_ok());
+        assert!(validate_chain_vs_host_capacity(None, None).is_ok());
+    }
+
+    #[test]
+    fn capacity_cross_check_ignores_unparseable_values() {
+        // Parity with the consumers: registration skips a bad
+        // OPERATOR_MAX_CAPACITY; the runtime defaults a bad SANDBOX_MAX_COUNT.
+        assert!(validate_chain_vs_host_capacity(Some("abc"), Some("10")).is_ok());
+        assert!(validate_chain_vs_host_capacity(Some("50"), Some("abc")).is_ok());
     }
 }

--- a/sandbox-runtime/src/reaper.rs
+++ b/sandbox-runtime/src/reaper.rs
@@ -681,6 +681,10 @@ mod tests {
             snapshot_auto_commit: true,
             snapshot_destination_prefix: Some("s3://my-bucket/snapshots/".to_string()),
             sandbox_max_count: 100,
+            sandbox_max_cpu_cores: 0,
+            sandbox_max_memory_mb: 0,
+            sandbox_max_disk_gb: 0,
+            sandbox_host_memory_budget_mb: 0,
         }
     }
 

--- a/sandbox-runtime/src/runtime.rs
+++ b/sandbox-runtime/src/runtime.rs
@@ -165,6 +165,16 @@ pub struct SidecarRuntimeConfig {
     pub snapshot_auto_commit: bool,
     pub snapshot_destination_prefix: Option<String>,
     pub sandbox_max_count: usize,
+    /// Per-sandbox CPU maximum (cores). 0 = no cap.
+    pub sandbox_max_cpu_cores: u64,
+    /// Per-sandbox memory maximum (MB). 0 = no cap. Also the value an
+    /// unlimited (0) request clamps to, and the footprint an unlimited
+    /// sandbox is accounted at in the host memory budget.
+    pub sandbox_max_memory_mb: u64,
+    /// Per-sandbox disk maximum (GB). 0 = no cap.
+    pub sandbox_max_disk_gb: u64,
+    /// Total memory (MB) admissible across all running sandboxes. 0 = disabled.
+    pub sandbox_host_memory_budget_mb: u64,
 }
 
 static RUNTIME_CONFIG: OnceCell<SidecarRuntimeConfig> = OnceCell::new();
@@ -271,6 +281,22 @@ impl SidecarRuntimeConfig {
                 .ok()
                 .and_then(|v| v.parse::<usize>().ok())
                 .unwrap_or(100);
+            let sandbox_max_cpu_cores = env::var("SANDBOX_MAX_CPU_CORES")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(0);
+            let sandbox_max_memory_mb = env::var("SANDBOX_MAX_MEMORY_MB")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(0);
+            let sandbox_max_disk_gb = env::var("SANDBOX_MAX_DISK_GB")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(0);
+            let sandbox_host_memory_budget_mb = env::var("SANDBOX_HOST_MEMORY_BUDGET_MB")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(0);
 
             // Validate critical configuration values. Panics are intentional here —
             // these represent unrecoverable startup misconfigurations. Unlike process::exit,
@@ -288,6 +314,10 @@ impl SidecarRuntimeConfig {
                 reaper_interval = sandbox_reaper_interval,
                 gc_interval = sandbox_gc_interval,
                 max_sandboxes = sandbox_max_count,
+                max_cpu_cores = sandbox_max_cpu_cores,
+                max_memory_mb = sandbox_max_memory_mb,
+                max_disk_gb = sandbox_max_disk_gb,
+                host_memory_budget_mb = sandbox_host_memory_budget_mb,
                 "Runtime configuration loaded"
             );
 
@@ -311,6 +341,10 @@ impl SidecarRuntimeConfig {
                 snapshot_auto_commit,
                 snapshot_destination_prefix,
                 sandbox_max_count,
+                sandbox_max_cpu_cores,
+                sandbox_max_memory_mb,
+                sandbox_max_disk_gb,
+                sandbox_host_memory_budget_mb,
             }
         })
     }
@@ -675,24 +709,173 @@ pub async fn acquire_creation_permit() -> tokio::sync::MutexGuard<'static, ()> {
     CREATION_PERMIT.lock().await
 }
 
-fn enforce_sandbox_count_limit(
-    config: &SidecarRuntimeConfig,
-    reusing_existing_slot: bool,
-) -> Result<()> {
-    if config.sandbox_max_count == 0 {
+/// Decision core of the sandbox count cap, separated from store access so the
+/// rejection class is unit-testable. `max == 0` = no cap.
+fn check_sandbox_count_limit(current: usize, reusing_existing_slot: bool, max: usize) -> Result<()> {
+    if max == 0 {
         return Ok(());
     }
 
-    let current = sandboxes()?.values()?.len();
     let effective_current = adjusted_sandbox_count_for_limit(current, reusing_existing_slot);
-    if effective_current >= config.sandbox_max_count {
-        return Err(SandboxError::Validation(format!(
+    if effective_current >= max {
+        // Unavailable (→ 503), not Validation (→ 400): the request is
+        // well-formed — this host is at capacity. The class tells callers to
+        // retry on another operator instead of fixing the request.
+        return Err(SandboxError::Unavailable(format!(
             "Sandbox limit reached ({current}/{max}). Delete unused sandboxes before creating new ones.",
-            max = config.sandbox_max_count,
         )));
     }
 
     Ok(())
+}
+
+fn enforce_sandbox_count_limit(
+    config: &SidecarRuntimeConfig,
+    reusing_existing_slot: bool,
+) -> Result<()> {
+    let current = sandboxes()?.values()?.len();
+    check_sandbox_count_limit(current, reusing_existing_slot, config.sandbox_max_count)
+}
+
+/// Apply a per-sandbox operator maximum to one requested resource value.
+///
+/// `max == 0` means no cap: the request passes through, including 0 =
+/// unlimited. With a cap set: a request above the cap is a typed
+/// `Unavailable` rejection (retry on a bigger operator), and a request of 0
+/// clamps to the cap — an operator who sets a maximum must never run an
+/// unlimited container.
+fn enforce_resource_max(requested: u64, max: u64, resource: &str) -> Result<u64> {
+    if max == 0 {
+        return Ok(requested);
+    }
+    if requested == 0 {
+        return Ok(max);
+    }
+    if requested > max {
+        return Err(SandboxError::Unavailable(format!(
+            "Requested {resource} {requested} exceeds this operator's maximum {max}. \
+             Retry on an operator with a higher {resource} limit."
+        )));
+    }
+    Ok(requested)
+}
+
+/// Memory a sandbox is accounted at for the host memory budget.
+///
+/// `None` means the footprint is unknowable: the sandbox requests unlimited
+/// memory (0) and no `SANDBOX_MAX_MEMORY_MB` clamp is configured — callers
+/// skip it (with a one-time warning) rather than guessing.
+fn accounted_memory_mb(memory_mb: u64, sandbox_max_memory_mb: u64) -> Option<u64> {
+    if memory_mb > 0 {
+        Some(memory_mb)
+    } else if sandbox_max_memory_mb > 0 {
+        Some(sandbox_max_memory_mb)
+    } else {
+        None
+    }
+}
+
+static UNACCOUNTABLE_MEMORY_WARN: std::sync::Once = std::sync::Once::new();
+
+/// Decision core of the host memory budget, separated from store access so it
+/// is unit-testable. `budget_mb == 0` disables the check. Records (and an
+/// incoming request) with unknowable footprint are skipped with a one-time
+/// warning — see [`accounted_memory_mb`].
+fn check_host_memory_budget(
+    running_memory_mb: impl IntoIterator<Item = u64>,
+    incoming_memory_mb: u64,
+    sandbox_max_memory_mb: u64,
+    budget_mb: u64,
+) -> Result<()> {
+    if budget_mb == 0 {
+        return Ok(());
+    }
+
+    let mut live_mb: u64 = 0;
+    let mut unaccounted = 0usize;
+    for memory_mb in running_memory_mb {
+        match accounted_memory_mb(memory_mb, sandbox_max_memory_mb) {
+            Some(mb) => live_mb = live_mb.saturating_add(mb),
+            None => unaccounted += 1,
+        }
+    }
+    let incoming_mb = match accounted_memory_mb(incoming_memory_mb, sandbox_max_memory_mb) {
+        Some(mb) => mb,
+        None => {
+            unaccounted += 1;
+            0
+        }
+    };
+    if unaccounted > 0 {
+        UNACCOUNTABLE_MEMORY_WARN.call_once(|| {
+            tracing::warn!(
+                unaccounted,
+                "Host memory budget cannot account for sandboxes with unlimited memory; \
+                 set SANDBOX_MAX_MEMORY_MB so every sandbox has a bounded footprint"
+            );
+        });
+    }
+
+    let committed = live_mb.saturating_add(incoming_mb);
+    if committed > budget_mb {
+        return Err(SandboxError::Unavailable(format!(
+            "Host memory budget exceeded: {committed} MB committed ({live_mb} MB running + \
+             {incoming_mb} MB requested) > SANDBOX_HOST_MEMORY_BUDGET_MB={budget_mb}. \
+             Retry on another operator."
+        )));
+    }
+
+    Ok(())
+}
+
+/// Enforce `SANDBOX_HOST_MEMORY_BUDGET_MB` at admission. Must be called with
+/// [`CREATION_PERMIT`] held so the running-memory sum cannot race a
+/// concurrent create.
+fn enforce_host_memory_budget(
+    config: &SidecarRuntimeConfig,
+    incoming_memory_mb: u64,
+    reused_sandbox_id: Option<&str>,
+) -> Result<()> {
+    if config.sandbox_host_memory_budget_mb == 0 {
+        return Ok(());
+    }
+
+    let running_memory_mb: Vec<u64> = sandboxes()?
+        .values()?
+        .into_iter()
+        .filter(|record| record.state == SandboxState::Running)
+        // A create that replaces an existing record (recreate / image upgrade)
+        // frees the old container's memory, so it doesn't count against the budget.
+        .filter(|record| reused_sandbox_id != Some(record.id.as_str()))
+        .map(|record| record.memory_mb)
+        .collect();
+
+    check_host_memory_budget(
+        running_memory_mb,
+        incoming_memory_mb,
+        config.sandbox_max_memory_mb,
+        config.sandbox_host_memory_budget_mb,
+    )
+}
+
+/// Per-sandbox resource maxima + host memory budget, applied under
+/// [`CREATION_PERMIT`] before backend dispatch. Returns the request with
+/// effective (possibly clamped) resource values so the container, the stored
+/// record, and the budget accounting all agree.
+fn admit_sandbox_resources(
+    config: &SidecarRuntimeConfig,
+    request: &CreateSandboxParams,
+    sandbox_id_override: Option<&str>,
+) -> Result<CreateSandboxParams> {
+    let mut admitted = request.clone();
+    admitted.cpu_cores =
+        enforce_resource_max(request.cpu_cores, config.sandbox_max_cpu_cores, "cpu_cores")?;
+    admitted.memory_mb =
+        enforce_resource_max(request.memory_mb, config.sandbox_max_memory_mb, "memory_mb")?;
+    admitted.disk_gb =
+        enforce_resource_max(request.disk_gb, config.sandbox_max_disk_gb, "disk_gb")?;
+    enforce_host_memory_budget(config, admitted.memory_mb, sandbox_id_override)?;
+    Ok(admitted)
 }
 
 fn restore_previous_store_entry(
@@ -1092,6 +1275,11 @@ async fn create_sidecar_with_token(
     sandbox_id_override: Option<&str>,
 ) -> Result<(SandboxRecord, Option<crate::tee::AttestationReport>)> {
     let _creation_permit = acquire_creation_permit().await;
+    // Resource admission runs under the permit and before backend dispatch:
+    // per-sandbox maxima (reject over-max, clamp unlimited-to-max) and the
+    // host memory budget apply identically to Docker, Firecracker, and TEE.
+    let admitted = admit_sandbox_resources(SidecarRuntimeConfig::load(), request, sandbox_id_override)?;
+    let request = &admitted;
     match resolve_runtime_backend(request)? {
         RuntimeBackend::Tee => {
             let backend = tee.ok_or_else(|| {
@@ -1157,6 +1345,13 @@ async fn create_sidecar_tee(
     let sandbox_id = sandbox_id_override
         .map(ToString::to_string)
         .unwrap_or_else(next_sandbox_id);
+    let previous_store_entry = existing_store_entry_for_override(&sandbox_id)?;
+
+    // Same admission gate as the Docker/Firecracker paths — TEE creates must
+    // not bypass the host sandbox count cap. Runs with [`CREATION_PERMIT`]
+    // held (acquired in `create_sidecar_with_token`) so the check can't race.
+    enforce_sandbox_count_limit(config, previous_store_entry.is_some())?;
+
     let token = match token_override {
         Some(t) if !t.trim().is_empty() => t.to_string(),
         _ => crate::auth::generate_token(),
@@ -4784,6 +4979,10 @@ mod core_logic_tests {
             snapshot_auto_commit: true,
             snapshot_destination_prefix: None,
             sandbox_max_count: 100,
+            sandbox_max_cpu_cores: 0,
+            sandbox_max_memory_mb: 0,
+            sandbox_max_disk_gb: 0,
+            sandbox_host_memory_budget_mb: 0,
         }
     }
 
@@ -4793,6 +4992,97 @@ mod core_logic_tests {
         assert_eq!(adjusted_sandbox_count_for_limit(1, false), 1);
         assert_eq!(adjusted_sandbox_count_for_limit(1, true), 0);
         assert_eq!(adjusted_sandbox_count_for_limit(5, true), 4);
+    }
+
+    // ── admission control: count-limit class, resource maxima, memory budget ──
+
+    #[test]
+    fn count_limit_rejection_is_unavailable() {
+        // Capacity exhaustion must map to Unavailable (→ 503) so callers
+        // retry on another operator; Validation (→ 400) would tell them the
+        // request itself is malformed.
+        let err = check_sandbox_count_limit(3, false, 3).unwrap_err();
+        assert!(matches!(err, SandboxError::Unavailable(_)), "got {err:?}");
+        assert!(err.to_string().contains("Sandbox limit reached (3/3)"));
+    }
+
+    #[test]
+    fn count_limit_uncapped_reuse_and_in_range_pass() {
+        assert!(check_sandbox_count_limit(10_000, false, 0).is_ok(), "0 = no cap");
+        assert!(
+            check_sandbox_count_limit(3, true, 3).is_ok(),
+            "replacing an existing slot stays within the cap"
+        );
+        assert!(check_sandbox_count_limit(2, false, 3).is_ok());
+    }
+
+    #[test]
+    fn resource_max_uncapped_passthrough() {
+        assert_eq!(enforce_resource_max(0, 0, "memory_mb").unwrap(), 0);
+        assert_eq!(enforce_resource_max(4096, 0, "memory_mb").unwrap(), 4096);
+    }
+
+    #[test]
+    fn resource_max_clamps_unlimited_request_to_max() {
+        // 0 = unlimited must clamp to the cap: an operator who sets a maximum
+        // must never run an unlimited container.
+        assert_eq!(enforce_resource_max(0, 2048, "memory_mb").unwrap(), 2048);
+    }
+
+    #[test]
+    fn resource_max_rejects_over_max_as_unavailable() {
+        let err = enforce_resource_max(4096, 2048, "memory_mb").unwrap_err();
+        assert!(matches!(err, SandboxError::Unavailable(_)), "got {err:?}");
+        let msg = err.to_string();
+        assert!(msg.contains("memory_mb"), "message names the resource: {msg}");
+        assert!(msg.contains("4096") && msg.contains("2048"), "message names both values: {msg}");
+    }
+
+    #[test]
+    fn resource_max_in_range_passthrough() {
+        assert_eq!(enforce_resource_max(1024, 2048, "memory_mb").unwrap(), 1024);
+    }
+
+    #[test]
+    fn accounted_memory_prefers_request_then_max_then_unknown() {
+        assert_eq!(accounted_memory_mb(1024, 2048), Some(1024));
+        assert_eq!(accounted_memory_mb(0, 2048), Some(2048));
+        assert_eq!(accounted_memory_mb(0, 0), None);
+    }
+
+    #[test]
+    fn memory_budget_disabled_when_zero() {
+        assert!(check_host_memory_budget([u64::MAX, u64::MAX], 999_999, 0, 0).is_ok());
+    }
+
+    #[test]
+    fn memory_budget_rejects_over_budget_as_unavailable() {
+        // 1024 + 2048 running + 2048 requested = 5120 > 4096.
+        let err = check_host_memory_budget([1024, 2048], 2048, 2048, 4096).unwrap_err();
+        assert!(matches!(err, SandboxError::Unavailable(_)), "got {err:?}");
+        assert!(err.to_string().contains("memory budget"), "got {err}");
+    }
+
+    #[test]
+    fn memory_budget_admits_exactly_at_budget() {
+        assert!(check_host_memory_budget([1024, 2048], 1024, 2048, 4096).is_ok());
+    }
+
+    #[test]
+    fn memory_budget_counts_unlimited_records_at_max() {
+        // A running record with memory_mb=0 is accounted at SANDBOX_MAX_MEMORY_MB:
+        // 2048 (0→max) + 2048 requested = 4096 ≤ 4096 passes…
+        assert!(check_host_memory_budget([0], 2048, 2048, 4096).is_ok());
+        // …and one extra MB of running memory rejects.
+        assert!(check_host_memory_budget([0, 1], 2048, 2048, 4096).is_err());
+    }
+
+    #[test]
+    fn memory_budget_skips_unaccountable_records() {
+        // Without SANDBOX_MAX_MEMORY_MB, unlimited records can't be accounted
+        // and are skipped (warned once) rather than guessed.
+        assert!(check_host_memory_budget([0, 0], 1024, 0, 2048).is_ok());
+        assert!(check_host_memory_budget([1500, 0], 1024, 0, 2048).is_err());
     }
 
     #[test]

--- a/sandbox-runtime/src/runtime.rs
+++ b/sandbox-runtime/src/runtime.rs
@@ -711,7 +711,11 @@ pub async fn acquire_creation_permit() -> tokio::sync::MutexGuard<'static, ()> {
 
 /// Decision core of the sandbox count cap, separated from store access so the
 /// rejection class is unit-testable. `max == 0` = no cap.
-fn check_sandbox_count_limit(current: usize, reusing_existing_slot: bool, max: usize) -> Result<()> {
+fn check_sandbox_count_limit(
+    current: usize,
+    reusing_existing_slot: bool,
+    max: usize,
+) -> Result<()> {
     if max == 0 {
         return Ok(());
     }
@@ -1278,7 +1282,8 @@ async fn create_sidecar_with_token(
     // Resource admission runs under the permit and before backend dispatch:
     // per-sandbox maxima (reject over-max, clamp unlimited-to-max) and the
     // host memory budget apply identically to Docker, Firecracker, and TEE.
-    let admitted = admit_sandbox_resources(SidecarRuntimeConfig::load(), request, sandbox_id_override)?;
+    let admitted =
+        admit_sandbox_resources(SidecarRuntimeConfig::load(), request, sandbox_id_override)?;
     let request = &admitted;
     match resolve_runtime_backend(request)? {
         RuntimeBackend::Tee => {
@@ -5008,7 +5013,10 @@ mod core_logic_tests {
 
     #[test]
     fn count_limit_uncapped_reuse_and_in_range_pass() {
-        assert!(check_sandbox_count_limit(10_000, false, 0).is_ok(), "0 = no cap");
+        assert!(
+            check_sandbox_count_limit(10_000, false, 0).is_ok(),
+            "0 = no cap"
+        );
         assert!(
             check_sandbox_count_limit(3, true, 3).is_ok(),
             "replacing an existing slot stays within the cap"
@@ -5034,8 +5042,14 @@ mod core_logic_tests {
         let err = enforce_resource_max(4096, 2048, "memory_mb").unwrap_err();
         assert!(matches!(err, SandboxError::Unavailable(_)), "got {err:?}");
         let msg = err.to_string();
-        assert!(msg.contains("memory_mb"), "message names the resource: {msg}");
-        assert!(msg.contains("4096") && msg.contains("2048"), "message names both values: {msg}");
+        assert!(
+            msg.contains("memory_mb"),
+            "message names the resource: {msg}"
+        );
+        assert!(
+            msg.contains("4096") && msg.contains("2048"),
+            "message names both values: {msg}"
+        );
     }
 
     #[test]

--- a/sandbox-runtime/tests/admission_control.rs
+++ b/sandbox-runtime/tests/admission_control.rs
@@ -35,7 +35,10 @@ fn tee_params(name: &str, cpu_cores: u64, memory_mb: u64) -> CreateSandboxParams
 fn expect_unavailable(err: SandboxError, needle: &str) {
     match err {
         SandboxError::Unavailable(msg) => {
-            assert!(msg.contains(needle), "Unavailable message missing {needle:?}: {msg}");
+            assert!(
+                msg.contains(needle),
+                "Unavailable message missing {needle:?}: {msg}"
+            );
         }
         other => panic!("expected SandboxError::Unavailable({needle:?}), got {other:?}"),
     }
@@ -43,21 +46,25 @@ fn expect_unavailable(err: SandboxError, needle: &str) {
 
 #[tokio::test]
 async fn admission_control_end_to_end() {
-    let _guard = sandbox_runtime::TEST_ENV_GUARD
-        .lock()
-        .unwrap_or_else(|p| p.into_inner());
     let state_dir = tempfile::tempdir().unwrap();
-    // SAFETY: single test in this binary; env set before the first
-    // SidecarRuntimeConfig::load() under the process-wide env guard.
-    unsafe {
-        std::env::set_var("BLUEPRINT_STATE_DIR", state_dir.path());
-        std::env::set_var("SIDECAR_IMAGE", "test:latest");
-        std::env::set_var("SIDECAR_PUBLIC_HOST", "127.0.0.1");
-        std::env::set_var("SANDBOX_MAX_COUNT", "3");
-        std::env::set_var("SANDBOX_MAX_CPU_CORES", "4");
-        std::env::set_var("SANDBOX_MAX_MEMORY_MB", "2048");
-        std::env::set_var("SANDBOX_MAX_DISK_GB", "50");
-        std::env::set_var("SANDBOX_HOST_MEMORY_BUDGET_MB", "4096");
+    {
+        // Guard scoped to the env mutation only (not across awaits): this
+        // binary has a single test, so nothing else reads the env before the
+        // first SidecarRuntimeConfig::load() below.
+        let _guard = sandbox_runtime::TEST_ENV_GUARD
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        // SAFETY: env set under the process-wide guard, before first config load.
+        unsafe {
+            std::env::set_var("BLUEPRINT_STATE_DIR", state_dir.path());
+            std::env::set_var("SIDECAR_IMAGE", "test:latest");
+            std::env::set_var("SIDECAR_PUBLIC_HOST", "127.0.0.1");
+            std::env::set_var("SANDBOX_MAX_COUNT", "3");
+            std::env::set_var("SANDBOX_MAX_CPU_CORES", "4");
+            std::env::set_var("SANDBOX_MAX_MEMORY_MB", "2048");
+            std::env::set_var("SANDBOX_MAX_DISK_GB", "50");
+            std::env::set_var("SANDBOX_HOST_MEMORY_BUDGET_MB", "4096");
+        }
     }
     let mock = MockTeeBackend::new(TeeType::Tdx);
 

--- a/sandbox-runtime/tests/admission_control.rs
+++ b/sandbox-runtime/tests/admission_control.rs
@@ -1,0 +1,122 @@
+//! Admission-control end-to-end: sandbox count cap on the TEE path,
+//! per-sandbox resource maxima, and the host memory budget — all exercised
+//! through the real `create_sidecar` entry point with the mock TEE backend
+//! (no Docker required).
+//!
+//! Lives in its own test binary (own process) because `SidecarRuntimeConfig`
+//! is a process-global `OnceCell` snapshot of the environment: the knobs
+//! below must be set before the first `load()` and would leak into every
+//! other in-crate test otherwise. The single #[tokio::test] keeps the store
+//! mutations sequential.
+
+#![cfg(feature = "test-utils")]
+
+use sandbox_runtime::error::SandboxError;
+use sandbox_runtime::runtime::{CreateSandboxParams, SandboxState, create_sidecar, sandboxes};
+use sandbox_runtime::tee::mock::MockTeeBackend;
+use sandbox_runtime::tee::{TeeConfig, TeeType};
+
+fn tee_params(name: &str, cpu_cores: u64, memory_mb: u64) -> CreateSandboxParams {
+    CreateSandboxParams {
+        name: name.into(),
+        image: "test:latest".into(),
+        tee_config: Some(TeeConfig {
+            required: true,
+            tee_type: TeeType::Tdx,
+            attestation_nonce: None,
+        }),
+        owner: "0xadmission".into(),
+        cpu_cores,
+        memory_mb,
+        ..Default::default()
+    }
+}
+
+fn expect_unavailable(err: SandboxError, needle: &str) {
+    match err {
+        SandboxError::Unavailable(msg) => {
+            assert!(msg.contains(needle), "Unavailable message missing {needle:?}: {msg}");
+        }
+        other => panic!("expected SandboxError::Unavailable({needle:?}), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn admission_control_end_to_end() {
+    let _guard = sandbox_runtime::TEST_ENV_GUARD
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let state_dir = tempfile::tempdir().unwrap();
+    // SAFETY: single test in this binary; env set before the first
+    // SidecarRuntimeConfig::load() under the process-wide env guard.
+    unsafe {
+        std::env::set_var("BLUEPRINT_STATE_DIR", state_dir.path());
+        std::env::set_var("SIDECAR_IMAGE", "test:latest");
+        std::env::set_var("SIDECAR_PUBLIC_HOST", "127.0.0.1");
+        std::env::set_var("SANDBOX_MAX_COUNT", "3");
+        std::env::set_var("SANDBOX_MAX_CPU_CORES", "4");
+        std::env::set_var("SANDBOX_MAX_MEMORY_MB", "2048");
+        std::env::set_var("SANDBOX_MAX_DISK_GB", "50");
+        std::env::set_var("SANDBOX_HOST_MEMORY_BUDGET_MB", "4096");
+    }
+    let mock = MockTeeBackend::new(TeeType::Tdx);
+
+    // Within every cap → admitted, requested values stored untouched.
+    let (first, _) = create_sidecar(&tee_params("a", 2, 1024), Some(&mock))
+        .await
+        .expect("in-range request must be admitted");
+    assert_eq!(first.memory_mb, 1024);
+    assert_eq!(first.cpu_cores, 2);
+
+    // Unlimited (0) memory with a max set → clamped to the max, not unlimited.
+    let (second, _) = create_sidecar(&tee_params("b", 2, 0), Some(&mock))
+        .await
+        .expect("unlimited request must clamp, not reject");
+    assert_eq!(
+        second.memory_mb, 2048,
+        "memory_mb=0 must clamp to SANDBOX_MAX_MEMORY_MB"
+    );
+
+    // Over the per-sandbox memory max → Unavailable.
+    let err = create_sidecar(&tee_params("c", 2, 4096), Some(&mock))
+        .await
+        .unwrap_err();
+    expect_unavailable(err, "memory_mb");
+
+    // Over the per-sandbox CPU max → Unavailable.
+    let err = create_sidecar(&tee_params("d", 8, 1024), Some(&mock))
+        .await
+        .unwrap_err();
+    expect_unavailable(err, "cpu_cores");
+
+    // Over the per-sandbox disk max → Unavailable.
+    let mut disk_heavy = tee_params("e", 2, 1024);
+    disk_heavy.disk_gb = 500;
+    let err = create_sidecar(&disk_heavy, Some(&mock)).await.unwrap_err();
+    expect_unavailable(err, "disk_gb");
+
+    // Host memory budget: 1024 + 2048 running; +2048 = 5120 > 4096 → Unavailable.
+    let err = create_sidecar(&tee_params("f", 2, 2048), Some(&mock))
+        .await
+        .unwrap_err();
+    expect_unavailable(err, "memory budget");
+
+    // Exactly at budget (3072 + 1024 = 4096) → admitted.
+    let (third, _) = create_sidecar(&tee_params("g", 2, 1024), Some(&mock))
+        .await
+        .expect("request exactly at the budget must be admitted");
+
+    // Stopping a sandbox frees its budget share but keeps its store slot, so
+    // the next create passes the budget and hits the COUNT cap — proving the
+    // TEE path enforces SANDBOX_MAX_COUNT and rejects with the 503 class.
+    assert!(
+        sandboxes()
+            .unwrap()
+            .update(&third.id, |record| record.state = SandboxState::Stopped)
+            .unwrap()
+    );
+    let err = create_sidecar(&tee_params("h", 2, 1024), Some(&mock))
+        .await
+        .unwrap_err();
+    expect_unavailable(err, "Sandbox limit reached");
+}


### PR DESCRIPTION
## Problem

Four admission-control gaps let a host accept work it cannot run, or reject it with the wrong signal:

1. **TEE path bypassed the sandbox count cap.** `create_sidecar_tee` never called `enforce_sandbox_count_limit`, while the Docker (`runtime.rs` ~2640) and Firecracker (~2200) paths do — a TEE operator could be driven past `SANDBOX_MAX_COUNT` without bound.
2. **Capacity rejection mapped to the wrong HTTP class.** The count-limit rejection was `SandboxError::Validation` → 400, though `error.rs` documents `Unavailable` → 503 for capacity exhaustion. Callers could not distinguish retry-on-another-operator from bad-request.
3. **No per-sandbox resource maxima and no host memory budget.** Any single request could demand unlimited CPU/memory/disk, and nothing bounded aggregate memory across sandboxes.
4. **No chain-vs-host cross-check.** An operator could register `OPERATOR_MAX_CAPACITY` on-chain above the host's `SANDBOX_MAX_COUNT`, guaranteeing the chain assigns work the host must reject.

## Changes

- **TEE count cap** (`sandbox-runtime/src/runtime.rs`): `create_sidecar_tee` now runs the same `enforce_sandbox_count_limit(config, previous_store_entry.is_some())` guard as Docker/Firecracker, with `CREATION_PERMIT` already held by `create_sidecar_with_token`, so the check cannot race.
- **503 capacity class**: the count-limit rejection is now `SandboxError::Unavailable` (→ 503 via `classify_sandbox_error`), refactored into a pure `check_sandbox_count_limit` so the class is unit-testable. No other code asserted the old class (verified by grep for `Sandbox limit reached` — the only reference was the message site itself).
- **Per-sandbox maxima** — new env knobs, same style as `SANDBOX_MAX_COUNT` / the idle-lifetime clamps:
  - `SANDBOX_MAX_CPU_CORES` / `SANDBOX_MAX_MEMORY_MB` / `SANDBOX_MAX_DISK_GB` (0 = no cap, default). A request **exceeding** a max → typed `Unavailable`; a request of **0 (= unlimited)** with a max set → **clamped to the max** (a capped operator never runs an unlimited container). The clamped values flow into the container config and the stored record, so accounting agrees with what runs.
- **Host memory budget** — `SANDBOX_HOST_MEMORY_BUDGET_MB` (0 = disabled): at admission, under `CREATION_PERMIT`, sum of effective `memory_mb` over **running** sandboxes plus the incoming request must stay within budget; over → `Unavailable`. Unlimited (0) records are accounted at `SANDBOX_MAX_MEMORY_MB` when set, else skipped with a one-time warning. Recreate/upgrade excludes the record being replaced.
- **Startup cross-check** (`ai-agent-sandbox-blueprint-bin/src/main.rs`): when both `OPERATOR_MAX_CAPACITY` and `SANDBOX_MAX_COUNT` are set and chain capacity > host cap, startup fails with a message naming both values. Equal/less/uncapped (0) passes.
- **Docs**: every knob (new + existing `SANDBOX_MAX_COUNT`, `OPERATOR_MAX_CAPACITY`) documented in `.env.example`.

## Design choices flagged

- **All three backends get the resource maxima + budget**, not just TEE: admission runs once in `create_sidecar_with_token` under the permit, before backend dispatch — one gate instead of three copies.
- **The cross-check only fires when `SANDBOX_MAX_COUNT` is explicitly set** (as scoped). Note the runtime's *effective* default cap is 100 when the var is unset, so `OPERATOR_MAX_CAPACITY>100` with no explicit `SANDBOX_MAX_COUNT` still passes startup; tightening that would change behavior for existing deployments and is left out deliberately.
- **Budget accounting counts `Running` records only** (stopped sandboxes hold no memory); `resume` is not budget-checked in this tranche — creation admission only, as scoped.
- **Unaccountable requests** (memory 0 with no `SANDBOX_MAX_MEMORY_MB`) are skipped-with-warn in the budget sum, same rule for stored records and the incoming request.

## Tests

- `sandbox-runtime/tests/admission_control.rs` — end-to-end through the real `create_sidecar` entry point with the mock TEE backend (own test binary because `SidecarRuntimeConfig` is a process-global env snapshot): in-range admit, 0→max clamp, per-resource `Unavailable` rejections (cpu/mem/disk), budget rejection, exactly-at-budget admit, and the TEE **count-cap** rejection with the 503 class.
- `runtime.rs` `core_logic_tests` — 12 new unit tests covering the pure decision cores: count-limit class + uncapped/reuse paths, resource-max passthrough/clamp/reject, memory accounting, budget disabled/over/exact/unlimited-at-max/skip-unaccountable.
- `main.rs` — 5 new unit tests for the cross-check (exceeds → error naming both values; equal/less/uncapped/missing/unparseable → pass).

**Mutation-verified** (fix reverted → named test red → fix restored):
1. Removed the TEE `enforce_sandbox_count_limit` call → `admission_control_end_to_end` FAILED (0 passed, 1 failed).
2. Reverted `Unavailable` → `Validation` on the count-limit rejection → `count_limit_rejection_is_unavailable` FAILED.

**Suites run:**
- `cargo test -p sandbox-runtime --features tee-all,test-utils` (CI feature set): 505 lib + 1 integration passed; only failure is the **pre-existing** `bench_regression::resolve_bearer_stays_under_threshold_at_10k_sessions` debug-profile flake — **proven by baseline**: same test fails on an untouched `origin/main` worktree.
- `cargo test --workspace --lib`: all green except one scheduling-dependent run of `provision_progress::tests::provision_lifecycle` (shared-store race with `clear_all_for_testing`), also **proven pre-existing by baseline**: fails 1-in-3 on untouched `origin/main` with the same filter; CI's nextest process-per-test isolation never hits it.
- `cargo test -p ai-agent-sandbox-blueprint-bin`: 8/8.
- `cargo clippy` (all 4 CI jobs + repo gate `--all-targets --all-features`): clean. `cargo fmt --check`: clean.

Not run: `REAL_SIDECAR`/`SIDECAR_E2E` Docker suites (admission logic fully covered by the unit + mock-TEE e2e above; no sidecar API contract touched).