### PR TITLE
ci: enforce the module-size ratchet in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      # Pure bash + git; no toolchain needed, so it fails fast before the
+      # heavier steps. Enforces scripts/.god-object-baseline.txt (CLAUDE.md
+      # "Module Size Discipline") in CI, not only the local pre-commit hook,
+      # so a baselined file growing past its ceiling is caught on every push.
+      - name: Module-size ratchet (no god objects)
+        run: bash scripts/check-file-sizes.sh
+
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 


### PR DESCRIPTION
## Problem

The module-size ratchet (`scripts/check-file-sizes.sh`, enforcing `scripts/.god-object-baseline.txt` per CLAUDE.md 'Module Size Discipline') ran **only in the local pre-commit hook** — it appeared in zero CI workflows. So a baselined file that grew past its ceiling could merge unnoticed if the author's hook didn't fire (e.g. `firecracker.rs` grew 1156→1423 LOC and its ceiling was only corrected retroactively).

## Change

Add a **Module-size ratchet** step to the `Rustfmt` job in `ci.yml`. It runs right after checkout — pure bash + git, no toolchain — so it fails fast before the heavier protoc/rustfmt steps. Now every push is gated on the ratchet, not just local commits.

## Verification

- `bash scripts/check-file-sizes.sh` passes on current `main` (baseline is truthful after the four god-object splits #105–#108): `✓ no new or grown god objects`.
- YAML validated.