### PR TITLE
refactor(tee): split azure.rs god object into type/impl/contract modules

### DIFF
--- a/sandbox-runtime/src/tee/azure/backend.rs
+++ b/sandbox-runtime/src/tee/azure/backend.rs
@@ -1,0 +1,223 @@
+//! `TeeBackend` contract for Azure Confidential VM + SKR.
+
+use super::*;
+
+#[async_trait::async_trait]
+impl TeeBackend for AzureSkrBackend {
+    async fn deploy(&self, params: &TeeDeployParams) -> Result<TeeDeployment> {
+        let vm_name = format!("tee-sandbox-{}", params.sandbox_id);
+        let pip_name = format!("{vm_name}-pip");
+        let nic_name = format!("{vm_name}-nic");
+
+        // Create networking resources.
+        let pip_id = self.create_public_ip(&pip_name).await?;
+        let nic_id = self.create_nic(&nic_name, &pip_id).await?;
+
+        // Create the Confidential VM.
+        let token = self.arm_token().await?;
+        let vm_url = format!(
+            "{}/virtualMachines/{}?api-version={}",
+            self.compute_base_url(),
+            vm_name,
+            COMPUTE_API_VERSION
+        );
+        let body = self.build_cvm_body(params, &vm_name, &nic_id);
+
+        let resp = self
+            .http
+            .put(&vm_url)
+            .bearer_auth(&token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| SandboxError::CloudProvider(format!("Create VM: {e}")))?;
+
+        if !resp.status().is_success() {
+            let err_body = resp.text().await.unwrap_or_default();
+            // Clean up networking resources on failure.
+            let _ = self
+                .delete_network_resource(&format!(
+                    "{}/networkInterfaces/{}?api-version={}",
+                    self.network_base_url(),
+                    nic_name,
+                    NETWORK_API_VERSION
+                ))
+                .await;
+            let _ = self
+                .delete_network_resource(&format!(
+                    "{}/publicIPAddresses/{}?api-version={}",
+                    self.network_base_url(),
+                    pip_name,
+                    NETWORK_API_VERSION
+                ))
+                .await;
+            return Err(SandboxError::CloudProvider(format!(
+                "Azure VM creation failed: {err_body}"
+            )));
+        }
+
+        // Wait for VM provisioning and get public IP.
+        let public_ip = self.wait_for_running(&vm_name, &pip_name).await?;
+        let sidecar_url = format!("http://{}:{}", public_ip, params.http_port);
+
+        // Wait for sidecar health.
+        super::wait_for_sidecar_health(
+            &sidecar_url,
+            &params.sidecar_token,
+            Duration::from_secs(300),
+        )
+        .await?;
+
+        // Fetch attestation from the sidecar (which reads the vTPM + MAA).
+        let attestation =
+            super::fetch_sidecar_attestation(&sidecar_url, &params.sidecar_token).await?;
+
+        let metadata = serde_json::json!({
+            "azure_vm_name": vm_name,
+            "azure_resource_group": self.config.resource_group,
+            "azure_location": self.config.location,
+            "azure_pip_name": pip_name,
+            "azure_nic_name": nic_name,
+            "public_ip": public_ip,
+            "vm_size": self.config.vm_size,
+        });
+
+        if !params.extra_ports.is_empty() {
+            tracing::warn!("Extra ports not yet supported for Azure backend — ignored");
+        }
+
+        Ok(TeeDeployment {
+            deployment_id: vm_name,
+            sidecar_url,
+            ssh_port: params.ssh_port,
+            attestation,
+            metadata_json: metadata.to_string(),
+            extra_ports: std::collections::HashMap::new(),
+        })
+    }
+
+    async fn attestation(
+        &self,
+        deployment_id: &str,
+        _report_data: Option<[u8; 64]>,
+    ) -> Result<AttestationReport> {
+        let (sidecar_url, token) = super::sidecar_info_for_deployment(deployment_id)?;
+        super::fetch_sidecar_attestation(&sidecar_url, &token).await
+    }
+
+    async fn stop(&self, deployment_id: &str) -> Result<()> {
+        let token = self.arm_token().await?;
+        let url = format!(
+            "{}/virtualMachines/{}/deallocate?api-version={}",
+            self.compute_base_url(),
+            deployment_id,
+            COMPUTE_API_VERSION
+        );
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .map_err(|e| SandboxError::CloudProvider(format!("Deallocate VM: {e}")))?;
+
+        if !resp.status().is_success() {
+            let err_body = resp.text().await.unwrap_or_default();
+            return Err(SandboxError::CloudProvider(format!(
+                "Azure deallocate failed: {err_body}"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn destroy(&self, deployment_id: &str) -> Result<()> {
+        // Look up associated resources from metadata.
+        let (nic_name, pip_name) = {
+            let store = crate::runtime::sandboxes()?;
+            let record = store.find(|r| r.tee_deployment_id.as_deref() == Some(deployment_id))?;
+            if let Some(record) = record {
+                if let Some(ref meta_json) = record.tee_metadata_json {
+                    let meta: serde_json::Value =
+                        serde_json::from_str(meta_json).unwrap_or_default();
+                    (
+                        meta["azure_nic_name"].as_str().map(|s| s.to_string()),
+                        meta["azure_pip_name"].as_str().map(|s| s.to_string()),
+                    )
+                } else {
+                    (None, None)
+                }
+            } else {
+                (None, None)
+            }
+        };
+
+        let token = self.arm_token().await?;
+
+        // Delete the VM.
+        let vm_url = format!(
+            "{}/virtualMachines/{}?api-version={}",
+            self.compute_base_url(),
+            deployment_id,
+            COMPUTE_API_VERSION
+        );
+        let resp = self
+            .http
+            .delete(&vm_url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .map_err(|e| SandboxError::CloudProvider(format!("Delete VM: {e}")))?;
+
+        if !resp.status().is_success() {
+            let err_body = resp.text().await.unwrap_or_default();
+            return Err(SandboxError::CloudProvider(format!(
+                "Azure VM delete failed: {err_body}"
+            )));
+        }
+
+        // Wait briefly for VM deletion to propagate before cleaning up NIC/IP.
+        tokio::time::sleep(Duration::from_secs(10)).await;
+
+        // Clean up NIC.
+        if let Some(nic) = nic_name {
+            let _ = self
+                .delete_network_resource(&format!(
+                    "{}/networkInterfaces/{}?api-version={}",
+                    self.network_base_url(),
+                    nic,
+                    NETWORK_API_VERSION
+                ))
+                .await;
+        }
+
+        // Clean up public IP.
+        if let Some(pip) = pip_name {
+            let _ = self
+                .delete_network_resource(&format!(
+                    "{}/publicIPAddresses/{}?api-version={}",
+                    self.network_base_url(),
+                    pip,
+                    NETWORK_API_VERSION
+                ))
+                .await;
+        }
+
+        Ok(())
+    }
+
+    fn tee_type(&self) -> TeeType {
+        TeeType::Sev
+    }
+
+    async fn derive_public_key(&self, deployment_id: &str) -> Result<TeePublicKey> {
+        super::sidecar_derive_public_key(deployment_id).await
+    }
+
+    async fn inject_sealed_secrets(
+        &self,
+        deployment_id: &str,
+        sealed: &SealedSecret,
+    ) -> Result<SealedSecretResult> {
+        super::sidecar_inject_sealed_secrets(deployment_id, sealed).await
+    }
+}

--- a/sandbox-runtime/src/tee/azure/methods.rs
+++ b/sandbox-runtime/src/tee/azure/methods.rs
@@ -1,102 +1,6 @@
-//! Azure Confidential VM + Secure Key Release (SKR) TEE backend.
-//!
-//! Deploys sidecar containers on Azure Confidential VMs (DCasv5/ECasv5)
-//! running AMD SEV-SNP. Uses Microsoft Azure Attestation (MAA) for
-//! hardware attestation validation and Key Vault SKR for secret release.
-//!
-//! # Deploy flow
-//!
-//! 1. Create a public IP and NIC in the configured subnet.
-//! 2. Create a Confidential VM (DCasv5 or ECasv5 series, SEV-SNP) with the
-//!    sidecar pre-installed in the VM image. System-assigned managed identity
-//!    is enabled for Key Vault access.
-//! 3. The sidecar reads the SEV-SNP attestation report from the vTPM NV Index
-//!    (`0x01400001`), sends it to MAA for validation, and receives a signed JWT.
-//! 4. Key Vault SKR validates the MAA JWT and releases the wrapped key
-//!    to the TEE using the ephemeral `TpmEphemeralEncryptionKey`.
-//!
-//! # Sealed secrets
-//!
-//! The HCL (Host Compatibility Layer) generates an ephemeral RSA key pair at
-//! boot, seals the private key to the vTPM. MAA embeds the public key in
-//! `x-ms-runtime.keys`. Key Vault's `/release` endpoint validates the MAA
-//! JWT, wraps the secret to the TEE's ephemeral key. Only the TEE holding
-//! the vTPM-sealed private key can unwrap.
-//!
-//! # Authentication
-//!
-//! Uses OAuth2 client credentials flow with `AZURE_TENANT_ID`,
-//! `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET`. This avoids a dependency
-//! on `azure_identity` while supporting service principal auth.
+//! AzureSkrBackend implementation helpers (auth, network, CVM lifecycle).
 
-use std::time::Duration;
-
-use tokio::sync::RwLock;
-
-use base64::Engine;
-
-use super::sealed_secrets::{SealedSecret, SealedSecretResult, TeePublicKey};
-use super::{AttestationReport, TeeBackend, TeeDeployParams, TeeDeployment, TeeType};
-use crate::error::{Result, SandboxError};
-
-const COMPUTE_API_VERSION: &str = "2024-07-01";
-const NETWORK_API_VERSION: &str = "2023-11-01";
-
-/// Configuration for the Azure SKR backend, read from environment variables.
-#[derive(Clone, Debug)]
-pub struct AzureConfig {
-    pub subscription_id: String,
-    pub resource_group: String,
-    pub location: String,
-    pub vm_image: String,
-    pub vm_size: String,
-    pub subnet_id: String,
-    pub key_vault_url: Option<String>,
-    pub maa_endpoint: Option<String>,
-    // OAuth2 client credentials
-    pub tenant_id: String,
-    pub client_id: String,
-    pub client_secret: String,
-}
-
-impl AzureConfig {
-    /// Load configuration from environment variables.
-    ///
-    /// Required: `AZURE_SUBSCRIPTION_ID`, `AZURE_RESOURCE_GROUP`, `AZURE_LOCATION`,
-    /// `AZURE_VM_IMAGE`, `AZURE_SUBNET_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
-    /// `AZURE_CLIENT_SECRET`.
-    /// Optional: `AZURE_VM_SIZE` (default: Standard_DC4as_v5),
-    /// `AZURE_KEY_VAULT_URL`, `AZURE_MAA_ENDPOINT`.
-    pub fn from_env() -> Result<Self> {
-        Ok(Self {
-            subscription_id: require_env("AZURE_SUBSCRIPTION_ID")?,
-            resource_group: require_env("AZURE_RESOURCE_GROUP")?,
-            location: require_env("AZURE_LOCATION")?,
-            vm_image: require_env("AZURE_VM_IMAGE")?,
-            vm_size: std::env::var("AZURE_VM_SIZE")
-                .unwrap_or_else(|_| "Standard_DC4as_v5".to_string()),
-            subnet_id: require_env("AZURE_SUBNET_ID")?,
-            key_vault_url: std::env::var("AZURE_KEY_VAULT_URL").ok(),
-            maa_endpoint: std::env::var("AZURE_MAA_ENDPOINT").ok(),
-            tenant_id: require_env("AZURE_TENANT_ID")?,
-            client_id: require_env("AZURE_CLIENT_ID")?,
-            client_secret: require_env("AZURE_CLIENT_SECRET")?,
-        })
-    }
-}
-
-/// Cached OAuth2 access token.
-struct CachedToken {
-    token: String,
-    expires_at: std::time::Instant,
-}
-
-/// TEE backend that deploys containers on Azure Confidential VMs with SKR.
-pub struct AzureSkrBackend {
-    pub config: AzureConfig,
-    http: reqwest::Client,
-    token_cache: RwLock<Option<CachedToken>>,
-}
+use super::*;
 
 impl AzureSkrBackend {
     pub fn new(config: AzureConfig) -> Self {
@@ -113,7 +17,7 @@ impl AzureSkrBackend {
     /// round-trip and double-checks the cache after acquiring it, so N concurrent
     /// callers (deploy fans out many ARM calls) trigger at most one OAuth POST —
     /// the losers of the lock race observe the token the winner just cached.
-    async fn arm_token(&self) -> Result<String> {
+    pub(crate) async fn arm_token(&self) -> Result<String> {
         // Fast path: a valid cached token under a shared read lock.
         {
             let cache = self.token_cache.read().await;
@@ -185,14 +89,14 @@ impl AzureSkrBackend {
         Ok(access_token)
     }
 
-    fn compute_base_url(&self) -> String {
+    pub(crate) fn compute_base_url(&self) -> String {
         format!(
             "https://management.azure.com/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Compute",
             self.config.subscription_id, self.config.resource_group
         )
     }
 
-    fn network_base_url(&self) -> String {
+    pub(crate) fn network_base_url(&self) -> String {
         format!(
             "https://management.azure.com/subscriptions/{}/resourceGroups/{}/providers/Microsoft.Network",
             self.config.subscription_id, self.config.resource_group
@@ -200,7 +104,7 @@ impl AzureSkrBackend {
     }
 
     /// Create a public IP address for a VM.
-    async fn create_public_ip(&self, name: &str) -> Result<String> {
+    pub(crate) async fn create_public_ip(&self, name: &str) -> Result<String> {
         let token = self.arm_token().await?;
         let url = format!(
             "{}/publicIPAddresses/{}?api-version={}",
@@ -248,7 +152,7 @@ impl AzureSkrBackend {
     }
 
     /// Create a NIC attached to the configured subnet with a public IP.
-    async fn create_nic(&self, name: &str, public_ip_id: &str) -> Result<String> {
+    pub(crate) async fn create_nic(&self, name: &str, public_ip_id: &str) -> Result<String> {
         let token = self.arm_token().await?;
         let url = format!(
             "{}/networkInterfaces/{}?api-version={}",
@@ -302,7 +206,7 @@ impl AzureSkrBackend {
     }
 
     /// Build the Confidential VM creation JSON body.
-    fn build_cvm_body(
+    pub(crate) fn build_cvm_body(
         &self,
         params: &TeeDeployParams,
         vm_name: &str,
@@ -378,7 +282,7 @@ impl AzureSkrBackend {
     }
 
     /// Poll until the VM is running, then retrieve its public IP.
-    async fn wait_for_running(&self, vm_name: &str, pip_name: &str) -> Result<String> {
+    pub(crate) async fn wait_for_running(&self, vm_name: &str, pip_name: &str) -> Result<String> {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(300);
 
         // First wait for the VM to be provisioned.
@@ -456,7 +360,7 @@ impl AzureSkrBackend {
     }
 
     /// Delete a network resource (NIC or public IP) by its full ARM ID.
-    async fn delete_network_resource(&self, resource_url: &str) -> Result<()> {
+    pub(crate) async fn delete_network_resource(&self, resource_url: &str) -> Result<()> {
         let token = self.arm_token().await?;
         let _ = self
             .http
@@ -466,232 +370,4 @@ impl AzureSkrBackend {
             .await;
         Ok(())
     }
-}
-
-#[async_trait::async_trait]
-impl TeeBackend for AzureSkrBackend {
-    async fn deploy(&self, params: &TeeDeployParams) -> Result<TeeDeployment> {
-        let vm_name = format!("tee-sandbox-{}", params.sandbox_id);
-        let pip_name = format!("{vm_name}-pip");
-        let nic_name = format!("{vm_name}-nic");
-
-        // Create networking resources.
-        let pip_id = self.create_public_ip(&pip_name).await?;
-        let nic_id = self.create_nic(&nic_name, &pip_id).await?;
-
-        // Create the Confidential VM.
-        let token = self.arm_token().await?;
-        let vm_url = format!(
-            "{}/virtualMachines/{}?api-version={}",
-            self.compute_base_url(),
-            vm_name,
-            COMPUTE_API_VERSION
-        );
-        let body = self.build_cvm_body(params, &vm_name, &nic_id);
-
-        let resp = self
-            .http
-            .put(&vm_url)
-            .bearer_auth(&token)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| SandboxError::CloudProvider(format!("Create VM: {e}")))?;
-
-        if !resp.status().is_success() {
-            let err_body = resp.text().await.unwrap_or_default();
-            // Clean up networking resources on failure.
-            let _ = self
-                .delete_network_resource(&format!(
-                    "{}/networkInterfaces/{}?api-version={}",
-                    self.network_base_url(),
-                    nic_name,
-                    NETWORK_API_VERSION
-                ))
-                .await;
-            let _ = self
-                .delete_network_resource(&format!(
-                    "{}/publicIPAddresses/{}?api-version={}",
-                    self.network_base_url(),
-                    pip_name,
-                    NETWORK_API_VERSION
-                ))
-                .await;
-            return Err(SandboxError::CloudProvider(format!(
-                "Azure VM creation failed: {err_body}"
-            )));
-        }
-
-        // Wait for VM provisioning and get public IP.
-        let public_ip = self.wait_for_running(&vm_name, &pip_name).await?;
-        let sidecar_url = format!("http://{}:{}", public_ip, params.http_port);
-
-        // Wait for sidecar health.
-        super::wait_for_sidecar_health(
-            &sidecar_url,
-            &params.sidecar_token,
-            Duration::from_secs(300),
-        )
-        .await?;
-
-        // Fetch attestation from the sidecar (which reads the vTPM + MAA).
-        let attestation =
-            super::fetch_sidecar_attestation(&sidecar_url, &params.sidecar_token).await?;
-
-        let metadata = serde_json::json!({
-            "azure_vm_name": vm_name,
-            "azure_resource_group": self.config.resource_group,
-            "azure_location": self.config.location,
-            "azure_pip_name": pip_name,
-            "azure_nic_name": nic_name,
-            "public_ip": public_ip,
-            "vm_size": self.config.vm_size,
-        });
-
-        if !params.extra_ports.is_empty() {
-            tracing::warn!("Extra ports not yet supported for Azure backend — ignored");
-        }
-
-        Ok(TeeDeployment {
-            deployment_id: vm_name,
-            sidecar_url,
-            ssh_port: params.ssh_port,
-            attestation,
-            metadata_json: metadata.to_string(),
-            extra_ports: std::collections::HashMap::new(),
-        })
-    }
-
-    async fn attestation(
-        &self,
-        deployment_id: &str,
-        _report_data: Option<[u8; 64]>,
-    ) -> Result<AttestationReport> {
-        let (sidecar_url, token) = super::sidecar_info_for_deployment(deployment_id)?;
-        super::fetch_sidecar_attestation(&sidecar_url, &token).await
-    }
-
-    async fn stop(&self, deployment_id: &str) -> Result<()> {
-        let token = self.arm_token().await?;
-        let url = format!(
-            "{}/virtualMachines/{}/deallocate?api-version={}",
-            self.compute_base_url(),
-            deployment_id,
-            COMPUTE_API_VERSION
-        );
-        let resp = self
-            .http
-            .post(&url)
-            .bearer_auth(&token)
-            .send()
-            .await
-            .map_err(|e| SandboxError::CloudProvider(format!("Deallocate VM: {e}")))?;
-
-        if !resp.status().is_success() {
-            let err_body = resp.text().await.unwrap_or_default();
-            return Err(SandboxError::CloudProvider(format!(
-                "Azure deallocate failed: {err_body}"
-            )));
-        }
-        Ok(())
-    }
-
-    async fn destroy(&self, deployment_id: &str) -> Result<()> {
-        // Look up associated resources from metadata.
-        let (nic_name, pip_name) = {
-            let store = crate::runtime::sandboxes()?;
-            let record = store.find(|r| r.tee_deployment_id.as_deref() == Some(deployment_id))?;
-            if let Some(record) = record {
-                if let Some(ref meta_json) = record.tee_metadata_json {
-                    let meta: serde_json::Value =
-                        serde_json::from_str(meta_json).unwrap_or_default();
-                    (
-                        meta["azure_nic_name"].as_str().map(|s| s.to_string()),
-                        meta["azure_pip_name"].as_str().map(|s| s.to_string()),
-                    )
-                } else {
-                    (None, None)
-                }
-            } else {
-                (None, None)
-            }
-        };
-
-        let token = self.arm_token().await?;
-
-        // Delete the VM.
-        let vm_url = format!(
-            "{}/virtualMachines/{}?api-version={}",
-            self.compute_base_url(),
-            deployment_id,
-            COMPUTE_API_VERSION
-        );
-        let resp = self
-            .http
-            .delete(&vm_url)
-            .bearer_auth(&token)
-            .send()
-            .await
-            .map_err(|e| SandboxError::CloudProvider(format!("Delete VM: {e}")))?;
-
-        if !resp.status().is_success() {
-            let err_body = resp.text().await.unwrap_or_default();
-            return Err(SandboxError::CloudProvider(format!(
-                "Azure VM delete failed: {err_body}"
-            )));
-        }
-
-        // Wait briefly for VM deletion to propagate before cleaning up NIC/IP.
-        tokio::time::sleep(Duration::from_secs(10)).await;
-
-        // Clean up NIC.
-        if let Some(nic) = nic_name {
-            let _ = self
-                .delete_network_resource(&format!(
-                    "{}/networkInterfaces/{}?api-version={}",
-                    self.network_base_url(),
-                    nic,
-                    NETWORK_API_VERSION
-                ))
-                .await;
-        }
-
-        // Clean up public IP.
-        if let Some(pip) = pip_name {
-            let _ = self
-                .delete_network_resource(&format!(
-                    "{}/publicIPAddresses/{}?api-version={}",
-                    self.network_base_url(),
-                    pip,
-                    NETWORK_API_VERSION
-                ))
-                .await;
-        }
-
-        Ok(())
-    }
-
-    fn tee_type(&self) -> TeeType {
-        TeeType::Sev
-    }
-
-    async fn derive_public_key(&self, deployment_id: &str) -> Result<TeePublicKey> {
-        super::sidecar_derive_public_key(deployment_id).await
-    }
-
-    async fn inject_sealed_secrets(
-        &self,
-        deployment_id: &str,
-        sealed: &SealedSecret,
-    ) -> Result<SealedSecretResult> {
-        super::sidecar_inject_sealed_secrets(deployment_id, sealed).await
-    }
-}
-
-fn require_env(name: &str) -> Result<String> {
-    std::env::var(name).map_err(|_| {
-        SandboxError::Validation(format!(
-            "Azure SKR backend requires {name} environment variable"
-        ))
-    })
 }

--- a/sandbox-runtime/src/tee/azure/mod.rs
+++ b/sandbox-runtime/src/tee/azure/mod.rs
@@ -1,0 +1,116 @@
+//! Azure Confidential VM + Secure Key Release (SKR) TEE backend.
+//!
+//! Deploys sidecar containers on Azure Confidential VMs (DCasv5/ECasv5)
+//! running AMD SEV-SNP. Uses Microsoft Azure Attestation (MAA) for
+//! hardware attestation validation and Key Vault SKR for secret release.
+//!
+//! # Deploy flow
+//!
+//! 1. Create a public IP and NIC in the configured subnet.
+//! 2. Create a Confidential VM (DCasv5 or ECasv5 series, SEV-SNP) with the
+//!    sidecar pre-installed in the VM image. System-assigned managed identity
+//!    is enabled for Key Vault access.
+//! 3. The sidecar reads the SEV-SNP attestation report from the vTPM NV Index
+//!    (`0x01400001`), sends it to MAA for validation, and receives a signed JWT.
+//! 4. Key Vault SKR validates the MAA JWT and releases the wrapped key
+//!    to the TEE using the ephemeral `TpmEphemeralEncryptionKey`.
+//!
+//! # Sealed secrets
+//!
+//! The HCL (Host Compatibility Layer) generates an ephemeral RSA key pair at
+//! boot, seals the private key to the vTPM. MAA embeds the public key in
+//! `x-ms-runtime.keys`. Key Vault's `/release` endpoint validates the MAA
+//! JWT, wraps the secret to the TEE's ephemeral key. Only the TEE holding
+//! the vTPM-sealed private key can unwrap.
+//!
+//! # Authentication
+//!
+//! Uses OAuth2 client credentials flow with `AZURE_TENANT_ID`,
+//! `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET`. This avoids a dependency
+//! on `azure_identity` while supporting service principal auth.
+
+use std::time::Duration;
+
+use tokio::sync::RwLock;
+
+use base64::Engine;
+
+use super::sealed_secrets::{SealedSecret, SealedSecretResult, TeePublicKey};
+use super::{AttestationReport, TeeBackend, TeeDeployParams, TeeDeployment, TeeType};
+use crate::error::{Result, SandboxError};
+
+const COMPUTE_API_VERSION: &str = "2024-07-01";
+const NETWORK_API_VERSION: &str = "2023-11-01";
+
+/// Configuration for the Azure SKR backend, read from environment variables.
+#[derive(Clone, Debug)]
+pub struct AzureConfig {
+    pub subscription_id: String,
+    pub resource_group: String,
+    pub location: String,
+    pub vm_image: String,
+    pub vm_size: String,
+    pub subnet_id: String,
+    pub key_vault_url: Option<String>,
+    pub maa_endpoint: Option<String>,
+    // OAuth2 client credentials
+    pub tenant_id: String,
+    pub client_id: String,
+    pub client_secret: String,
+}
+
+impl AzureConfig {
+    /// Load configuration from environment variables.
+    ///
+    /// Required: `AZURE_SUBSCRIPTION_ID`, `AZURE_RESOURCE_GROUP`, `AZURE_LOCATION`,
+    /// `AZURE_VM_IMAGE`, `AZURE_SUBNET_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
+    /// `AZURE_CLIENT_SECRET`.
+    /// Optional: `AZURE_VM_SIZE` (default: Standard_DC4as_v5),
+    /// `AZURE_KEY_VAULT_URL`, `AZURE_MAA_ENDPOINT`.
+    pub fn from_env() -> Result<Self> {
+        Ok(Self {
+            subscription_id: require_env("AZURE_SUBSCRIPTION_ID")?,
+            resource_group: require_env("AZURE_RESOURCE_GROUP")?,
+            location: require_env("AZURE_LOCATION")?,
+            vm_image: require_env("AZURE_VM_IMAGE")?,
+            vm_size: std::env::var("AZURE_VM_SIZE")
+                .unwrap_or_else(|_| "Standard_DC4as_v5".to_string()),
+            subnet_id: require_env("AZURE_SUBNET_ID")?,
+            key_vault_url: std::env::var("AZURE_KEY_VAULT_URL").ok(),
+            maa_endpoint: std::env::var("AZURE_MAA_ENDPOINT").ok(),
+            tenant_id: require_env("AZURE_TENANT_ID")?,
+            client_id: require_env("AZURE_CLIENT_ID")?,
+            client_secret: require_env("AZURE_CLIENT_SECRET")?,
+        })
+    }
+}
+
+/// Cached OAuth2 access token.
+pub(crate) struct CachedToken {
+    token: String,
+    expires_at: std::time::Instant,
+}
+
+/// TEE backend that deploys containers on Azure Confidential VMs with SKR.
+pub struct AzureSkrBackend {
+    pub config: AzureConfig,
+    pub(crate) http: reqwest::Client,
+    pub(crate) token_cache: RwLock<Option<CachedToken>>,
+}
+
+mod backend;
+mod methods;
+
+// tee-level helpers the moved impl code reaches via `super::` (azure is now a submodule).
+pub(crate) use super::{
+    fetch_sidecar_attestation, sidecar_derive_public_key, sidecar_info_for_deployment,
+    sidecar_inject_sealed_secrets, wait_for_sidecar_health,
+};
+
+pub(crate) fn require_env(name: &str) -> Result<String> {
+    std::env::var(name).map_err(|_| {
+        SandboxError::Validation(format!(
+            "Azure SKR backend requires {name} environment variable"
+        ))
+    })
+}

--- a/scripts/.god-object-baseline.txt
+++ b/scripts/.god-object-baseline.txt
@@ -12,7 +12,6 @@
 744 sandbox-runtime/src/scoped_session_auth.rs
 721 ui/src/components/shared/SessionSidebar.tsx
 701 ui/src/lib/stores/chatSessions.ts
-697 sandbox-runtime/src/tee/azure.rs
 682 ui/src/components/shared/InfrastructureModal.tsx
 653 ai-agent-instance-blueprint-lib/src/auto_provision.rs
 627 ui/src/lib/hooks/useCreateDeploy.ts


### PR DESCRIPTION
## Problem

`sandbox-runtime/src/tee/azure.rs` was 697 LOC — the Azure Confidential VM + SKR backend, with 588 of those lines in two `AzureSkrBackend` impl blocks (inherent helpers + the `TeeBackend` trait impl).

## Change

Split `azure.rs` → `azure/`. Pure code motion, no behavior change:

| module | LOC | responsibility |
|---|---|---|
| mod.rs | 116 | `AzureConfig`, `CachedToken`, `AzureSkrBackend` struct, `require_env`, tee-helper re-exports |
| methods.rs | 373 | inherent impl: ARM token auth, public-IP / NIC / CVM creation, wait-for-running, resource teardown |
| backend.rs | 223 | `TeeBackend` trait impl (deploy / stop / destroy / attestation / key / secrets) |

The inherent helpers and the `http` / `token_cache` fields are widened to `pub(crate)` so the trait impl (now a sibling module) can reach them; the `super::`-referenced tee sidecar helpers are re-exported from `mod.rs`.

## Verification

- `cargo clippy -p sandbox-runtime --features tee-all --tests` + default `--all-targets` clean (`-D warnings`)
- `--features tee-all,test-utils`: 516 passed, 0 failed
- fmt clean; ratchet green; baseline drops only the `azure.rs` line