### PR TITLE
feat(firecracker): warm-pool snapshot serving via microvm-runtime 0.4.0-alpha.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,36 @@ SIDECAR_PULL_IMAGE=true
 # accounted at SANDBOX_MAX_MEMORY_MB when set) over budget → 503 Unavailable.
 # SANDBOX_HOST_MEMORY_BUDGET_MB=0
 
+# ── Firecracker Warm Pool / Snapshot Restore (optional) ──────────────────────
+
+# Number of pre-restored Firecracker VMs kept claimable (0 = disabled, the
+# default). When > 0, dedicated template VMs are cold-booted, snapshotted,
+# and pre-restored entries wait paused; a create claims one via rename +
+# resume instead of cold-booting. Misses fall back to cold boot with the
+# reason logged. Claims are admission-accounted exactly like cold boots
+# (SANDBOX_MAX_COUNT / SANDBOX_HOST_MEMORY_BUDGET_MB), but the pool's own
+# inventory sits OUTSIDE those budgets — size the memory budget knowing the
+# pool holds roughly pool_size × 2 × VM memory with the `file` mem backend.
+# An unparseable value is a startup error, never a silent disable.
+# SANDBOX_FC_WARM_POOL_SIZE=0
+
+# Max age (seconds) of a pooled pre-restored entry before it is evicted and
+# re-restored from the golden snapshot. Default 3600.
+# SANDBOX_FC_WARM_MAX_AGE_SECS=3600
+
+# Rootfs clone size (GB) for warm template VMs. 0 (default) boots the
+# provider's workspace-default rootfs — matching cold creates with
+# disk_gb=0. > 0 requires SANDBOX_FIRECRACKER_DEFAULT_STACK and restricts
+# warm claims to creates requesting that stack image and disk size.
+# SANDBOX_FC_WARM_DISK_GB=0
+
+# Guest-memory backend for Firecracker snapshot restore (read by the
+# microvm-runtime primitive). `file` (default) loads the snapshot's memory
+# file eagerly; `uffd` serves guest pages lazily through a userfaultfd
+# handler (faster restore, pages fault in on demand). Invalid values fail
+# loudly at config load.
+# MICROVM_MEM_BACKEND=file
+
 # ── Operator API ──────────────────────────────────────────────────────────────
 
 # Port for the operator HTTP API (default: 9090)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,7 +4325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7262,9 +7262,9 @@ dependencies = [
 
 [[package]]
 name = "microvm-runtime"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22c15fabcd508d4b626b7f8319626a565c73bffa5db509e1f537fb595693019"
+checksum = "9133803bf92f4d43da70ac99314ad3a5485d920a06914826d83eaed2399c0306"
 dependencies = [
  "base64 0.22.1",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4325,7 +4325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7262,21 +7262,9 @@ dependencies = [
 
 [[package]]
 name = "microvm-runtime"
-version = "0.2.0-alpha.1"
+version = "0.4.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312192f848cd63715ac374ac0d72cb3cfc1fa5f77b6376b4ac1bb7e8c24e1c6c"
-dependencies = [
- "libc",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "microvm-runtime"
-version = "0.4.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4563a12aed22bc8775cdf836068572b0de91af1822fa20b9342b89bf7a35dd"
+checksum = "c22c15fabcd508d4b626b7f8319626a565c73bffa5db509e1f537fb595693019"
 dependencies = [
  "base64 0.22.1",
  "libc",
@@ -7290,11 +7278,11 @@ dependencies = [
 
 [[package]]
 name = "microvm-warm-pool"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334921033131e3101715e67c3b4f031ec0790b1d6b0e281549c2a7cb0850bc7f"
+checksum = "a0fe3571a4d0afa9f8a5519f958a34c331f8c2df16eb1e584d17e5cc10ff8be7"
 dependencies = [
- "microvm-runtime 0.2.0-alpha.1",
+ "microvm-runtime",
 ]
 
 [[package]]
@@ -9511,7 +9499,7 @@ dependencies = [
  "hyper 1.10.1",
  "k256",
  "libc",
- "microvm-runtime 0.4.0-alpha.1",
+ "microvm-runtime",
  "microvm-warm-pool",
  "once_cell",
  "pasetors 0.6.8",

--- a/sandbox-runtime/Cargo.toml
+++ b/sandbox-runtime/Cargo.toml
@@ -14,7 +14,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 dashmap = "6"
 docktopus = { version = "0.4.0-alpha.3", features = ["deploy"] }
 hex = "0.4"
-microvm-runtime = { version = "0.4.0-alpha.2", features = ["firecracker"] }
+microvm-runtime = { version = "0.4.0-alpha.3", features = ["firecracker"] }
 microvm-warm-pool = "0.1.0-alpha.2"
 once_cell = "1"
 libc = { version = "0.2", optional = true }

--- a/sandbox-runtime/Cargo.toml
+++ b/sandbox-runtime/Cargo.toml
@@ -14,8 +14,8 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 dashmap = "6"
 docktopus = { version = "0.4.0-alpha.3", features = ["deploy"] }
 hex = "0.4"
-microvm-runtime = { version = "0.4.0-alpha.1", features = ["firecracker"] }
-microvm-warm-pool = "0.1.0-alpha.1"
+microvm-runtime = { version = "0.4.0-alpha.2", features = ["firecracker"] }
+microvm-warm-pool = "0.1.0-alpha.2"
 once_cell = "1"
 libc = { version = "0.2", optional = true }
 phala-tee-deploy-rs = { version = "0.2.0", optional = true }

--- a/sandbox-runtime/src/firecracker.rs
+++ b/sandbox-runtime/src/firecracker.rs
@@ -5,9 +5,20 @@
 //! separate "host-agent" service; this module talks directly to the VMM over
 //! its unix socket via the primitive.
 //!
-//! ## Wired today (`microvm-runtime 0.4.0-alpha.1`)
+//! ## Wired today (`microvm-runtime 0.4.0-alpha.2` + `microvm-warm-pool 0.1.0-alpha.2`)
 //!
 //! - VM create / start / stop / destroy lifecycle.
+//! - **Warm-pool snapshot serving** via [`crate::firecracker_warm`], gated
+//!   by `SANDBOX_FC_WARM_POOL_SIZE` (0 = off, the default). When enabled,
+//!   dedicated template VMs (never tenant VMs) are cold-booted, paused, and
+//!   snapshotted; pre-restored entries wait in a [`microvm_warm_pool`] pool
+//!   and are handed off to creates via `rename_vm` + resume. Misses fall
+//!   back to cold boot with a logged, typed reason — the one designed
+//!   fallback in this module.
+//! - **Snapshot-restore memory backend**: `MICROVM_MEM_BACKEND=file|uffd`
+//!   is read by the primitive itself (`FirecrackerConfig::from_env`);
+//!   `uffd` restores guest memory through a userfaultfd handler (lazy CoW
+//!   paging from the snapshot's mem file) instead of a full file load.
 //! - **Per-VM TAP / bridge / NAT** via [`NetworkManager`]. The host bridge,
 //!   per-VM TAP, and gateway are set up before `create_vm_with_spec`; the
 //!   resulting [`VmNetwork`] is recorded so the host-reachable sidecar URL
@@ -52,12 +63,14 @@
 //!   `SANDBOX_FIRECRACKER_DEFAULT_STACK`.
 
 use std::collections::HashMap;
+use std::net::Ipv4Addr;
 use std::sync::{Arc, Mutex, OnceLock};
 
+use async_trait::async_trait;
 use microvm_runtime::{
     GuestMetadataClient, GuestMetadataConfig, NetworkManager, RootfsRegistry, VmNetwork,
     VsockManager,
-    adapters::firecracker::FirecrackerVmProvider,
+    adapters::firecracker::{FirecrackerConfig, FirecrackerVmProvider},
     error::VmRuntimeError,
     model::{NetworkInterface, VmSpec, VmStatus, VsockSpec},
     provider::{VmProvider, VmQuery},
@@ -66,6 +79,10 @@ use rand::RngCore;
 use rand::rngs::OsRng;
 
 use crate::error::{Result, SandboxError};
+use crate::firecracker_warm::{
+    self, TemplateIdentity, WarmClaim, WarmClaimRequest, WarmHost, WarmLineage, WarmOutcome,
+    WarmServing, WarmSettings,
+};
 
 use crate::firecracker_dnat;
 
@@ -120,6 +137,24 @@ struct VmAttachments {
     /// `true` iff a per-VM rootfs clone was created and must be released
     /// on delete. `false` for VMs that reused the provider's default rootfs.
     rootfs_cloned: bool,
+    /// Warm-claim lineage: host resources this sandbox holds under ids other
+    /// than its own (rider TAP, template vsock CID, template rootfs clone).
+    /// `None` for cold-booted VMs. In-memory only — an operator restart
+    /// loses it and leaks the aliases until host-level cleanup (documented
+    /// in `firecracker_warm`).
+    warm: Option<WarmLineage>,
+}
+
+impl VmAttachments {
+    fn cold(dnat_rule_count: usize, rootfs_cloned: bool) -> Self {
+        Self {
+            network_attached: true,
+            vsock_attached: true,
+            dnat_rule_count,
+            rootfs_cloned,
+            warm: None,
+        }
+    }
 }
 
 fn attachments_map() -> &'static Mutex<HashMap<String, Arc<VmAttachments>>> {
@@ -423,6 +458,333 @@ fn release_attachments(vm_id: &str, attachments: &VmAttachments) {
     {
         tracing::warn!(vm_id, ?err, "failed to release firecracker rootfs clone");
     }
+    if let Some(warm) = &attachments.warm {
+        // Warm-claimed sandboxes hold host resources under lineage ids: the
+        // vsock CID (and, when cloned, the rootfs slot) live under the
+        // template id; the TAP the VM rides lives under the rider id. All
+        // are single-owner by construction (one claim per generation), so
+        // releasing them here cannot race another VM.
+        if warm.rootfs_cloned
+            && let Err(err) = rootfs_registry().release(&warm.template_id)
+        {
+            tracing::warn!(
+                vm_id,
+                template_id = %warm.template_id,
+                ?err,
+                "failed to release warm template rootfs clone"
+            );
+        }
+        if let Err(err) = vsock_manager().detach(&warm.template_id) {
+            tracing::warn!(
+                vm_id,
+                template_id = %warm.template_id,
+                ?err,
+                "failed to detach warm template vsock"
+            );
+        }
+        if let Some(rider_id) = &warm.rider_id
+            && let Err(err) = network().detach(rider_id)
+        {
+            tracing::warn!(vm_id, rider_id, ?err, "failed to detach warm rider network");
+        }
+    }
+}
+
+/// Production [`WarmHost`]: composes template identity with the same
+/// primitives the cold path uses (`NetworkManager` / `VsockManager` /
+/// `RootfsRegistry`) and gates template readiness on the guest metadata
+/// daemon answering over vsock — the identical readiness bar a cold-booted
+/// sandbox must clear before env injection.
+struct OperatorWarmHost;
+
+#[async_trait]
+impl WarmHost for OperatorWarmHost {
+    async fn compose_template(
+        &self,
+        template_id: &str,
+        disk_gb: u64,
+        stack: Option<&str>,
+        spec: &mut VmSpec,
+    ) -> Result<TemplateIdentity> {
+        let (vm_net, uds_path) = match attach_network_and_vsock(template_id, spec) {
+            Ok(v) => v,
+            Err(err) => {
+                let _ = network().detach(template_id);
+                let _ = vsock_manager().detach(template_id);
+                return Err(err);
+            }
+        };
+
+        let mut rootfs_cloned = false;
+        if disk_gb > 0 {
+            let stack_name = stack.ok_or_else(|| {
+                SandboxError::Validation(
+                    "SANDBOX_FC_WARM_DISK_GB > 0 requires SANDBOX_FIRECRACKER_DEFAULT_STACK \
+                     so the warm template has a rootfs template to clone"
+                        .to_string(),
+                )
+            })?;
+            let target_bytes = disk_gb.saturating_mul(1024 * 1024 * 1024);
+            match rootfs_registry().clone_for_vm_with_size(template_id, stack_name, target_bytes) {
+                Ok(rootfs) => {
+                    spec.rootfs = Some(rootfs.path);
+                    rootfs_cloned = true;
+                }
+                Err(err) => {
+                    let _ = network().detach(template_id);
+                    let _ = vsock_manager().detach(template_id);
+                    return Err(map_vm_error("warm rootfs_clone", template_id, err));
+                }
+            }
+        }
+
+        Ok(TemplateIdentity {
+            guest_ip: Some(vm_net.guest_ip),
+            metadata_uds: Some(uds_path),
+            rootfs_cloned,
+        })
+    }
+
+    async fn await_guest_ready(
+        &self,
+        template_id: &str,
+        identity: &TemplateIdentity,
+    ) -> Result<()> {
+        let uds_path = identity.metadata_uds.clone().ok_or_else(|| {
+            SandboxError::Unavailable(format!(
+                "warm template {template_id} composed without a vsock UDS"
+            ))
+        })?;
+        let vm_id = template_id.to_string();
+        tokio::task::spawn_blocking(move || -> std::result::Result<(), VmRuntimeError> {
+            let client = GuestMetadataClient::new(uds_path, GuestMetadataConfig::from_env());
+            let mut conn = client.connect()?;
+            conn.ping()
+        })
+        .await
+        .map_err(|e| {
+            SandboxError::Unavailable(format!("warm guest-ready join error for {vm_id}: {e}"))
+        })?
+        .map_err(|e| map_vm_error("warm guest_ready", template_id, e))
+    }
+
+    async fn prepare_snapshot_source(&self, template_id: &str, identity: &TemplateIdentity) {
+        // The vmstate records the template's vsock UDS path; the restored
+        // entry's Firecracker binds a fresh listener there. The paused
+        // template still holds the old listener fd — unlinking the file
+        // orphans it (the template never serves again; it exists only as
+        // the snapshot's durable home) and frees the path for the entry.
+        if let Some(uds) = &identity.metadata_uds
+            && let Err(err) = std::fs::remove_file(uds)
+        {
+            tracing::warn!(
+                template_id,
+                uds = %uds.display(),
+                %err,
+                "failed to unlink warm template vsock UDS; entry restore may fail to bind"
+            );
+        }
+    }
+
+    async fn attach_rider(&self, rider_id: &str) -> Result<Option<NetworkInterface>> {
+        // The rider TAP carries the claimed VM's traffic; the guest keeps
+        // the MAC + IP recorded in the snapshot (Firecracker's restore
+        // override swaps the host device only), so no guest_mac is set.
+        let vm_net = network()
+            .attach(rider_id)
+            .map_err(|e| map_vm_error("warm rider network_attach", rider_id, e))?;
+        Ok(Some(NetworkInterface {
+            iface_id: "eth0".into(),
+            host_dev_name: vm_net.tap_name,
+            guest_mac: None,
+            rx_rate_limiter: None,
+            tx_rate_limiter: None,
+        }))
+    }
+
+    async fn release_template(&self, template_id: &str, identity: &TemplateIdentity, all: bool) {
+        if let Err(err) = network().detach(template_id) {
+            tracing::warn!(template_id, ?err, "failed to detach warm template network");
+        }
+        if all {
+            if let Err(err) = vsock_manager().detach(template_id) {
+                tracing::warn!(template_id, ?err, "failed to detach warm template vsock");
+            }
+            if identity.rootfs_cloned
+                && let Err(err) = rootfs_registry().release(template_id)
+            {
+                tracing::warn!(
+                    template_id,
+                    ?err,
+                    "failed to release warm template rootfs clone"
+                );
+            }
+        }
+    }
+}
+
+/// Process-wide warm-serving engine. `None` until the first create with
+/// `SANDBOX_FC_WARM_POOL_SIZE > 0` — constructing it spins up the pool's
+/// refill thread, which a disabled deployment must never pay for.
+static WARM_SERVING: OnceLock<Arc<WarmServing<FirecrackerVmProvider>>> = OnceLock::new();
+
+/// Whether the warm engine was ever constructed. Test-visible so the
+/// admission-order invariant ("a rejected create never touches the pool")
+/// can be pinned from integration tests.
+#[cfg(any(test, feature = "test-utils"))]
+pub fn warm_pool_initialized_for_tests() -> bool {
+    WARM_SERVING.get().is_some()
+}
+
+/// Try to serve the create from the warm pool. Returns the typed outcome;
+/// the caller logs misses and proceeds with the cold path.
+///
+/// MUST only be called from [`create_and_start`]: the runtime layer runs
+/// `admit_sandbox_resources` + `enforce_sandbox_count_limit` (under the
+/// creation permit) before dispatching here, which is what makes a warm
+/// claim count against `SANDBOX_MAX_COUNT` / the host memory budget exactly
+/// like a cold boot. Pool inventory itself is not a sandbox and is never
+/// admission-accounted — see the invariant note in [`firecracker_warm`].
+async fn warm_claim(req: &FirecrackerCreateRequest) -> Result<WarmOutcome> {
+    let pool_size = firecracker_warm::configured_pool_size()?;
+    if pool_size == 0 {
+        return Ok(WarmOutcome::Miss(firecracker_warm::WarmMiss::Disabled));
+    }
+
+    let serving = match WARM_SERVING.get() {
+        Some(s) => s,
+        None => {
+            let entry_max_age = firecracker_warm::configured_entry_max_age()?;
+            let disk_gb = firecracker_warm::configured_warm_disk_gb()?;
+            // Workspace defaults define the pooled machine shape; requests
+            // must match them (or leave cpu/mem unset) to claim.
+            let fc_config = FirecrackerConfig::from_env();
+            let settings = WarmSettings {
+                pool_size,
+                stack: default_stack_name(),
+                disk_gb,
+                vcpu_count: fc_config.vcpu_count,
+                mem_size_mib: fc_config.mem_size_mib,
+                entry_max_age,
+            };
+            WARM_SERVING.get_or_init(|| {
+                Arc::new(WarmServing::new(
+                    provider().clone(),
+                    Arc::new(OperatorWarmHost),
+                    settings,
+                ))
+            })
+        }
+    };
+
+    serving.ensure_seeding();
+    Ok(serving
+        .claim(&WarmClaimRequest {
+            sandbox_id: req.session_id.clone(),
+            image: req.image.clone(),
+            cpu_cores: req.cpu_cores,
+            memory_mb: req.memory_mb,
+            disk_gb: req.disk_gb,
+        })
+        .await)
+}
+
+/// Finish provisioning a warm-claimed VM: DNAT for requested ports, per-VM
+/// env + sidecar token over the inherited vsock, attachment bookkeeping,
+/// endpoint from the inherited guest IP. Any failure destroys the claimed
+/// VM and propagates — the claim already consumed the generation, and the
+/// same environmental cause would fail a cold boot's identical steps.
+async fn finish_warm_claim(
+    req: FirecrackerCreateRequest,
+    claim: WarmClaim,
+) -> Result<FirecrackerProvisionResult> {
+    let vm_id = req.session_id.clone();
+    let guest_ip: Ipv4Addr = claim.guest_ip.ok_or_else(|| {
+        SandboxError::Unavailable(format!(
+            "warm claim for {vm_id} carried no guest IP; the operator warm host always \
+             composes one — this indicates a non-production WarmHost in a production path"
+        ))
+    })?;
+    let metadata_uds = claim.metadata_uds.clone().ok_or_else(|| {
+        SandboxError::Unavailable(format!(
+            "warm claim for {vm_id} carried no metadata UDS; env injection is impossible"
+        ))
+    })?;
+
+    async fn teardown_warm_claim(vm_id: &str, dnat_rule_count: usize, lineage: WarmLineage) {
+        let cleanup_id = vm_id.to_string();
+        let _ = tokio::task::spawn_blocking(move || provider().destroy_vm(&cleanup_id)).await;
+        release_attachments(
+            vm_id,
+            &VmAttachments {
+                network_attached: false,
+                vsock_attached: false,
+                dnat_rule_count,
+                rootfs_cloned: false,
+                warm: Some(lineage),
+            },
+        );
+    }
+
+    let mut dnat_rule_count = 0usize;
+    for port in &req.ports {
+        if let Err(err) = firecracker_dnat::install_port_forward(&vm_id, guest_ip, *port) {
+            tracing::error!(
+                vm_id = %vm_id,
+                host_port = port.host_port,
+                container_port = port.container_port,
+                %err,
+                "failed to install DNAT for warm-claimed port forward; tearing down"
+            );
+            teardown_warm_claim(&vm_id, dnat_rule_count, claim.lineage.clone()).await;
+            return Err(SandboxError::Unavailable(format!(
+                "firecracker port forward install failed for warm-claimed {vm_id}: {err}"
+            )));
+        }
+        dnat_rule_count += 1;
+    }
+
+    let sidecar_auth_token =
+        match inject_runtime_metadata(&vm_id, metadata_uds, req.env.clone()).await {
+            Ok(t) => t,
+            Err(err) => {
+                teardown_warm_claim(&vm_id, dnat_rule_count, claim.lineage.clone()).await;
+                return Err(err);
+            }
+        };
+
+    record_attachments(
+        &vm_id,
+        VmAttachments {
+            network_attached: false,
+            vsock_attached: false,
+            dnat_rule_count,
+            rootfs_cloned: false,
+            warm: Some(claim.lineage),
+        },
+    );
+
+    let endpoint = format!("http://{guest_ip}:{}", sidecar_port());
+    Ok(FirecrackerProvisionResult {
+        container: FirecrackerContainer {
+            id: vm_id,
+            endpoint: Some(endpoint),
+        },
+        sidecar_auth_token: Some(sidecar_auth_token),
+    })
+}
+
+/// Guest IP a warm-claimed sandbox inherited from its template, if any.
+/// Consulted by [`start`] so resume rebuilds the endpoint from the IP the
+/// guest actually has instead of the sandbox-id-derived allocation.
+fn warm_guest_ip(vm_id: &str) -> Option<Ipv4Addr> {
+    attachments_map()
+        .lock()
+        .ok()?
+        .get(vm_id)?
+        .warm
+        .as_ref()?
+        .guest_ip
 }
 
 /// Sanity-check the configured Firecracker provider is reachable.
@@ -447,6 +809,23 @@ pub(crate) async fn health() -> Result<()> {
 pub(crate) async fn create_and_start(
     req: FirecrackerCreateRequest,
 ) -> Result<FirecrackerProvisionResult> {
+    // Warm-pool serving first (SANDBOX_FC_WARM_POOL_SIZE > 0): a claim
+    // hands off a pre-restored VM via rename + resume. Any miss is logged
+    // with its typed reason and falls through to the cold boot below — the
+    // one designed fallback in this module. Invalid warm configuration is a
+    // hard error, never a silent cold boot.
+    match warm_claim(&req).await? {
+        WarmOutcome::Claimed(claim) => return finish_warm_claim(req, claim).await,
+        WarmOutcome::Miss(firecracker_warm::WarmMiss::Disabled) => {}
+        WarmOutcome::Miss(miss) => {
+            tracing::info!(
+                sandbox_id = %req.session_id,
+                reason = %miss,
+                "firecracker warm-pool miss; falling back to cold boot"
+            );
+        }
+    }
+
     let vm_id = req.session_id.clone();
     let mut spec = spec_from_request(&req);
 
@@ -470,15 +849,7 @@ pub(crate) async fn create_and_start(
     let rootfs_cloned = match attach_rootfs(&vm_id, &req, &mut spec) {
         Ok(v) => v,
         Err(err) => {
-            release_attachments(
-                &vm_id,
-                &VmAttachments {
-                    network_attached: true,
-                    vsock_attached: true,
-                    dnat_rule_count: 0,
-                    rootfs_cloned: false,
-                },
-            );
+            release_attachments(&vm_id, &VmAttachments::cold(0, false));
             return Err(err);
         }
     };
@@ -497,15 +868,7 @@ pub(crate) async fn create_and_start(
     })?
     .map_err(|e| map_vm_error("create", &vm_id, e))
     {
-        release_attachments(
-            &vm_id,
-            &VmAttachments {
-                network_attached: true,
-                vsock_attached: true,
-                dnat_rule_count: 0,
-                rootfs_cloned,
-            },
-        );
+        release_attachments(&vm_id, &VmAttachments::cold(0, rootfs_cloned));
         return Err(err);
     }
 
@@ -520,15 +883,7 @@ pub(crate) async fn create_and_start(
         // Best-effort cleanup so a partial create doesn't leak a process.
         let cleanup_id = vm_id.clone();
         let _ = tokio::task::spawn_blocking(move || provider().destroy_vm(&cleanup_id)).await;
-        release_attachments(
-            &vm_id,
-            &VmAttachments {
-                network_attached: true,
-                vsock_attached: true,
-                dnat_rule_count: 0,
-                rootfs_cloned,
-            },
-        );
+        release_attachments(&vm_id, &VmAttachments::cold(0, rootfs_cloned));
         return Err(err);
     }
 
@@ -548,15 +903,7 @@ pub(crate) async fn create_and_start(
             // Tear everything down.
             let cleanup_id = vm_id.clone();
             let _ = tokio::task::spawn_blocking(move || provider().destroy_vm(&cleanup_id)).await;
-            release_attachments(
-                &vm_id,
-                &VmAttachments {
-                    network_attached: true,
-                    vsock_attached: true,
-                    dnat_rule_count,
-                    rootfs_cloned,
-                },
-            );
+            release_attachments(&vm_id, &VmAttachments::cold(dnat_rule_count, rootfs_cloned));
             return Err(SandboxError::Unavailable(format!(
                 "firecracker port forward install failed for {vm_id}: {err}"
             )));
@@ -573,28 +920,12 @@ pub(crate) async fn create_and_start(
         Err(err) => {
             let cleanup_id = vm_id.clone();
             let _ = tokio::task::spawn_blocking(move || provider().destroy_vm(&cleanup_id)).await;
-            release_attachments(
-                &vm_id,
-                &VmAttachments {
-                    network_attached: true,
-                    vsock_attached: true,
-                    dnat_rule_count,
-                    rootfs_cloned,
-                },
-            );
+            release_attachments(&vm_id, &VmAttachments::cold(dnat_rule_count, rootfs_cloned));
             return Err(err);
         }
     };
 
-    record_attachments(
-        &vm_id,
-        VmAttachments {
-            network_attached: true,
-            vsock_attached: true,
-            dnat_rule_count,
-            rootfs_cloned,
-        },
-    );
+    record_attachments(&vm_id, VmAttachments::cold(dnat_rule_count, rootfs_cloned));
 
     let endpoint = format!("http://{}:{}", vm_net.guest_ip, sidecar_port());
 
@@ -623,14 +954,23 @@ pub(crate) async fn start(container_id: &str) -> Result<FirecrackerContainer> {
         })?
         .map_err(|e| map_vm_error("start", &vm_id, e))?;
 
-    // `NetworkManager::attach` is idempotent: for a known vm_id it returns
-    // the same TAP / IP allocation. Resuming a VM whose TAP was torn down
-    // out-of-band recreates it; this matches what an operator would do by
-    // hand for debugging.
-    let vm_net = network()
-        .attach(container_id)
-        .map_err(|e| map_vm_error("network_attach_resume", container_id, e))?;
-    let endpoint = format!("http://{}:{}", vm_net.guest_ip, sidecar_port());
+    // Warm-claimed VMs keep the guest IP baked into their template's
+    // snapshot; deriving one from the sandbox id here would report an
+    // endpoint the guest never configured.
+    let guest_ip = match warm_guest_ip(container_id) {
+        Some(ip) => ip,
+        None => {
+            // `NetworkManager::attach` is idempotent: for a known vm_id it
+            // returns the same TAP / IP allocation. Resuming a VM whose TAP
+            // was torn down out-of-band recreates it; this matches what an
+            // operator would do by hand for debugging.
+            network()
+                .attach(container_id)
+                .map_err(|e| map_vm_error("network_attach_resume", container_id, e))?
+                .guest_ip
+        }
+    };
+    let endpoint = format!("http://{}:{}", guest_ip, sidecar_port());
 
     Ok(FirecrackerContainer {
         id: container_id.to_string(),
@@ -786,15 +1126,7 @@ mod tests {
         let vm_id = "vm-attach-roundtrip";
         // Ensure no leftover state from a previous test run.
         let _ = take_attachments(vm_id);
-        record_attachments(
-            vm_id,
-            VmAttachments {
-                network_attached: true,
-                vsock_attached: true,
-                dnat_rule_count: 2,
-                rootfs_cloned: true,
-            },
-        );
+        record_attachments(vm_id, VmAttachments::cold(2, true));
         let first = take_attachments(vm_id).expect("first take returns recorded value");
         assert_eq!(first.dnat_rule_count, 2);
         assert!(first.rootfs_cloned);

--- a/sandbox-runtime/src/firecracker_warm.rs
+++ b/sandbox-runtime/src/firecracker_warm.rs
@@ -1,0 +1,1631 @@
+//! Firecracker warm-pool snapshot serving.
+//!
+//! Keeps `SANDBOX_FC_WARM_POOL_SIZE` *generations* warm. A generation is a
+//! self-contained unit of pre-provisioned identity:
+//!
+//! - a **template VM** (`fcwarm-g<N>-tpl`): cold-booted once on the
+//!   operator's configured base stack with its own TAP / vsock / rootfs,
+//!   paused, and snapshotted (`golden`). It is kept paused afterwards
+//!   because the snapshot artifacts live in its state dir — destroying it
+//!   would delete them (`microvm-runtime` layout).
+//! - a **rider TAP** (`fcwarm-g<N>-rider`): the host interface the pooled
+//!   entry restores onto via `SnapshotRef::network_overrides` (the template
+//!   still holds its own TAP while paused, so the entry cannot reuse it).
+//! - a [`WarmPool`] bucket of depth 1 holding one **pre-restored, paused
+//!   entry** ready for handoff.
+//!
+//! A claim is `acquire → rename_vm(entry, sandbox_id) → start_vm` — the
+//! handoff flow `microvm-runtime 0.4.0-alpha.2` implements `rename_vm` for.
+//! The claimed VM inherits the generation's identity: the template's guest
+//! IP (baked into the snapshot's memory image), the template's vsock UDS +
+//! CID (recorded in the vmstate), the template's rootfs backing file, and
+//! the rider TAP. Because that identity is single-occupancy, a generation
+//! serves exactly one claim: on claim the bucket is unregistered, the paused
+//! template is destroyed (releasing its memory and its TAP), and a fresh
+//! generation is seeded on the next create. Idle-time entry evictions
+//! (age / failed validation) do NOT retire the generation — the refill
+//! thread restores a replacement from the still-alive template snapshot,
+//! reusing the rider TAP sequentially.
+//!
+//! ## Admission-control invariant
+//!
+//! Pool inventory (templates + pre-restored entries) is NOT a live sandbox:
+//! it never enters the sandbox store, so `SANDBOX_MAX_COUNT` and
+//! `SANDBOX_HOST_MEMORY_BUDGET_MB` do not see it. Accounting applies at
+//! claim time: the claim runs inside `firecracker::create_and_start`, which
+//! the runtime layer only calls AFTER `admit_sandbox_resources` +
+//! `enforce_sandbox_count_limit` have passed under the creation permit — a
+//! warm claim is admitted exactly like a cold boot. Operators must size the
+//! memory budget knowing the pool's own footprint sits outside it:
+//! roughly `pool_size × 2 × mem_size_mib` with the `file` memory backend
+//! (paused template + restored entry per generation), less with
+//! `MICROVM_MEM_BACKEND=uffd` where entry pages fault in lazily.
+//!
+//! ## Fail-loud boundaries
+//!
+//! The single designed fallback is warm-miss → cold boot, and every miss
+//! carries a typed [`WarmMiss`] reason that the create path logs. Seeding
+//! failures are logged loudly and retried on subsequent creates
+//! ([`WarmServing::ensure_seeding`]); a misconfigured
+//! `SANDBOX_FC_WARM_POOL_SIZE` is a hard error, never a silent disable.
+//!
+//! ## Known limitations (documented, not silent)
+//!
+//! - Pool VMs are process-local: after an operator restart, templates and
+//!   entries from the previous process are orphaned Firecracker processes
+//!   the reaper cannot reconcile (they have no sandbox record). Host-level
+//!   cleanup (`pkill -f 'fcwarm-'` or a reboot) is the remediation.
+//! - A warm-claimed sandbox's alias resources (rider TAP, template vsock
+//!   CID, template rootfs clone) are tracked in process memory; a restart
+//!   leaks them until the host is reconciled the same way.
+
+use std::net::Ipv4Addr;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use microvm_runtime::{
+    model::{NetworkInterface, SnapshotRef, VmSpec, VmStatus},
+    provider::{VmProvider, VmQuery},
+};
+#[cfg(test)]
+use microvm_warm_pool::WarmPoolMetrics;
+use microvm_warm_pool::{EntryValidator, StackKey, ValidationResult, WarmPool, WarmPoolConfig};
+
+use crate::error::{Result, SandboxError};
+
+/// Snapshot name every generation's golden image is stored under.
+pub(crate) const GOLDEN_SNAPSHOT_ID: &str = "golden";
+
+/// Parse `SANDBOX_FC_WARM_POOL_SIZE`. Absent or `0` disables warm serving;
+/// anything unparseable is a hard configuration error — a typo must never
+/// silently disable the pool.
+pub(crate) fn configured_pool_size() -> Result<usize> {
+    match std::env::var("SANDBOX_FC_WARM_POOL_SIZE") {
+        Err(_) => Ok(0),
+        Ok(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                return Ok(0);
+            }
+            trimmed.parse::<usize>().map_err(|_| {
+                SandboxError::Validation(format!(
+                    "SANDBOX_FC_WARM_POOL_SIZE must be a non-negative integer, got {trimmed:?}"
+                ))
+            })
+        }
+    }
+}
+
+/// Parse `SANDBOX_FC_WARM_MAX_AGE_SECS` (pool-entry age eviction). Default
+/// 3600s: evictions force a snapshot re-restore, so a long default keeps the
+/// pool quiet; operators lower it if they want fresher entries.
+pub(crate) fn configured_entry_max_age() -> Result<Duration> {
+    match std::env::var("SANDBOX_FC_WARM_MAX_AGE_SECS") {
+        Err(_) => Ok(Duration::from_secs(3600)),
+        Ok(raw) => raw
+            .trim()
+            .parse::<u64>()
+            .map(Duration::from_secs)
+            .map_err(|_| {
+                SandboxError::Validation(format!(
+                    "SANDBOX_FC_WARM_MAX_AGE_SECS must be a non-negative integer, got {raw:?}"
+                ))
+            }),
+    }
+}
+
+/// Parse `SANDBOX_FC_WARM_DISK_GB` — the per-generation rootfs clone size.
+/// `0` (default) keeps the provider's workspace-default rootfs (no clone),
+/// matching the cold path's `disk_gb == 0` semantics.
+pub(crate) fn configured_warm_disk_gb() -> Result<u64> {
+    match std::env::var("SANDBOX_FC_WARM_DISK_GB") {
+        Err(_) => Ok(0),
+        Ok(raw) => raw.trim().parse::<u64>().map_err(|_| {
+            SandboxError::Validation(format!(
+                "SANDBOX_FC_WARM_DISK_GB must be a non-negative integer, got {raw:?}"
+            ))
+        }),
+    }
+}
+
+/// Shape a warm generation is provisioned at and a create request must match
+/// (or leave unset) to be servable from the pool.
+#[derive(Debug, Clone)]
+pub(crate) struct WarmSettings {
+    /// Number of generations to keep claimable.
+    pub pool_size: usize,
+    /// Stack the template's rootfs is cloned from when `disk_gb > 0`
+    /// (`SANDBOX_FIRECRACKER_DEFAULT_STACK`). Irrelevant when `disk_gb == 0`
+    /// — the cold path ignores `image` in that case too, so warm/cold serve
+    /// identical guests.
+    pub stack: Option<String>,
+    /// Rootfs clone size for the template (`SANDBOX_FC_WARM_DISK_GB`).
+    pub disk_gb: u64,
+    /// vCPU count baked into the golden snapshot (provider workspace default).
+    pub vcpu_count: u8,
+    /// Memory baked into the golden snapshot (provider workspace default).
+    pub mem_size_mib: u32,
+    /// Pool-entry age eviction (`SANDBOX_FC_WARM_MAX_AGE_SECS`).
+    pub entry_max_age: Duration,
+}
+
+/// Host-side composition the engine cannot do itself (TAP / vsock / rootfs /
+/// guest readiness). Production wires the operator's `NetworkManager` /
+/// `VsockManager` / `RootfsRegistry` (see `firecracker::OperatorWarmHost`);
+/// tests and the network-less e2e substitute fakes.
+#[async_trait]
+pub(crate) trait WarmHost: Send + Sync + 'static {
+    /// Attach the template's own network + vsock + (optional) rootfs clone,
+    /// mutating `spec` in place. Returns the identity the generation's
+    /// eventual claimant inherits.
+    async fn compose_template(
+        &self,
+        template_id: &str,
+        disk_gb: u64,
+        stack: Option<&str>,
+        spec: &mut VmSpec,
+    ) -> Result<TemplateIdentity>;
+
+    /// Block until the guest inside the freshly booted template is ready to
+    /// be snapshotted (production: guest metadata daemon answers a ping).
+    async fn await_guest_ready(&self, template_id: &str, identity: &TemplateIdentity)
+    -> Result<()>;
+
+    /// Called once after the golden snapshot is written, before the bucket
+    /// is registered (i.e. before any restore can run). Production unlinks
+    /// the template's vsock UDS *file*: the paused template keeps an
+    /// orphaned listener fd (harmless — it never serves again), freeing the
+    /// path so the restored entry's Firecracker can bind the vsock device
+    /// recorded in the vmstate at the same path.
+    async fn prepare_snapshot_source(&self, template_id: &str, identity: &TemplateIdentity);
+
+    /// Attach the TAP the pooled entry restores onto. `None` when the host
+    /// composes no network (network-less e2e) — the snapshot then carries no
+    /// interface to override.
+    async fn attach_rider(&self, rider_id: &str) -> Result<Option<NetworkInterface>>;
+
+    /// Release template-keyed host resources. Flags select which: on claim,
+    /// only the TAP is released (vsock CID + rootfs clone move to the
+    /// claimed sandbox and are released at its delete); on seed failure,
+    /// everything is. Rider TAPs are never released through this trait:
+    /// `attach_rider` is the last fallible seeding step, and a claimed
+    /// rider is released at sandbox delete (`firecracker::release_attachments`).
+    async fn release_template(&self, template_id: &str, identity: &TemplateIdentity, all: bool);
+}
+
+/// Identity captured at template compose time, inherited by the claimant.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TemplateIdentity {
+    /// Guest IP baked into the snapshot (kernel/network state). `None` only
+    /// for hosts that compose no network.
+    pub guest_ip: Option<Ipv4Addr>,
+    /// Host UDS path of the template's vsock — the claimed VM's metadata
+    /// listener binds here (recorded in the vmstate).
+    pub metadata_uds: Option<PathBuf>,
+    /// Whether a per-template rootfs clone was created (must be released
+    /// when the claimed sandbox is deleted).
+    pub rootfs_cloned: bool,
+}
+
+/// One claimable generation.
+#[derive(Debug, Clone)]
+pub(crate) struct Generation {
+    pub template_id: String,
+    pub rider_id: String,
+    pub stack_key: StackKey,
+    pub identity: TemplateIdentity,
+    pub rider_attached: bool,
+}
+
+/// Everything the create path needs to finish provisioning a claimed VM.
+#[derive(Debug, Clone)]
+pub(crate) struct WarmClaim {
+    /// Guest IP for the endpoint URL + DNAT (template's, via the snapshot).
+    pub guest_ip: Option<Ipv4Addr>,
+    /// UDS to inject per-sandbox env + sidecar token through.
+    pub metadata_uds: Option<PathBuf>,
+    /// Alias ids whose host resources now belong to the claimed sandbox.
+    pub lineage: WarmLineage,
+}
+
+/// Host resources a warm-claimed sandbox holds under ids other than its own.
+/// Released at sandbox delete in `firecracker::release_attachments`.
+#[derive(Debug, Clone)]
+pub(crate) struct WarmLineage {
+    /// Template id: owns the vsock CID allocation and (when
+    /// `rootfs_cloned`) the rootfs clone slot backing the claimed VM.
+    pub template_id: String,
+    /// Rider id: owns the TAP the claimed VM rides. `None` on network-less
+    /// hosts.
+    pub rider_id: Option<String>,
+    pub rootfs_cloned: bool,
+    /// Guest IP for endpoint rebuilds on resume (`firecracker::start`).
+    pub guest_ip: Option<Ipv4Addr>,
+}
+
+/// Typed warm-miss reason. Logged by the create path before the designed
+/// fallback to cold boot — the only silent thing about a miss is nothing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum WarmMiss {
+    /// `SANDBOX_FC_WARM_POOL_SIZE` is 0/unset.
+    Disabled,
+    /// Pool enabled but no generation is ready yet (seeding in flight or
+    /// all seeds failed so far).
+    NotReady,
+    /// Ready generations exist but their buckets are empty (entry evicted
+    /// and not yet refilled, or refill failing).
+    Empty,
+    DiskMismatch {
+        requested: u64,
+        pooled: u64,
+    },
+    ImageMismatch {
+        requested: String,
+        pooled: String,
+    },
+    CpuMismatch {
+        requested: u64,
+        pooled: u8,
+    },
+    MemoryMismatch {
+        requested: u64,
+        pooled: u32,
+    },
+    /// Handoff rename failed; the entry was destroyed and the generation
+    /// returned to the pool for refill.
+    RenameFailed(String),
+    /// Post-rename resume failed; the claimed VM was destroyed and the
+    /// generation returned to the pool for refill.
+    ResumeFailed(String),
+}
+
+impl std::fmt::Display for WarmMiss {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WarmMiss::Disabled => write!(f, "warm pool disabled (SANDBOX_FC_WARM_POOL_SIZE=0)"),
+            WarmMiss::NotReady => write!(f, "no warm generation ready (seeding in flight)"),
+            WarmMiss::Empty => write!(f, "warm buckets empty (entry evicted, refill pending)"),
+            WarmMiss::DiskMismatch { requested, pooled } => write!(
+                f,
+                "disk_gb mismatch (requested {requested}, pooled {pooled})"
+            ),
+            WarmMiss::ImageMismatch { requested, pooled } => {
+                write!(
+                    f,
+                    "image mismatch (requested {requested:?}, pooled {pooled:?})"
+                )
+            }
+            WarmMiss::CpuMismatch { requested, pooled } => {
+                write!(
+                    f,
+                    "cpu_cores mismatch (requested {requested}, pooled {pooled})"
+                )
+            }
+            WarmMiss::MemoryMismatch { requested, pooled } => {
+                write!(
+                    f,
+                    "memory_mb mismatch (requested {requested}, pooled {pooled})"
+                )
+            }
+            WarmMiss::RenameFailed(e) => write!(f, "warm handoff rename failed: {e}"),
+            WarmMiss::ResumeFailed(e) => write!(f, "warm handoff resume failed: {e}"),
+        }
+    }
+}
+
+/// Outcome of a warm-claim attempt.
+#[derive(Debug)]
+pub(crate) enum WarmOutcome {
+    Claimed(WarmClaim),
+    Miss(WarmMiss),
+}
+
+/// Request shape the claim gate evaluates (subset of
+/// `firecracker::FirecrackerCreateRequest` the engine needs — it must not
+/// see env/labels, which are injected after the claim).
+#[derive(Debug, Clone)]
+pub(crate) struct WarmClaimRequest {
+    pub sandbox_id: String,
+    pub image: String,
+    pub cpu_cores: u64,
+    pub memory_mb: u64,
+    pub disk_gb: u64,
+}
+
+/// Validates pool entries by provider record: present and paused
+/// (`Stopped`). Catches destroyed/renamed-away records; it cannot see a
+/// crashed FC child behind a live record — the claim path's resume would
+/// surface that as `ResumeFailed` (logged miss, cold fallback).
+struct PausedEntryValidator<P: VmQuery> {
+    provider: P,
+}
+
+impl<P: VmQuery + Send + Sync + 'static> EntryValidator for PausedEntryValidator<P> {
+    fn validate(&self, vm_id: &str) -> ValidationResult {
+        match self.provider.get_vm(vm_id) {
+            Ok(Some(view)) if view.status == VmStatus::Stopped => ValidationResult::Healthy,
+            Ok(Some(view)) => {
+                ValidationResult::Unhealthy(format!("entry {vm_id} in state {}", view.status))
+            }
+            Ok(None) => ValidationResult::Unhealthy(format!("entry {vm_id} has no record")),
+            Err(e) => ValidationResult::Unhealthy(format!("entry {vm_id} query failed: {e}")),
+        }
+    }
+}
+
+/// Seed/claim counters, exposed alongside [`WarmPoolMetrics`].
+#[derive(Debug, Default)]
+struct WarmCounters {
+    claims: AtomicU64,
+    misses: AtomicU64,
+    seed_failures: AtomicU64,
+}
+
+/// The warm-serving engine. Generic over the provider so tests drive it with
+/// an in-memory fake and the e2e with the real `FirecrackerVmProvider`.
+pub(crate) struct WarmServing<P: VmProvider + VmQuery + Clone + 'static> {
+    provider: P,
+    host: Arc<dyn WarmHost>,
+    settings: WarmSettings,
+    pool: WarmPool<P>,
+    ready: Mutex<Vec<Generation>>,
+    seeds_in_flight: Arc<AtomicUsize>,
+    generation_counter: AtomicU64,
+    counters: WarmCounters,
+}
+
+impl<P: VmProvider + VmQuery + Clone + 'static> WarmServing<P> {
+    pub(crate) fn new(provider: P, host: Arc<dyn WarmHost>, settings: WarmSettings) -> Self {
+        let pool = WarmPool::start(
+            provider.clone(),
+            WarmPoolConfig {
+                // Depth 1 per generation: a generation's identity (rider
+                // TAP, vsock UDS, rootfs file) is single-occupancy, so a
+                // deeper bucket would restore entries that collide on it.
+                min_depth: 1,
+                max_depth: 1,
+                refill_interval: Duration::from_secs(2),
+                entry_max_age: settings.entry_max_age,
+            },
+            Arc::new(PausedEntryValidator {
+                provider: provider.clone(),
+            }),
+        );
+        Self {
+            provider,
+            host,
+            settings,
+            pool,
+            ready: Mutex::new(Vec::new()),
+            seeds_in_flight: Arc::new(AtomicUsize::new(0)),
+            generation_counter: AtomicU64::new(0),
+            counters: WarmCounters::default(),
+        }
+    }
+
+    /// Number of generations currently claimable (bucket may still be
+    /// refilling; see [`WarmMiss::Empty`]).
+    pub(crate) fn ready_generations(&self) -> usize {
+        lock_ready(&self.ready).len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pool_metrics(&self) -> WarmPoolMetrics {
+        self.pool.metrics()
+    }
+
+    /// Top the pool back up to `pool_size` generations. Called by the create
+    /// path on every request: cheap when saturated, and it doubles as the
+    /// retry loop for failed seeds (no supervisor thread to babysit).
+    pub(crate) fn ensure_seeding(self: &Arc<Self>) {
+        loop {
+            let ready = self.ready_generations();
+            let in_flight = self.seeds_in_flight.load(Ordering::SeqCst);
+            if ready + in_flight >= self.settings.pool_size {
+                return;
+            }
+            // Reserve the slot before spawning so concurrent creates cannot
+            // over-seed past pool_size.
+            if self
+                .seeds_in_flight
+                .compare_exchange(in_flight, in_flight + 1, Ordering::SeqCst, Ordering::SeqCst)
+                .is_err()
+            {
+                continue;
+            }
+            let this = Arc::clone(self);
+            tokio::spawn(async move {
+                let outcome = this.seed_generation().await;
+                this.seeds_in_flight.fetch_sub(1, Ordering::SeqCst);
+                if let Err(err) = outcome {
+                    this.counters.seed_failures.fetch_add(1, Ordering::Relaxed);
+                    tracing::error!(%err, "firecracker warm-pool generation seed failed");
+                }
+            });
+        }
+    }
+
+    /// Cold-boot a template, snapshot it, and register the generation's
+    /// bucket. The pool's refill thread pre-restores the entry afterwards.
+    pub(crate) async fn seed_generation(&self) -> Result<()> {
+        let generation = self.generation_counter.fetch_add(1, Ordering::SeqCst);
+        let template_id = format!("fcwarm-g{generation}-tpl");
+        let rider_id = format!("fcwarm-g{generation}-rider");
+
+        let mut spec = VmSpec {
+            vcpu_count: Some(self.settings.vcpu_count),
+            mem_size_mib: Some(self.settings.mem_size_mib),
+            ..VmSpec::default()
+        };
+        let identity = self
+            .host
+            .compose_template(
+                &template_id,
+                self.settings.disk_gb,
+                self.settings.stack.as_deref(),
+                &mut spec,
+            )
+            .await?;
+
+        if let Err(err) = self
+            .boot_pause_snapshot(&template_id, &spec, &identity)
+            .await
+        {
+            // Roll back everything the template holds; the VM itself is
+            // destroyed (best-effort) inside boot_pause_snapshot.
+            self.host
+                .release_template(&template_id, &identity, true)
+                .await;
+            return Err(err);
+        }
+
+        self.host
+            .prepare_snapshot_source(&template_id, &identity)
+            .await;
+
+        let rider_iface = match self.host.attach_rider(&rider_id).await {
+            Ok(iface) => iface,
+            Err(err) => {
+                self.destroy_vm_best_effort(&template_id).await;
+                self.host
+                    .release_template(&template_id, &identity, true)
+                    .await;
+                return Err(err);
+            }
+        };
+        let rider_attached = rider_iface.is_some();
+
+        let stack_key = StackKey {
+            stack_name: self
+                .settings
+                .stack
+                .clone()
+                .unwrap_or_else(|| "workspace-default".to_string()),
+            version: format!("g{generation}"),
+            vcpu_count: self.settings.vcpu_count,
+            mem_size_mib: self.settings.mem_size_mib,
+        };
+        self.pool.register(
+            stack_key.clone(),
+            SnapshotRef {
+                vm_id: template_id.clone(),
+                snapshot_id: GOLDEN_SNAPSHOT_ID.to_string(),
+                // Entries wait paused; the claim resumes after rename so a
+                // pooled guest burns no CPU and its clock is corrected at
+                // handoff time, not pool-idle time.
+                resume_immediately: false,
+                network_overrides: rider_iface.into_iter().collect(),
+            },
+        );
+
+        lock_ready(&self.ready).push(Generation {
+            template_id: template_id.clone(),
+            rider_id,
+            stack_key,
+            identity,
+            rider_attached,
+        });
+        tracing::info!(
+            template_id,
+            generation,
+            "firecracker warm-pool generation seeded (golden snapshot registered)"
+        );
+        Ok(())
+    }
+
+    async fn boot_pause_snapshot(
+        &self,
+        template_id: &str,
+        spec: &VmSpec,
+        identity: &TemplateIdentity,
+    ) -> Result<()> {
+        let create_id = template_id.to_string();
+        let create_spec = spec.clone();
+        let provider = self.provider.clone();
+        run_provider(
+            move || provider.create_vm_with_spec(&create_id, &create_spec),
+            "warm template create",
+            template_id,
+        )
+        .await?;
+
+        let result: Result<()> = async {
+            let start_id = template_id.to_string();
+            let provider = self.provider.clone();
+            run_provider(
+                move || provider.start_vm(&start_id),
+                "warm template start",
+                template_id,
+            )
+            .await?;
+
+            self.host.await_guest_ready(template_id, identity).await?;
+
+            let pause_id = template_id.to_string();
+            let provider = self.provider.clone();
+            run_provider(
+                move || provider.stop_vm(&pause_id),
+                "warm template pause",
+                template_id,
+            )
+            .await?;
+
+            let snap_id = template_id.to_string();
+            let provider = self.provider.clone();
+            run_provider(
+                move || provider.snapshot_vm(&snap_id, GOLDEN_SNAPSHOT_ID),
+                "warm template snapshot",
+                template_id,
+            )
+            .await?;
+            Ok(())
+        }
+        .await;
+
+        if result.is_err() {
+            self.destroy_vm_best_effort(template_id).await;
+        }
+        result
+    }
+
+    /// Try to serve `request` from the pool. Never falls back internally —
+    /// the caller owns the (logged) cold-boot fallback.
+    pub(crate) async fn claim(&self, request: &WarmClaimRequest) -> WarmOutcome {
+        if let Some(miss) = self.shape_gate(request) {
+            return self.miss(miss);
+        }
+
+        // Pop a claimable generation whose bucket has an entry. The
+        // generation leaves `ready` before any await so a concurrent claim
+        // cannot double-serve it; on failure it is pushed back (its
+        // template + snapshot still exist, so the refill thread restores a
+        // replacement entry).
+        let (generation, handle) = {
+            let mut ready = lock_ready(&self.ready);
+            let mut found = None;
+            for (idx, generation) in ready.iter().enumerate() {
+                if let Some(handle) = self.pool.acquire(&generation.stack_key) {
+                    found = Some((idx, handle));
+                    break;
+                }
+            }
+            match found {
+                Some((idx, handle)) => (ready.remove(idx), handle),
+                None => {
+                    drop(ready);
+                    let reason = if self.ready_generations() == 0 {
+                        WarmMiss::NotReady
+                    } else {
+                        WarmMiss::Empty
+                    };
+                    return self.miss(reason);
+                }
+            }
+        };
+
+        let entry_id = handle.source_vm_id.clone();
+        let sandbox_id = request.sandbox_id.clone();
+
+        // Handoff: re-key the pre-restored entry onto the sandbox id.
+        let rename_provider = self.provider.clone();
+        let rename_entry = entry_id.clone();
+        let rename_target = sandbox_id.clone();
+        if let Err(err) = run_provider(
+            move || rename_provider.rename_vm(&rename_entry, &rename_target),
+            "warm handoff rename",
+            &entry_id,
+        )
+        .await
+        {
+            self.destroy_vm_best_effort(&entry_id).await;
+            lock_ready(&self.ready).push(generation);
+            return self.miss(WarmMiss::RenameFailed(err.to_string()));
+        }
+
+        // Entries are restored paused; resume under the new identity.
+        let resume_provider = self.provider.clone();
+        let resume_id = sandbox_id.clone();
+        if let Err(err) = run_provider(
+            move || resume_provider.start_vm(&resume_id),
+            "warm handoff resume",
+            &sandbox_id,
+        )
+        .await
+        {
+            self.destroy_vm_best_effort(&sandbox_id).await;
+            lock_ready(&self.ready).push(generation);
+            return self.miss(WarmMiss::ResumeFailed(err.to_string()));
+        }
+
+        // The generation is spent: its identity now belongs to the claimed
+        // sandbox. Unregister the bucket (a refill racing this window would
+        // restore an entry the unregister immediately destroys — upstream
+        // WarmPool destroys orphans inserted into unregistered buckets),
+        // destroy the paused template (frees its guest memory and TAP; the
+        // snapshot artifacts die with it, which is fine — nothing restores
+        // from a spent generation), and keep the vsock CID + rootfs clone
+        // alive under the template id until the sandbox is deleted.
+        self.pool.unregister(&generation.stack_key);
+        self.destroy_vm_best_effort(&generation.template_id).await;
+        self.host
+            .release_template(&generation.template_id, &generation.identity, false)
+            .await;
+
+        self.counters.claims.fetch_add(1, Ordering::Relaxed);
+        tracing::info!(
+            sandbox_id = %request.sandbox_id,
+            template_id = %generation.template_id,
+            "firecracker warm-pool claim served (snapshot-restored VM handed off via rename)"
+        );
+
+        WarmOutcome::Claimed(WarmClaim {
+            guest_ip: generation.identity.guest_ip,
+            metadata_uds: generation.identity.metadata_uds.clone(),
+            lineage: WarmLineage {
+                template_id: generation.template_id,
+                rider_id: generation.rider_attached.then_some(generation.rider_id),
+                rootfs_cloned: generation.identity.rootfs_cloned,
+                guest_ip: generation.identity.guest_ip,
+            },
+        })
+    }
+
+    /// `None` = request matches the pooled shape.
+    fn shape_gate(&self, request: &WarmClaimRequest) -> Option<WarmMiss> {
+        if request.disk_gb != self.settings.disk_gb {
+            return Some(WarmMiss::DiskMismatch {
+                requested: request.disk_gb,
+                pooled: self.settings.disk_gb,
+            });
+        }
+        // When disk_gb == 0 the cold path boots the workspace-default rootfs
+        // regardless of `image`, so warm serves any image for parity. With a
+        // cloned template the image must name the pooled stack (or be empty
+        // and default to it).
+        if self.settings.disk_gb > 0 {
+            let pooled = self.settings.stack.clone().unwrap_or_default();
+            let requested = request.image.trim();
+            if !requested.is_empty() && requested != pooled {
+                return Some(WarmMiss::ImageMismatch {
+                    requested: requested.to_string(),
+                    pooled,
+                });
+            }
+        }
+        if request.cpu_cores != 0 && request.cpu_cores != u64::from(self.settings.vcpu_count) {
+            return Some(WarmMiss::CpuMismatch {
+                requested: request.cpu_cores,
+                pooled: self.settings.vcpu_count,
+            });
+        }
+        if request.memory_mb != 0 && request.memory_mb != u64::from(self.settings.mem_size_mib) {
+            return Some(WarmMiss::MemoryMismatch {
+                requested: request.memory_mb,
+                pooled: self.settings.mem_size_mib,
+            });
+        }
+        None
+    }
+
+    fn miss(&self, miss: WarmMiss) -> WarmOutcome {
+        self.counters.misses.fetch_add(1, Ordering::Relaxed);
+        WarmOutcome::Miss(miss)
+    }
+
+    async fn destroy_vm_best_effort(&self, vm_id: &str) {
+        let provider = self.provider.clone();
+        let id = vm_id.to_string();
+        let owner = vm_id.to_string();
+        if let Err(err) =
+            run_provider(move || provider.destroy_vm(&id), "warm destroy", &owner).await
+        {
+            tracing::warn!(vm_id = %owner, %err, "failed destroying warm-pool VM");
+        }
+    }
+}
+
+/// Provider calls shell out / do unix-socket I/O; keep them off the async
+/// runtime. Mirrors `firecracker.rs`'s spawn_blocking convention.
+async fn run_provider<F>(f: F, action: &str, vm_id: &str) -> Result<()>
+where
+    F: FnOnce() -> std::result::Result<(), microvm_runtime::error::VmRuntimeError> + Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| SandboxError::Unavailable(format!("{action} join error for {vm_id}: {e}")))?
+        .map_err(|e| SandboxError::Unavailable(format!("{action} for {vm_id}: {e}")))
+}
+
+fn lock_ready(m: &Mutex<Vec<Generation>>) -> std::sync::MutexGuard<'_, Vec<Generation>> {
+    match m.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+/// Test / e2e host that composes no network, no vsock, and no rootfs clone.
+/// The engine's lifecycle (seed → refill → claim → retire) is identical;
+/// only the identity fields are empty. Also used by the KVM-gated e2e where
+/// TAP creation would require root.
+#[cfg(test)]
+pub(crate) struct NoNetworkWarmHost {
+    /// Simulated guest-ready delay (the e2e uses a real boot-settle wait).
+    pub ready_delay: Duration,
+}
+
+#[cfg(test)]
+#[async_trait]
+impl WarmHost for NoNetworkWarmHost {
+    async fn compose_template(
+        &self,
+        _template_id: &str,
+        _disk_gb: u64,
+        _stack: Option<&str>,
+        _spec: &mut VmSpec,
+    ) -> Result<TemplateIdentity> {
+        Ok(TemplateIdentity::default())
+    }
+
+    async fn await_guest_ready(
+        &self,
+        _template_id: &str,
+        _identity: &TemplateIdentity,
+    ) -> Result<()> {
+        if !self.ready_delay.is_zero() {
+            tokio::time::sleep(self.ready_delay).await;
+        }
+        Ok(())
+    }
+
+    async fn prepare_snapshot_source(&self, _template_id: &str, _identity: &TemplateIdentity) {}
+
+    async fn attach_rider(&self, _rider_id: &str) -> Result<Option<NetworkInterface>> {
+        Ok(None)
+    }
+
+    async fn release_template(&self, _template_id: &str, _identity: &TemplateIdentity, _all: bool) {
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_settings(pool_size: usize) -> WarmSettings {
+    WarmSettings {
+        pool_size,
+        stack: None,
+        disk_gb: 0,
+        vcpu_count: 2,
+        mem_size_mib: 1024,
+        entry_max_age: Duration::from_secs(3600),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap as StdHashMap;
+    use std::time::Instant;
+
+    /// In-memory provider with full lifecycle + rename + failure injection.
+    /// `microvm_runtime::InMemoryVmProvider` lacks `rename_vm` (falls to the
+    /// trait's `Unsupported` default) and ignores specs, so the claim path
+    /// needs this richer fake.
+    #[derive(Clone, Default)]
+    struct TestProvider {
+        state: Arc<Mutex<StdHashMap<String, TestVm>>>,
+        fail_rename: Arc<Mutex<Option<String>>>,
+        fail_start_of: Arc<Mutex<Option<String>>>,
+    }
+
+    #[derive(Debug, Clone)]
+    struct TestVm {
+        status: VmStatus,
+        snapshots: Vec<String>,
+        restored_from: Option<SnapshotRef>,
+    }
+
+    impl TestProvider {
+        fn vm(&self, id: &str) -> Option<TestVm> {
+            self.state.lock().unwrap().get(id).cloned()
+        }
+
+        fn live_count(&self) -> usize {
+            self.state
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|vm| vm.status != VmStatus::Destroyed)
+                .count()
+        }
+    }
+
+    impl VmProvider for TestProvider {
+        fn create_vm(&self, vm_id: &str) -> microvm_runtime::error::VmRuntimeResult<()> {
+            self.create_vm_with_spec(vm_id, &VmSpec::default())
+        }
+
+        fn create_vm_with_spec(
+            &self,
+            vm_id: &str,
+            spec: &VmSpec,
+        ) -> microvm_runtime::error::VmRuntimeResult<()> {
+            use microvm_runtime::error::VmRuntimeError;
+            let mut state = self.state.lock().unwrap();
+            if state.contains_key(vm_id) {
+                return Err(VmRuntimeError::VmAlreadyExists(vm_id.into()));
+            }
+            // Mirror the real adapter: restoring from a missing snapshot is
+            // a typed failure, and a restored VM lands paused when
+            // `resume_immediately` is false.
+            let (status, restored_from) = match spec.restore_from.clone() {
+                Some(snap) => {
+                    let source_has_snapshot = state
+                        .get(&snap.vm_id)
+                        .map(|vm| {
+                            vm.status != VmStatus::Destroyed
+                                && vm.snapshots.iter().any(|s| s == &snap.snapshot_id)
+                        })
+                        .unwrap_or(false);
+                    if !source_has_snapshot {
+                        return Err(VmRuntimeError::SnapshotNotFound {
+                            vm_id: snap.vm_id.clone(),
+                            snapshot_id: snap.snapshot_id.clone(),
+                        });
+                    }
+                    let status = if snap.resume_immediately {
+                        VmStatus::Running
+                    } else {
+                        VmStatus::Stopped
+                    };
+                    (status, Some(snap))
+                }
+                None => (VmStatus::Created, None),
+            };
+            state.insert(
+                vm_id.into(),
+                TestVm {
+                    status,
+                    snapshots: Vec::new(),
+                    restored_from,
+                },
+            );
+            Ok(())
+        }
+
+        fn start_vm(&self, vm_id: &str) -> microvm_runtime::error::VmRuntimeResult<()> {
+            use microvm_runtime::error::VmRuntimeError;
+            if self.fail_start_of.lock().unwrap().as_deref() == Some(vm_id) {
+                return Err(VmRuntimeError::Shutdown("scripted start failure".into()));
+            }
+            let mut state = self.state.lock().unwrap();
+            let vm = state
+                .get_mut(vm_id)
+                .ok_or_else(|| VmRuntimeError::VmNotFound(vm_id.into()))?;
+            match vm.status {
+                VmStatus::Created | VmStatus::Stopped => {
+                    vm.status = VmStatus::Running;
+                    Ok(())
+                }
+                other => Err(VmRuntimeError::InvalidTransition {
+                    vm_id: vm_id.into(),
+                    from: other.to_string(),
+                    to: "running",
+                }),
+            }
+        }
+
+        fn stop_vm(&self, vm_id: &str) -> microvm_runtime::error::VmRuntimeResult<()> {
+            use microvm_runtime::error::VmRuntimeError;
+            let mut state = self.state.lock().unwrap();
+            let vm = state
+                .get_mut(vm_id)
+                .ok_or_else(|| VmRuntimeError::VmNotFound(vm_id.into()))?;
+            match vm.status {
+                VmStatus::Running => {
+                    vm.status = VmStatus::Stopped;
+                    Ok(())
+                }
+                other => Err(VmRuntimeError::InvalidTransition {
+                    vm_id: vm_id.into(),
+                    from: other.to_string(),
+                    to: "stopped",
+                }),
+            }
+        }
+
+        fn snapshot_vm(
+            &self,
+            vm_id: &str,
+            snapshot_id: &str,
+        ) -> microvm_runtime::error::VmRuntimeResult<()> {
+            use microvm_runtime::error::VmRuntimeError;
+            let mut state = self.state.lock().unwrap();
+            let vm = state
+                .get_mut(vm_id)
+                .ok_or_else(|| VmRuntimeError::VmNotFound(vm_id.into()))?;
+            if vm.status == VmStatus::Destroyed {
+                return Err(VmRuntimeError::InvalidTransition {
+                    vm_id: vm_id.into(),
+                    from: vm.status.to_string(),
+                    to: "snapshot",
+                });
+            }
+            vm.snapshots.push(snapshot_id.into());
+            Ok(())
+        }
+
+        fn destroy_vm(&self, vm_id: &str) -> microvm_runtime::error::VmRuntimeResult<()> {
+            use microvm_runtime::error::VmRuntimeError;
+            let mut state = self.state.lock().unwrap();
+            let vm = state
+                .get_mut(vm_id)
+                .ok_or_else(|| VmRuntimeError::VmNotFound(vm_id.into()))?;
+            vm.status = VmStatus::Destroyed;
+            Ok(())
+        }
+
+        fn rename_vm(
+            &self,
+            old_vm_id: &str,
+            new_vm_id: &str,
+        ) -> microvm_runtime::error::VmRuntimeResult<()> {
+            use microvm_runtime::error::VmRuntimeError;
+            if self.fail_rename.lock().unwrap().as_deref() == Some(old_vm_id) {
+                return Err(VmRuntimeError::Unsupported(
+                    "scripted rename failure".into(),
+                ));
+            }
+            let mut state = self.state.lock().unwrap();
+            if state.contains_key(new_vm_id) {
+                return Err(VmRuntimeError::VmAlreadyExists(new_vm_id.into()));
+            }
+            let vm = state
+                .remove(old_vm_id)
+                .ok_or_else(|| VmRuntimeError::VmNotFound(old_vm_id.into()))?;
+            state.insert(new_vm_id.into(), vm);
+            Ok(())
+        }
+    }
+
+    impl VmQuery for TestProvider {
+        fn list_vms(
+            &self,
+        ) -> microvm_runtime::error::VmRuntimeResult<Vec<microvm_runtime::model::VmView>> {
+            let state = self.state.lock().unwrap();
+            Ok(state
+                .iter()
+                .map(|(id, vm)| microvm_runtime::model::VmView {
+                    vm_id: id.clone(),
+                    status: vm.status,
+                    snapshots: vm.snapshots.clone(),
+                })
+                .collect())
+        }
+
+        fn get_vm(
+            &self,
+            vm_id: &str,
+        ) -> microvm_runtime::error::VmRuntimeResult<Option<microvm_runtime::model::VmView>>
+        {
+            let state = self.state.lock().unwrap();
+            Ok(state.get(vm_id).map(|vm| microvm_runtime::model::VmView {
+                vm_id: vm_id.into(),
+                status: vm.status,
+                snapshots: vm.snapshots.clone(),
+            }))
+        }
+
+        fn list_snapshots(
+            &self,
+            vm_id: &str,
+        ) -> microvm_runtime::error::VmRuntimeResult<Option<Vec<String>>> {
+            let state = self.state.lock().unwrap();
+            Ok(state.get(vm_id).map(|vm| vm.snapshots.clone()))
+        }
+    }
+
+    fn no_network_host() -> Arc<dyn WarmHost> {
+        Arc::new(NoNetworkWarmHost {
+            ready_delay: Duration::ZERO,
+        })
+    }
+
+    fn request(sandbox_id: &str) -> WarmClaimRequest {
+        WarmClaimRequest {
+            sandbox_id: sandbox_id.into(),
+            image: String::new(),
+            cpu_cores: 0,
+            memory_mb: 0,
+            disk_gb: 0,
+        }
+    }
+
+    async fn wait_for_entry<P: VmProvider + VmQuery + Clone + 'static>(serving: &WarmServing<P>) {
+        // The pool's own refill thread restores the entry asynchronously.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            if serving.pool_metrics().created_total >= 1 {
+                // created + validated: give the insert a beat to complete.
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        panic!("warm pool never restored an entry");
+    }
+
+    /// Named bug: claim path skips the rename handoff (e.g. hands back the
+    /// entry under its pool id), so the sandbox id never owns the VM.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn seed_then_claim_hands_off_via_rename_and_retires_generation() {
+        let provider = TestProvider::default();
+        let serving = Arc::new(WarmServing::new(
+            provider.clone(),
+            no_network_host(),
+            test_settings(1),
+        ));
+
+        serving.seed_generation().await.expect("seed");
+        assert_eq!(serving.ready_generations(), 1);
+        let template = provider.vm("fcwarm-g0-tpl").expect("template exists");
+        assert_eq!(
+            template.status,
+            VmStatus::Stopped,
+            "template paused post-snapshot"
+        );
+        assert_eq!(template.snapshots, vec![GOLDEN_SNAPSHOT_ID.to_string()]);
+
+        wait_for_entry(&serving).await;
+
+        let outcome = serving.claim(&request("sandbox-1")).await;
+        let claim = match outcome {
+            WarmOutcome::Claimed(c) => c,
+            WarmOutcome::Miss(m) => panic!("expected claim, got miss: {m}"),
+        };
+        assert_eq!(claim.lineage.template_id, "fcwarm-g0-tpl");
+
+        // The sandbox id owns a RUNNING VM restored from the golden
+        // snapshot; the entry's pool id no longer exists (renamed away).
+        let claimed = provider.vm("sandbox-1").expect("claimed VM exists");
+        assert_eq!(claimed.status, VmStatus::Running);
+        let restored = claimed
+            .restored_from
+            .expect("claimed VM was snapshot-restored");
+        assert_eq!(restored.vm_id, "fcwarm-g0-tpl");
+        assert_eq!(restored.snapshot_id, GOLDEN_SNAPSHOT_ID);
+
+        // Generation retired: template destroyed, bucket unregistered,
+        // nothing claimable until the next ensure_seeding pass.
+        assert_eq!(
+            provider.vm("fcwarm-g0-tpl").expect("record kept").status,
+            VmStatus::Destroyed
+        );
+        assert_eq!(serving.ready_generations(), 0);
+        match serving.claim(&request("sandbox-2")).await {
+            WarmOutcome::Miss(WarmMiss::NotReady) => {}
+            other => panic!("spent generation must not serve again: {other:?}"),
+        }
+    }
+
+    /// Named bug: the shape gate silently serves a mismatched request, so a
+    /// tenant asking for 4 GiB gets a 1 GiB pooled VM.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shape_gate_rejects_mismatches_with_typed_reasons() {
+        let provider = TestProvider::default();
+        let serving = Arc::new(WarmServing::new(
+            provider,
+            no_network_host(),
+            test_settings(1),
+        ));
+        serving.seed_generation().await.expect("seed");
+        wait_for_entry(&serving).await;
+
+        let mut req = request("sb-mem");
+        req.memory_mb = 4096;
+        assert!(matches!(
+            serving.claim(&req).await,
+            WarmOutcome::Miss(WarmMiss::MemoryMismatch {
+                requested: 4096,
+                pooled: 1024
+            })
+        ));
+
+        let mut req = request("sb-cpu");
+        req.cpu_cores = 8;
+        assert!(matches!(
+            serving.claim(&req).await,
+            WarmOutcome::Miss(WarmMiss::CpuMismatch {
+                requested: 8,
+                pooled: 2
+            })
+        ));
+
+        let mut req = request("sb-disk");
+        req.disk_gb = 20;
+        assert!(matches!(
+            serving.claim(&req).await,
+            WarmOutcome::Miss(WarmMiss::DiskMismatch {
+                requested: 20,
+                pooled: 0
+            })
+        ));
+
+        // disk_gb == 0 → image is irrelevant (cold path boots the workspace
+        // default rootfs for any image) — must still claim.
+        let mut req = request("sb-img");
+        req.image = "node-20".into();
+        assert!(matches!(serving.claim(&req).await, WarmOutcome::Claimed(_)));
+    }
+
+    /// Named bug: with a cloned template (disk_gb > 0) a request for a
+    /// different stack image is served the pooled stack's guest.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cloned_template_gates_on_image() {
+        let provider = TestProvider::default();
+        let mut settings = test_settings(1);
+        settings.disk_gb = 8;
+        settings.stack = Some("node-20".into());
+        let serving = Arc::new(WarmServing::new(provider, no_network_host(), settings));
+        serving.seed_generation().await.expect("seed");
+        wait_for_entry(&serving).await;
+
+        let mut req = request("sb-wrong-img");
+        req.disk_gb = 8;
+        req.image = "python-312".into();
+        assert!(matches!(
+            serving.claim(&req).await,
+            WarmOutcome::Miss(WarmMiss::ImageMismatch { .. })
+        ));
+
+        let mut req = request("sb-right-img");
+        req.disk_gb = 8;
+        req.image = "node-20".into();
+        assert!(matches!(serving.claim(&req).await, WarmOutcome::Claimed(_)));
+    }
+
+    /// Named bug: a failed rename consumes the generation (pool goes dark
+    /// after a transient handoff error instead of refilling and recovering).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rename_failure_returns_generation_for_refill_then_recovers() {
+        let provider = TestProvider::default();
+        let serving = Arc::new(WarmServing::new(
+            provider.clone(),
+            no_network_host(),
+            test_settings(1),
+        ));
+        serving.seed_generation().await.expect("seed");
+        wait_for_entry(&serving).await;
+
+        // Script the first entry's rename to fail.
+        let entry_id = provider
+            .state
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|(id, vm)| id.starts_with("warm-") && vm.status == VmStatus::Stopped)
+            .map(|(id, _)| id.clone())
+            .expect("pooled entry exists");
+        *provider.fail_rename.lock().unwrap() = Some(entry_id.clone());
+
+        match serving.claim(&request("sandbox-1")).await {
+            WarmOutcome::Miss(WarmMiss::RenameFailed(_)) => {}
+            other => panic!("expected RenameFailed, got {other:?}"),
+        }
+        // Failed entry destroyed, generation back in rotation.
+        assert_eq!(
+            provider.vm(&entry_id).expect("entry record").status,
+            VmStatus::Destroyed
+        );
+        assert_eq!(serving.ready_generations(), 1);
+
+        // Refill restores a replacement entry; the next claim succeeds.
+        *provider.fail_rename.lock().unwrap() = None;
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if let WarmOutcome::Claimed(_) = serving.claim(&request("sandbox-2")).await {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "pool never recovered from rename failure"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    /// Named bug: resume failure leaves a paused VM parked under the tenant
+    /// sandbox id (a dead sandbox that looks provisioned).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn resume_failure_destroys_claimed_vm_and_reports_miss() {
+        let provider = TestProvider::default();
+        let serving = Arc::new(WarmServing::new(
+            provider.clone(),
+            no_network_host(),
+            test_settings(1),
+        ));
+        serving.seed_generation().await.expect("seed");
+        wait_for_entry(&serving).await;
+
+        *provider.fail_start_of.lock().unwrap() = Some("sandbox-1".into());
+        match serving.claim(&request("sandbox-1")).await {
+            WarmOutcome::Miss(WarmMiss::ResumeFailed(_)) => {}
+            other => panic!("expected ResumeFailed, got {other:?}"),
+        }
+        assert_eq!(
+            provider.vm("sandbox-1").expect("record").status,
+            VmStatus::Destroyed,
+            "half-claimed VM must not survive under the sandbox id"
+        );
+        assert_eq!(serving.ready_generations(), 1, "generation stays claimable");
+    }
+
+    /// Named bug: ensure_seeding over-seeds past pool_size when creates race.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn ensure_seeding_caps_at_pool_size() {
+        let provider = TestProvider::default();
+        let serving = Arc::new(WarmServing::new(
+            provider.clone(),
+            no_network_host(),
+            test_settings(2),
+        ));
+        for _ in 0..8 {
+            serving.ensure_seeding();
+        }
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while serving.ready_generations() < 2 && Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert_eq!(serving.ready_generations(), 2);
+        // Templates g0 + g1 only — racing ensure_seeding calls must not
+        // have seeded extra generations.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let templates = provider
+            .state
+            .lock()
+            .unwrap()
+            .keys()
+            .filter(|id| id.ends_with("-tpl"))
+            .count();
+        assert_eq!(templates, 2);
+    }
+
+    /// The admission invariant, engine side: pool inventory lives only in
+    /// the provider — seeding N generations must not create or touch any
+    /// sandbox-store record (the engine has no store access at all; this
+    /// pins the VM-count shape so inventory stays distinguishable).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pool_inventory_is_template_plus_entry_only() {
+        let provider = TestProvider::default();
+        let serving = Arc::new(WarmServing::new(
+            provider.clone(),
+            no_network_host(),
+            test_settings(1),
+        ));
+        serving.seed_generation().await.expect("seed");
+        wait_for_entry(&serving).await;
+        // Exactly two live VMs: the paused template + the paused entry.
+        assert_eq!(provider.live_count(), 2);
+        let state = provider.state.lock().unwrap();
+        for id in state.keys() {
+            assert!(
+                id.starts_with("fcwarm-") || id.starts_with("warm-"),
+                "pool inventory must be namespaced, found {id}"
+            );
+        }
+    }
+
+    #[test]
+    fn pool_size_env_parses_and_fails_loud() {
+        let _guard = crate::TEST_ENV_GUARD
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let prior = std::env::var("SANDBOX_FC_WARM_POOL_SIZE").ok();
+
+        unsafe { std::env::remove_var("SANDBOX_FC_WARM_POOL_SIZE") };
+        assert_eq!(configured_pool_size().expect("absent = disabled"), 0);
+
+        unsafe { std::env::set_var("SANDBOX_FC_WARM_POOL_SIZE", "3") };
+        assert_eq!(configured_pool_size().expect("valid"), 3);
+
+        // Named bug: a typo'd value silently disables the pool instead of
+        // erroring — the operator believes warm serving is on.
+        unsafe { std::env::set_var("SANDBOX_FC_WARM_POOL_SIZE", "two") };
+        let err = configured_pool_size().expect_err("invalid must be a hard error");
+        assert!(matches!(err, SandboxError::Validation(_)), "got {err:?}");
+
+        match prior {
+            Some(v) => unsafe { std::env::set_var("SANDBOX_FC_WARM_POOL_SIZE", v) },
+            None => unsafe { std::env::remove_var("SANDBOX_FC_WARM_POOL_SIZE") },
+        }
+    }
+
+    // ---- KVM-gated e2e (real Firecracker) --------------------------------
+    //
+    // Follows the primitive's convention for real-VMM tests (`#[ignore]` +
+    // explicit invocation; the in-process contract tests in
+    // `tests/firecracker_in_process.rs` point at that convention). Run:
+    //
+    // ```sh
+    // FC_E2E_BIN=/usr/local/bin/firecracker-v1.12 \
+    //   cargo test -p sandbox-runtime --features test-utils --lib -- \
+    //   --ignored fc_warm_e2e --nocapture
+    // ```
+    //
+    // Requires /dev/kvm (rw), a Firecracker binary, and kernel + rootfs
+    // images (defaults below match the microvm-runtime workspace layout).
+    // No root needed: the e2e composes no TAP / jailer.
+
+    fn e2e_config(
+        tmp: &std::path::Path,
+    ) -> microvm_runtime::adapters::firecracker::FirecrackerConfig {
+        use microvm_runtime::adapters::firecracker::MemBackend;
+        let env_or =
+            |key: &str, default: &str| std::env::var(key).unwrap_or_else(|_| default.to_string());
+        let binary = env_or("FC_E2E_BIN", "/usr/local/bin/firecracker");
+        let kernel = env_or("FC_E2E_KERNEL", "/var/lib/firecracker/vmlinux");
+        let rootfs = env_or("FC_E2E_ROOTFS", "/var/lib/firecracker/rootfs/base.ext4");
+        for (what, path) in [
+            ("kvm", "/dev/kvm"),
+            ("binary", &binary),
+            ("kernel", &kernel),
+            ("rootfs", &rootfs),
+        ] {
+            assert!(
+                std::path::Path::new(path).exists(),
+                "e2e prerequisite missing: {what} at {path} (override with FC_E2E_BIN/KERNEL/ROOTFS)"
+            );
+        }
+        microvm_runtime::adapters::firecracker::FirecrackerConfig {
+            binary_path: binary.into(),
+            kernel_path: kernel.into(),
+            rootfs_path: rootfs.into(),
+            boot_args: "console=ttyS0 reboot=k panic=1 pci=off".into(),
+            socket_dir: tmp.join("sockets"),
+            state_dir: tmp.join("state"),
+            vcpu_count: 1,
+            mem_size_mib: 256,
+            rootfs_read_only: true,
+            api_timeout: Duration::from_secs(5),
+            socket_ready_timeout: Duration::from_secs(5),
+            mem_backend: MemBackend::File,
+        }
+    }
+
+    fn millis(d: Duration) -> f64 {
+        d.as_secs_f64() * 1e3
+    }
+
+    fn median(mut xs: Vec<f64>) -> f64 {
+        xs.sort_by(|a, b| a.partial_cmp(b).expect("finite"));
+        xs[xs.len() / 2]
+    }
+
+    /// Cold create→running vs warm claim (acquire → rename → resume)
+    /// against a real Firecracker, through the same engine production uses.
+    /// Prints per-iteration wall clocks; asserts the claim median beats the
+    /// cold median (the entire point of the pool).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "requires /dev/kvm, firecracker binary, kernel + rootfs images"]
+    async fn fc_warm_e2e_cold_vs_claim() {
+        use microvm_runtime::adapters::firecracker::FirecrackerVmProvider;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let provider = FirecrackerVmProvider::new(e2e_config(tmp.path()));
+        let settings = WarmSettings {
+            pool_size: 1,
+            stack: None,
+            disk_gb: 0,
+            vcpu_count: 1,
+            mem_size_mib: 256,
+            entry_max_age: Duration::from_secs(3600),
+        };
+        let serving = Arc::new(WarmServing::new(
+            provider.clone(),
+            Arc::new(NoNetworkWarmHost {
+                // Boot-settle before pausing for the golden snapshot,
+                // mirroring the primitive's own e2e.
+                ready_delay: Duration::from_secs(2),
+            }),
+            settings,
+        ));
+
+        const N: usize = 5;
+        let mut cold_ms = Vec::with_capacity(N);
+        let mut claim_ms = Vec::with_capacity(N);
+
+        for i in 0..N {
+            // Cold boot: FC process spawn + configure + InstanceStart.
+            let cold_id = format!("e2e-cold-{i}");
+            let spec = VmSpec {
+                vcpu_count: Some(1),
+                mem_size_mib: Some(256),
+                ..VmSpec::default()
+            };
+            let started = Instant::now();
+            provider
+                .create_vm_with_spec(&cold_id, &spec)
+                .expect("cold create");
+            provider.start_vm(&cold_id).expect("cold start");
+            cold_ms.push(millis(started.elapsed()));
+            provider.destroy_vm(&cold_id).expect("cold destroy");
+
+            // Warm claim: seed a generation (cold boot + snapshot, prepaid),
+            // wait for the pool's refill thread to pre-restore the entry,
+            // then measure only what a tenant create would pay.
+            serving.seed_generation().await.expect("seed");
+            wait_for_entry_nth(&serving, i as u64 + 1).await;
+            let sandbox_id = format!("e2e-claimed-{i}");
+            let started = Instant::now();
+            let outcome = serving.claim(&request(&sandbox_id)).await;
+            let elapsed = millis(started.elapsed());
+            match outcome {
+                WarmOutcome::Claimed(_) => claim_ms.push(elapsed),
+                WarmOutcome::Miss(m) => panic!("iteration {i}: expected claim, got miss: {m}"),
+            }
+            let view = provider
+                .get_vm(&sandbox_id)
+                .expect("query")
+                .expect("claimed VM exists");
+            assert_eq!(view.status, VmStatus::Running);
+            provider.destroy_vm(&sandbox_id).expect("claimed destroy");
+        }
+
+        println!("== firecracker warm-pool e2e (n={N}, 1 vCPU / 256 MiB, file mem backend) ==");
+        println!(
+            "cold create->running ms: {cold_ms:.1?} median {:.1}",
+            median(cold_ms.clone())
+        );
+        println!(
+            "warm claim (acquire+rename+resume) ms: {claim_ms:.1?} median {:.1}",
+            median(claim_ms.clone())
+        );
+        assert!(
+            median(claim_ms.clone()) < median(cold_ms.clone()),
+            "warm claim must beat cold boot (claim {:.1}ms vs cold {:.1}ms)",
+            median(claim_ms),
+            median(cold_ms)
+        );
+    }
+
+    async fn wait_for_entry_nth<P: VmProvider + VmQuery + Clone + 'static>(
+        serving: &WarmServing<P>,
+        created_total_at_least: u64,
+    ) {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while Instant::now() < deadline {
+            if serving.pool_metrics().created_total >= created_total_at_least {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("warm pool never restored entry #{created_total_at_least}");
+    }
+
+    /// Probe: can a restore bind the vsock UDS recorded in the vmstate while
+    /// the paused snapshot source still exists? Production relies on
+    /// `prepare_snapshot_source` unlinking the socket file first; this pins
+    /// that the unlink is sufficient (and documents Firecracker's raw
+    /// behavior without it). Requires /dev/vhost-vsock in addition to the
+    /// cold/claim prerequisites.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "requires /dev/kvm, /dev/vhost-vsock, firecracker binary, kernel + rootfs images"]
+    async fn fc_warm_e2e_vsock_restore_binding() {
+        use microvm_runtime::adapters::firecracker::FirecrackerVmProvider;
+        use microvm_runtime::model::VsockSpec;
+
+        assert!(
+            std::path::Path::new("/dev/vhost-vsock").exists(),
+            "e2e prerequisite missing: /dev/vhost-vsock (modprobe vhost_vsock)"
+        );
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let provider = FirecrackerVmProvider::new(e2e_config(tmp.path()));
+
+        let uds = tmp.path().join("tpl-vsock.sock");
+        let spec = VmSpec {
+            vcpu_count: Some(1),
+            mem_size_mib: Some(256),
+            vsock: Some(VsockSpec {
+                cid: 31337,
+                uds_path: uds.clone(),
+            }),
+            ..VmSpec::default()
+        };
+        provider
+            .create_vm_with_spec("vsock-tpl", &spec)
+            .expect("template create");
+        provider.start_vm("vsock-tpl").expect("template start");
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        provider.stop_vm("vsock-tpl").expect("template pause");
+        provider
+            .snapshot_vm("vsock-tpl", GOLDEN_SNAPSHOT_ID)
+            .expect("template snapshot");
+
+        let restore_spec = || VmSpec {
+            restore_from: Some(SnapshotRef {
+                vm_id: "vsock-tpl".into(),
+                snapshot_id: GOLDEN_SNAPSHOT_ID.into(),
+                resume_immediately: false,
+                network_overrides: vec![],
+            }),
+            ..VmSpec::default()
+        };
+
+        // Raw behavior: restore while the template's listener file exists.
+        let raw = provider.create_vm_with_spec("vsock-entry-raw", &restore_spec());
+        println!("restore WITH stale UDS file present: {raw:?}");
+        if raw.is_ok() {
+            provider
+                .destroy_vm("vsock-entry-raw")
+                .expect("destroy raw entry");
+        }
+
+        // Production behavior: prepare_snapshot_source unlinks the file.
+        let _ = std::fs::remove_file(&uds);
+        let prepared = provider.create_vm_with_spec("vsock-entry", &restore_spec());
+        println!("restore AFTER unlinking template UDS: {prepared:?}");
+        prepared.expect("restore must succeed once the UDS path is free");
+        provider
+            .rename_vm("vsock-entry", "vsock-claimed")
+            .expect("rename restored entry");
+        provider.start_vm("vsock-claimed").expect("resume claimed");
+
+        provider
+            .destroy_vm("vsock-claimed")
+            .expect("destroy claimed");
+        provider.destroy_vm("vsock-tpl").expect("destroy template");
+    }
+
+    #[test]
+    fn warm_miss_display_names_every_reason() {
+        let reasons = [
+            WarmMiss::Disabled,
+            WarmMiss::NotReady,
+            WarmMiss::Empty,
+            WarmMiss::DiskMismatch {
+                requested: 1,
+                pooled: 0,
+            },
+            WarmMiss::ImageMismatch {
+                requested: "a".into(),
+                pooled: "b".into(),
+            },
+            WarmMiss::CpuMismatch {
+                requested: 4,
+                pooled: 2,
+            },
+            WarmMiss::MemoryMismatch {
+                requested: 2048,
+                pooled: 1024,
+            },
+            WarmMiss::RenameFailed("x".into()),
+            WarmMiss::ResumeFailed("y".into()),
+        ];
+        for reason in reasons {
+            assert!(!reason.to_string().is_empty());
+        }
+    }
+}

--- a/sandbox-runtime/src/lib.rs
+++ b/sandbox-runtime/src/lib.rs
@@ -12,6 +12,7 @@ pub mod contracts;
 pub mod error;
 pub mod firecracker;
 mod firecracker_dnat;
+mod firecracker_warm;
 pub mod http;
 pub mod ingress_access_control;
 pub mod instance_types;

--- a/sandbox-runtime/tests/firecracker_warm_admission.rs
+++ b/sandbox-runtime/tests/firecracker_warm_admission.rs
@@ -1,0 +1,107 @@
+//! Admission-order invariant for warm-pool serving: a create rejected by
+//! admission control must NEVER touch the Firecracker warm pool — no claim,
+//! no seeding, not even engine construction. The warm claim lives inside
+//! `firecracker::create_and_start`, which the runtime layer only calls
+//! after `admit_sandbox_resources` + `enforce_sandbox_count_limit` pass;
+//! this test pins that ordering from the outside.
+//!
+//! Named bug it catches: moving the warm claim (or `ensure_seeding`) above
+//! the admission gates, which would let warm-claimed sandboxes evade
+//! `SANDBOX_MAX_COUNT` / the host memory budget — pool inventory is
+//! intentionally outside those budgets, so the *claim* being admitted is
+//! the entire accounting story.
+//!
+//! Own test binary (own process): `SidecarRuntimeConfig` is a process-global
+//! snapshot of the environment (same convention as `admission_control.rs`).
+
+#![cfg(feature = "test-utils")]
+
+use sandbox_runtime::error::SandboxError;
+use sandbox_runtime::runtime::{CreateSandboxParams, create_sidecar};
+use sandbox_runtime::tee::mock::MockTeeBackend;
+use sandbox_runtime::tee::{TeeConfig, TeeType};
+
+fn expect_unavailable(err: SandboxError, needle: &str) {
+    match err {
+        SandboxError::Unavailable(msg) => {
+            assert!(
+                msg.contains(needle),
+                "Unavailable message missing {needle:?}: {msg}"
+            );
+        }
+        other => panic!("expected SandboxError::Unavailable({needle:?}), got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rejected_create_never_touches_warm_pool() {
+    let state_dir = tempfile::tempdir().unwrap();
+    {
+        let _guard = sandbox_runtime::TEST_ENV_GUARD
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        // SAFETY: env set under the process-wide guard, before the first
+        // SidecarRuntimeConfig::load() in this process.
+        unsafe {
+            std::env::set_var("BLUEPRINT_STATE_DIR", state_dir.path());
+            std::env::set_var("SIDECAR_IMAGE", "test:latest");
+            std::env::set_var("SIDECAR_PUBLIC_HOST", "127.0.0.1");
+            std::env::set_var("SANDBOX_MAX_COUNT", "1");
+            // Warm pool nominally ON — the point of the test. Also point
+            // the FC primitive at nonexistent artifacts so any accidental
+            // seed/claim attempt fails loudly instead of booting VMs.
+            std::env::set_var("SANDBOX_FC_WARM_POOL_SIZE", "2");
+            std::env::set_var("MICROVM_FIRECRACKER_BIN", "/nonexistent/firecracker");
+            std::env::set_var("MICROVM_FIRECRACKER_KERNEL", "/nonexistent/vmlinux");
+            std::env::set_var("MICROVM_FIRECRACKER_ROOTFS", "/nonexistent/rootfs");
+        }
+    }
+
+    // Fill the single SANDBOX_MAX_COUNT slot via the mock TEE backend
+    // (needs no Docker / Firecracker). The TEE path never dispatches to
+    // firecracker::create_and_start, so the pool must stay untouched here.
+    let mock = MockTeeBackend::new(TeeType::Tdx);
+    let filler = CreateSandboxParams {
+        name: "filler".into(),
+        image: "test:latest".into(),
+        tee_config: Some(TeeConfig {
+            required: true,
+            tee_type: TeeType::Tdx,
+            attestation_nonce: None,
+        }),
+        owner: "0xwarm".into(),
+        cpu_cores: 1,
+        memory_mb: 512,
+        ..Default::default()
+    };
+    create_sidecar(&filler, Some(&mock))
+        .await
+        .expect("filler create must be admitted");
+    assert!(
+        !sandbox_runtime::firecracker::warm_pool_initialized_for_tests(),
+        "TEE create must not touch the firecracker warm pool"
+    );
+
+    // A firecracker create over the count cap must be rejected by admission
+    // BEFORE the warm pool is consulted: the engine (and its seeding) must
+    // never have been constructed.
+    let fc_request = CreateSandboxParams {
+        name: "fc-over-cap".into(),
+        image: String::new(),
+        metadata_json: r#"{"runtime_backend":"firecracker"}"#.into(),
+        owner: "0xwarm".into(),
+        cpu_cores: 1,
+        memory_mb: 512,
+        ..Default::default()
+    };
+    let err = create_sidecar(&fc_request, None)
+        .await
+        .expect_err("create over SANDBOX_MAX_COUNT must be rejected");
+    expect_unavailable(err, "Sandbox limit reached");
+
+    assert!(
+        !sandbox_runtime::firecracker::warm_pool_initialized_for_tests(),
+        "admission-rejected create must not initialize, seed, or claim from \
+         the warm pool — warm claims may only happen after admission"
+    );
+}


### PR DESCRIPTION
## What / why

Wires Firecracker warm-pool + snapshot-restore serving into the blueprint on the published `microvm-runtime 0.4.0-alpha.2` + `microvm-warm-pool 0.1.0-alpha.2` (jail-aware snapshots, `MICROVM_MEM_BACKEND=file|uffd`, `rename_vm`). A create that hits a warm generation gets a pre-restored, paused microVM via `rename_vm` + resume instead of a cold boot — **measured 32.8ms vs 111.3ms median on real FC v1.12** (below).

- `SANDBOX_FC_WARM_POOL_SIZE` (0 = disabled, default) keeps that many **generations** warm. A generation = one template VM (cold-booted on the operator's stack with its own TAP/vsock/rootfs, paused, snapshotted `golden`) + one rider TAP + a depth-1 `WarmPool` bucket holding a pre-restored paused entry. The claimed VM inherits the template's identity (guest IP baked into the snapshot memory, vsock UDS from the vmstate, rootfs backing file) and the rider TAP, so a generation serves exactly one claim; a fresh one is seeded by the next create (`ensure_seeding`, capped at pool size under racing creates).
- **Warm-miss → cold boot is the single designed fallback**, and every miss is logged with a typed reason (`Disabled`/`NotReady`/`Empty`/shape mismatches/`RenameFailed`/`ResumeFailed`). Everything else fails loud: an unparseable `SANDBOX_FC_WARM_POOL_SIZE` is a hard error, never a silent disable.
- New knobs documented in `.env.example`: `SANDBOX_FC_WARM_POOL_SIZE`, `SANDBOX_FC_WARM_MAX_AGE_SECS`, `SANDBOX_FC_WARM_DISK_GB`, `MICROVM_MEM_BACKEND` (read by the primitive; `uffd` = lazy userfaultfd restore). `firecracker.rs`'s 'Wired today' docstring updated to match.
- Warm-claim lineage (rider TAP, template vsock CID, template rootfs clone) is tracked in `VmAttachments` and released at sandbox delete; process-restart orphaning is documented, not silent.

## Admission invariant (#101)

Pool inventory (templates + pre-restored entries) never enters the sandbox store — `SANDBOX_MAX_COUNT` / `SANDBOX_HOST_MEMORY_BUDGET_MB` don't see it. **Accounting applies at claim time**: the warm claim lives inside `firecracker::create_and_start`, which the runtime layer only calls after `admit_sandbox_resources` + `enforce_sandbox_count_limit` pass under the creation permit, so a warm claim is admitted exactly like a cold boot. Operators size the memory budget knowing the pool's own footprint (~`pool_size × 2 × mem_size_mib` with the `file` backend) sits outside it — documented in the module header and `.env.example`.

`tests/firecracker_warm_admission.rs` pins the ordering from outside: with the pool nominally ON, a create rejected over `SANDBOX_MAX_COUNT=1` must never construct, seed, or claim from the pool.

**Mutation-verified:** deleting `enforce_sandbox_count_limit(...)` from `create_sidecar_firecracker` (runtime.rs) turns the test red — the over-cap create proceeds into `create_and_start`, initializes the warm engine, and fails with the wrong error (`Unavailable message missing \"Sandbox limit reached\": ensure_host ...`). Restored → green again.

## Measured numbers (real Firecracker, /dev/kvm)

KVM-gated e2e (`fc_warm_e2e_cold_vs_claim`, `#[ignore]`d, runs the production `WarmServing` engine against a real `FirecrackerVmProvider`; FC v1.12.0, 1 vCPU / 256 MiB, `file` mem backend, n=5):

| path | per-iteration ms | median |
|---|---|---|
| cold create→running | 135.2, 111.3, 109.2, 109.3, 111.9 | **111.3** |
| warm claim (acquire+rename+resume) | 33.9, 32.4, 35.4, 32.8, 29.2 | **32.8** (3.4×) |

Second e2e (`fc_warm_e2e_vsock_restore_binding`) empirically pins the `prepare_snapshot_source` design: restoring while the template's vsock UDS file exists fails (`VsockUnixBackend ... Address in use (os error 98)`); after the unlink the restore + rename + resume succeed.

**Caveat:** these e2e runs required tangle-network/microvm-runtime#25 as a local `[patch.crates-io]` (not committed). Published `0.4.0-alpha.2` has a bug that breaks *every* real-FC API call: `firecracker_request` reads responses with `read_to_end`, but Firecracker's API server (v1.6 and v1.12 measured) never closes the connection even for `Connection: close`, so every call blocks until the read timeout and `create_vm` dies with "api socket not ready". Unit/admission tests and the in-memory warm-engine tests are unaffected. Once `0.4.0-alpha.3` ships with that fix, a plain version bump makes the e2e runnable on the published crate.

## Tests

- `firecracker_warm` unit tests (in-memory provider with full lifecycle + rename + failure injection): seed→claim handoff via rename + generation retirement, shape-gate typed misses (cpu/mem/disk/image, incl. disk_gb=0 image-parity), rename-failure → generation returned + pool recovers, resume-failure → half-claimed VM destroyed, `ensure_seeding` race cap, pool-inventory namespacing, env parsing fails loud.
- `tests/firecracker_warm_admission.rs` — admission-order invariant (mutation-verified above).
- Full suite: `cargo test -p sandbox-runtime --features tee-all,test-utils --no-fail-fast` → lib 514 passed / admission_control 1 / firecracker_in_process 5 / firecracker_warm_admission 1 / ssh_e2e 1 / tee_integration 6, all green. Clippy `--all-targets` and `fmt --check` clean.
- Known flake fired: `bench_regression::resolve_bearer_stays_under_threshold_at_10k_sessions` (debug-profile timing). Proven pre-existing by baseline: fails identically on a clean `7493abf` worktree (mean 1022ns vs 930ns threshold) and alternates pass/fail on this branch with no changes to `session_auth`/`bench_regression`.