### PR TITLE
fix(workflows): legacy workflows authenticate with the spec sidecar_token

### DIFF
--- a/ai-agent-sandbox-blueprint-lib/src/workflows/mod.rs
+++ b/ai-agent-sandbox-blueprint-lib/src/workflows/mod.rs
@@ -9,7 +9,6 @@ use std::sync::Mutex;
 use crate::SandboxTaskRequest;
 use crate::auth::require_sidecar_token;
 use crate::jobs::exec::run_task_request_with_profile;
-use crate::runtime::require_sidecar_auth;
 use crate::store::PersistentStore;
 use crate::util::now_ts;
 

--- a/ai-agent-sandbox-blueprint-lib/src/workflows/run.rs
+++ b/ai-agent-sandbox-blueprint-lib/src/workflows/run.rs
@@ -15,14 +15,17 @@ pub async fn run_workflow(entry: &WorkflowEntry) -> Result<WorkflowExecution, St
         ));
     }
 
-    // Look up token from sandbox record. Falls back to spec.sidecar_token for
-    // backward compat with workflows created before 2-phase provisioning.
-    let token = record.token.clone();
-    if token.is_empty() {
-        // Legacy path: use token from workflow spec
-        let token_fallback = require_sidecar_token(spec.sidecar_token.as_deref().unwrap_or(""))?;
-        let _record = require_sidecar_auth(&record.sidecar_url, &token_fallback)?;
-    }
+    // Auth token for the sidecar request. Legacy workflows (created before
+    // 2-phase provisioning) stored no token on the sandbox record; fall back to
+    // the workflow spec's sidecar_token. There is no stored token to compare it
+    // against for those sandboxes, so it is passed through and the sidecar
+    // authenticates it on the request itself. `require_sidecar_token` still
+    // rejects an empty/blank fallback.
+    let token = if record.token.is_empty() {
+        require_sidecar_token(spec.sidecar_token.as_deref().unwrap_or(""))?
+    } else {
+        record.token.clone()
+    };
 
     // Session-per-tick: each execution gets a unique session so messages don't
     // accumulate in a single session forever. The stored session_id acts as a

--- a/ai-agent-sandbox-blueprint-lib/tests/integration.rs
+++ b/ai-agent-sandbox-blueprint-lib/tests/integration.rs
@@ -1085,6 +1085,55 @@ mod workflow_jobs {
 
     #[tokio::test]
     #[serial]
+    async fn legacy_workflow_with_empty_record_token_uses_spec_sidecar_token() {
+        // Regression: a sandbox provisioned before 2-phase provisioning stores
+        // no token on its record. run_workflow must fall back to the workflow
+        // spec's sidecar_token and authenticate the request with it. Before the
+        // fix the legacy branch validated the fallback but discarded it (the
+        // request went out with an empty token) and, worse, pre-checked it
+        // against the empty stored token via ct_eq — which always failed — so
+        // legacy workflows could never run.
+        reset_workflows();
+        let srv = MockServer::start().await;
+        // Record token is EMPTY (legacy sandbox).
+        let sid = insert_sandbox(&srv.uri(), "");
+
+        // The request must carry the spec's sidecar_token as the bearer.
+        Mock::given(method("POST"))
+            .and(path("/agents/run"))
+            .and(header("Authorization", "Bearer spec-tok"))
+            .respond_with(mock_agent_ok("legacy-ok"))
+            .expect(1)
+            .mount(&srv)
+            .await;
+
+        let entry = WorkflowEntry {
+            id: 90013,
+            name: "wf-legacy-tok".to_string(),
+            workflow_json: format!(
+                r#"{{"sidecar_url":"{}","prompt":"run","sidecar_token":"spec-tok"}}"#,
+                srv.uri()
+            ),
+            trigger_type: "manual".to_string(),
+            trigger_config: String::new(),
+            sandbox_config_json: "{}".to_string(),
+            target_kind: 0,
+            target_sandbox_id: sid.clone(),
+            target_service_id: 1,
+            active: true,
+            next_run_at: None,
+            last_run_at: None,
+            owner: String::new(),
+        };
+
+        let exec = run_workflow(&entry).await.unwrap();
+        assert!(exec.response["task"]["success"].as_bool().unwrap());
+
+        rm(&sid);
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn run_workflow_uses_record_token() {
         reset_workflows();
         let srv = MockServer::start().await;


### PR DESCRIPTION
## Problem

Workflows targeting a sandbox provisioned **before 2-phase provisioning** (so `record.token` is empty) could never run. The legacy branch in `run_workflow`:

```rust
let token = record.token.clone();          // empty
if token.is_empty() {
    let token_fallback = require_sidecar_token(spec.sidecar_token…)?;  // validated…
    let _record = require_sidecar_auth(&record.sidecar_url, &token_fallback)?;  // …then discarded
}
run_task_request_with_profile(&request, &token, …)  // request uses the EMPTY token
```

Two compounding defects: (1) `token_fallback` is validated but never assigned back to `token`, so the request goes out unauthenticated; (2) `require_sidecar_auth` does `ct_eq(record.token, token_fallback)` — comparing the fallback against the **empty** stored token — which **always** returns `Err("Unauthorized sidecar_token")`, so the branch never even reaches the request. The legacy path was dead.

Surfaced by the multi-shot reviewer on #125; it is pre-existing on `main` (that PR was pure code motion), so it is fixed here separately.

## Fix

Use the validated `spec.sidecar_token` as the request token when the record has none:

```rust
let token = if record.token.is_empty() {
    require_sidecar_token(spec.sidecar_token.as_deref().unwrap_or(""))?
} else {
    record.token.clone()
};
```

For a legacy sandbox there is no stored token to compare against, so the fallback is passed through and the **sidecar authenticates it end-to-end** on the actual request. `require_sidecar_token` still rejects an empty/blank fallback. The non-legacy path (record.token set) is unchanged. The now-unused `require_sidecar_auth` import is removed.

## Verification

- **Mutation-verified** regression test `legacy_workflow_with_empty_record_token_uses_spec_sidecar_token`: **fails on the old code** with `Err("Unauthorized sidecar_token")`, **passes with the fix**. A wiremock server requires `Authorization: Bearer spec-tok`, proving the spec token is what authenticates.
- `cargo fmt --check` clean; `cargo clippy -p ai-agent-sandbox-blueprint-lib --all-targets` + workspace `--tests --examples` clean (`-D warnings`)
- full crate suite: 121 passed, 0 failed