### PR TITLE
refactor(ui): split sandboxClient.ts god object into modules

### DIFF
--- a/scripts/.god-object-baseline.txt
+++ b/scripts/.god-object-baseline.txt
@@ -14,5 +14,4 @@
 682 ui/src/components/shared/InfrastructureModal.tsx
 653 ai-agent-instance-blueprint-lib/src/auto_provision.rs
 627 ui/src/lib/hooks/useCreateDeploy.ts
-624 ui/src/lib/api/sandboxClient.ts
 606 sandbox-runtime/src/util.rs

--- a/ui/src/lib/api/sandboxClient.ts
+++ b/ui/src/lib/api/sandboxClient.ts
@@ -9,117 +9,34 @@
  * retained for compatibility with non-browser callers and older integrations.
  */
 
-export type ClientMode = 'direct' | 'proxied';
+export type {
+  ClientMode,
+  SandboxClientConfig,
+  ChatSessionSummary,
+  ChatRunSummary,
+  ChatSessionDetail,
+  ExecResult,
+  PromptResult,
+  TaskResult,
+  ChatStreamEvent,
+  CancelChatRunResult,
+} from './sandboxClient.types';
 
-export interface SandboxClientConfig {
-  mode: ClientMode;
-  /** Direct mode: sidecar URL (e.g. http://localhost:32768) */
-  sidecarUrl?: string;
-  /** Direct mode: sidecar auth token */
-  sidecarToken?: string;
-  /** Proxied mode: operator API URL (e.g. http://localhost:9090) */
-  operatorApiUrl?: string;
-  /** Proxied mode: session PASETO token */
-  sessionToken?: string;
-  /** Proxied mode: lazily resolve a fresh session token */
-  sessionTokenProvider?: () => Promise<string | null>;
-  /** Sandbox ID for proxied mode routing */
-  sandboxId?: string;
-  /** Proxied mode: explicit resource path prefix (e.g. `/api/sandbox`) */
-  resourcePath?: string;
-}
-
-export interface ChatSessionSummary {
-  session_id: string;
-  title: string;
-  active_run_id?: string | null;
-}
-
-export interface ChatRunSummary {
-  id: string;
-  session_id: string;
-  kind: 'prompt' | 'task';
-  status: 'queued' | 'running' | 'cancelling' | 'completed' | 'failed' | 'cancelled' | 'interrupted';
-  request_text: string;
-  created_at: number;
-  started_at?: number | null;
-  completed_at?: number | null;
-  sidecar_session_id?: string | null;
-  trace_id?: string | null;
-  final_output?: string | null;
-  error?: string | null;
-}
-
-export interface ChatSessionDetail {
-  session_id: string;
-  title: string;
-  sidecar_session_id?: string | null;
-  active_run_id?: string | null;
-  messages: Array<{
-    id: string;
-    run_id?: string | null;
-    role: string;
-    content: string;
-    created_at?: number;
-    completed_at?: number | null;
-    parts?: Array<Record<string, unknown>>;
-    trace_id?: string | null;
-    success?: boolean | null;
-    error?: string | null;
-  }>;
-  run_progress?: Array<{
-    seq?: number;
-    run_id?: string | null;
-    status?: ChatRunSummary['status'] | string;
-    phase?: string;
-    message?: string;
-    timestamp_ms?: number;
-  }>;
-  runs: ChatRunSummary[];
-}
-
-export interface ExecResult {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-}
-
-export interface PromptResult {
-  accepted?: boolean;
-  response?: string;
-  runId?: string;
-  sessionId?: string;
-  status?: string;
-  acceptedAt?: number;
-}
-
-export interface TaskResult {
-  accepted?: boolean;
-  response?: string;
-  runId?: string;
-  sessionId?: string;
-  status?: string;
-  acceptedAt?: number;
-  isComplete?: boolean;
-}
+import type {
+  SandboxClientConfig,
+  ChatSessionSummary,
+  ChatSessionDetail,
+  ExecResult,
+  PromptResult,
+  TaskResult,
+  ChatStreamEvent,
+  CancelChatRunResult,
+} from './sandboxClient.types';
 
 interface OperatorErrorBody {
   error?: string;
   code?: string;
   retry_after_ms?: number;
-}
-
-export interface ChatStreamEvent {
-  type: string;
-  data: unknown;
-}
-
-export interface CancelChatRunResult {
-  success: boolean;
-  sessionId: string;
-  runId: string;
-  status: ChatRunSummary['status'] | string;
-  cancelledAt: number;
 }
 
 const CHAT_REQUEST_TIMEOUT_MS = 15_000;

--- a/ui/src/lib/api/sandboxClient.types.ts
+++ b/ui/src/lib/api/sandboxClient.types.ts
@@ -1,0 +1,112 @@
+/**
+ * Public type definitions for the unified sandbox API client.
+ *
+ * Consumers import these via `~/lib/api/sandboxClient`, which re-exports them.
+ */
+
+export type ClientMode = 'direct' | 'proxied';
+
+export interface SandboxClientConfig {
+  mode: ClientMode;
+  /** Direct mode: sidecar URL (e.g. http://localhost:32768) */
+  sidecarUrl?: string;
+  /** Direct mode: sidecar auth token */
+  sidecarToken?: string;
+  /** Proxied mode: operator API URL (e.g. http://localhost:9090) */
+  operatorApiUrl?: string;
+  /** Proxied mode: session PASETO token */
+  sessionToken?: string;
+  /** Proxied mode: lazily resolve a fresh session token */
+  sessionTokenProvider?: () => Promise<string | null>;
+  /** Sandbox ID for proxied mode routing */
+  sandboxId?: string;
+  /** Proxied mode: explicit resource path prefix (e.g. `/api/sandbox`) */
+  resourcePath?: string;
+}
+
+export interface ChatSessionSummary {
+  session_id: string;
+  title: string;
+  active_run_id?: string | null;
+}
+
+export interface ChatRunSummary {
+  id: string;
+  session_id: string;
+  kind: 'prompt' | 'task';
+  status: 'queued' | 'running' | 'cancelling' | 'completed' | 'failed' | 'cancelled' | 'interrupted';
+  request_text: string;
+  created_at: number;
+  started_at?: number | null;
+  completed_at?: number | null;
+  sidecar_session_id?: string | null;
+  trace_id?: string | null;
+  final_output?: string | null;
+  error?: string | null;
+}
+
+export interface ChatSessionDetail {
+  session_id: string;
+  title: string;
+  sidecar_session_id?: string | null;
+  active_run_id?: string | null;
+  messages: Array<{
+    id: string;
+    run_id?: string | null;
+    role: string;
+    content: string;
+    created_at?: number;
+    completed_at?: number | null;
+    parts?: Array<Record<string, unknown>>;
+    trace_id?: string | null;
+    success?: boolean | null;
+    error?: string | null;
+  }>;
+  run_progress?: Array<{
+    seq?: number;
+    run_id?: string | null;
+    status?: ChatRunSummary['status'] | string;
+    phase?: string;
+    message?: string;
+    timestamp_ms?: number;
+  }>;
+  runs: ChatRunSummary[];
+}
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface PromptResult {
+  accepted?: boolean;
+  response?: string;
+  runId?: string;
+  sessionId?: string;
+  status?: string;
+  acceptedAt?: number;
+}
+
+export interface TaskResult {
+  accepted?: boolean;
+  response?: string;
+  runId?: string;
+  sessionId?: string;
+  status?: string;
+  acceptedAt?: number;
+  isComplete?: boolean;
+}
+
+export interface ChatStreamEvent {
+  type: string;
+  data: unknown;
+}
+
+export interface CancelChatRunResult {
+  success: boolean;
+  sessionId: string;
+  runId: string;
+  status: ChatRunSummary['status'] | string;
+  cancelledAt: number;
+}


### PR DESCRIPTION
## Problem

`ui/src/lib/api/sandboxClient.ts` was 624 LOC, over the 600-LOC module-size ratchet ceiling (the last remaining `ui/` god object baselined in `scripts/.god-object-baseline.txt`).

## Change

Pure code motion, mirroring the merged `create.tsx` and `sandboxes.$id.tsx` splits. Extracted the 10 public type/interface definitions into a sibling `sandboxClient.types.ts` and re-exported them from `sandboxClient.ts`, so every consumer and the co-located test keep importing from `~/lib/api/sandboxClient` unchanged. The `SandboxClient` class, its factory functions (`createDirectClient` / `createProxiedClient` / `createProxiedInstanceClient`), the module constants, and the private `OperatorErrorBody` interface (used only by `formatApiFailure`) stay in place. No logic, control-flow, or signature changes.

### Per-file LOC

| File | Before | After |
|---|---|---|
| `ui/src/lib/api/sandboxClient.ts` | 624 | 541 |
| `ui/src/lib/api/sandboxClient.types.ts` | — | 112 (new) |

Both hand-written files are now under the 600-LOC threshold. The baseline diff drops only the `sandboxClient.ts` line and adds no new entry.

## Verification (all green locally)

- `pnpm typecheck` (react-router typegen && tsc --noEmit) → exit 0, zero errors
- `pnpm build` → client + server builds succeed
- `pnpm vitest run src/lib/api/sandboxClient.test.ts` → 13 passed, 0 failed (test unchanged)
- `scripts/check-file-sizes.sh` → "✓ module-size ratchet: no new or grown god objects"