### PR TITLE
refactor(ui): split useCreateDeploy.ts god object into modules

### DIFF
--- a/scripts/.god-object-baseline.txt
+++ b/scripts/.god-object-baseline.txt
@@ -13,5 +13,4 @@
 701 ui/src/lib/stores/chatSessions.ts
 682 ui/src/components/shared/InfrastructureModal.tsx
 653 ai-agent-instance-blueprint-lib/src/auto_provision.rs
-627 ui/src/lib/hooks/useCreateDeploy.ts
 606 sandbox-runtime/src/util.rs

--- a/ui/src/lib/hooks/createDeployChain.ts
+++ b/ui/src/lib/hooks/createDeployChain.ts
@@ -1,0 +1,49 @@
+/**
+ * On-chain resolution helpers for useCreateDeploy (instance Path B).
+ *
+ * Separated from the hook so the requestService receipt parsing and the
+ * ServiceActivated event scan live apart from the React state wiring.
+ */
+
+import { decodeEventLog } from 'viem';
+import { getAddresses, publicClient, tangleServicesAbi } from '@tangle-network/blueprint-ui';
+import type { SandboxAddresses } from '~/lib/contracts/chains';
+import { extractServiceRequestId } from '~/lib/contracts/serviceEvents';
+
+export function getRequestIdFromServiceReceiptLogs(
+  logs: Array<{ data: `0x${string}`; topics: readonly `0x${string}`[] }>,
+): number | null {
+  for (const log of logs) {
+    const requestId = extractServiceRequestId(log);
+    if (requestId != null) return requestId;
+  }
+
+  return null;
+}
+
+export async function resolveActivatedServiceId(requestId: number): Promise<string | null> {
+  const addrs = getAddresses<SandboxAddresses>();
+  const logs = await publicClient.getLogs({
+    address: addrs.services,
+    fromBlock: 0n,
+    toBlock: 'latest',
+  });
+
+  for (const log of logs) {
+    try {
+      const decoded = decodeEventLog({
+        abi: tangleServicesAbi,
+        data: log.data,
+        topics: [...log.topics] as [] | [`0x${string}`, ...`0x${string}`[]],
+      });
+      if (decoded.eventName !== 'ServiceActivated') continue;
+      if (!('requestId' in decoded.args) || !('serviceId' in decoded.args)) continue;
+      if (Number(decoded.args.requestId) !== requestId) continue;
+      return String(decoded.args.serviceId);
+    } catch {
+      // Ignore unrelated logs while scanning the chain.
+    }
+  }
+
+  return null;
+}

--- a/ui/src/lib/hooks/useCreateDeploy.ts
+++ b/ui/src/lib/hooks/useCreateDeploy.ts
@@ -42,8 +42,8 @@ import { isContractDeployed, type SandboxAddresses } from '~/lib/contracts/chain
 import type { InfraConfig } from '@tangle-network/blueprint-ui';
 import type { Address } from 'viem';
 import { expectedLocalRpcUrl, walletRpcMatchesAppRpc } from '~/lib/walletRpcSync';
-import { extractServiceRequestId } from '~/lib/contracts/serviceEvents';
 import { useReliableOperators } from './useReliableOperators';
+import { getRequestIdFromServiceReceiptLogs, resolveActivatedServiceId } from './createDeployChain';
 
 // Re-export types from logic module for external consumers
 export type { DeployMode, DeployStatus, JobSubmitStatus } from './createDeployLogic';
@@ -82,44 +82,6 @@ interface UseCreateDeployOpts {
 /** ~30 days at 3s blocks */
 const TTL_BLOCKS_30_DAYS = 864000n;
 const useSafeLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
-
-function getRequestIdFromServiceReceiptLogs(
-  logs: Array<{ data: `0x${string}`; topics: readonly `0x${string}`[] }>,
-): number | null {
-  for (const log of logs) {
-    const requestId = extractServiceRequestId(log);
-    if (requestId != null) return requestId;
-  }
-
-  return null;
-}
-
-async function resolveActivatedServiceId(requestId: number): Promise<string | null> {
-  const addrs = getAddresses<SandboxAddresses>();
-  const logs = await publicClient.getLogs({
-    address: addrs.services,
-    fromBlock: 0n,
-    toBlock: 'latest',
-  });
-
-  for (const log of logs) {
-    try {
-      const decoded = decodeEventLog({
-        abi: tangleServicesAbi,
-        data: log.data,
-        topics: [...log.topics] as [] | [`0x${string}`, ...`0x${string}`[]],
-      });
-      if (decoded.eventName !== 'ServiceActivated') continue;
-      if (!('requestId' in decoded.args) || !('serviceId' in decoded.args)) continue;
-      if (Number(decoded.args.requestId) !== requestId) continue;
-      return String(decoded.args.serviceId);
-    } catch {
-      // Ignore unrelated logs while scanning the chain.
-    }
-  }
-
-  return null;
-}
 
 // ── Hook ──
 


### PR DESCRIPTION
## Problem
`ui/src/lib/hooks/useCreateDeploy.ts` was a 627-LOC god object, over the 600-LOC module-size ratchet ceiling.

## Change
Pure code motion — extracted the two non-React on-chain resolution helpers (`getRequestIdFromServiceReceiptLogs`, `resolveActivatedServiceId`) into a sibling `createDeployChain.ts`. These scan the `requestService` receipt logs and the `ServiceActivated` events; they carry no React state, so they belong apart from the hook. Bodies moved verbatim — only import/export lines changed. The now-unused `extractServiceRequestId` import was dropped from the hook (it moved with its only caller).

No logic, JSX, or hook-order changes. No renames, no reformatting.

## Per-file LOC
| File | Before | After |
|---|---|---|
| `ui/src/lib/hooks/useCreateDeploy.ts` | 627 | 589 |
| `ui/src/lib/hooks/createDeployChain.ts` (new) | — | 49 |

Both under the 600-LOC ceiling; `useCreateDeploy.ts` drops off the god-object baseline entirely.

## Verification (all green locally)
- `cd ui && pnpm typecheck` (react-router typegen && tsc --noEmit) → exit 0
- `cd ui && pnpm build` → client + server builds succeed
- `cd ui && pnpm vitest run src/lib/hooks/useCreateDeploy.test.ts` → 36 passed, 0 failed (test unmodified; imports only `createDeployLogic`)
- `bash scripts/check-file-sizes.sh` → "✓ module-size ratchet: no new or grown god objects"; baseline diff drops only the `useCreateDeploy.ts` line, adds no new >600 file