### PR TITLE
fix(bsm): migrate AgentSandboxBlueprint to tnt-core 0.19 onJobResult ABI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,13 @@ jobs:
         #   (pinned by blueprint-networking@alpha.15 in tangle-network/blueprint).
         #   Exposure is local-network mDNS only; real fix requires upstream
         #   libp2p bump. Re-evaluate when blueprint-networking ships libp2p ≥ 0.55.
+        # RUSTSEC-2026-0118: hickory-proto 0.25.x NSEC3 closest-encloser unbounded loop.
+        #   Pulled in transitively once the tnt-core 0.19 blueprint-sdk graph moved
+        #   hickory-proto 0.24.4 -> 0.25.2. Only patched in the 0.26.0-beta.1 pre-release,
+        #   which this repo does not (and should not) force across the SDK graph; the
+        #   affected code is a DNS resolver's NSEC3 validation path, not on the
+        #   blueprint operator/ABI path. Re-evaluate when the SDK graph ships
+        #   hickory-proto ≥ 0.26 stable.
         run: >
           cargo audit
           --ignore RUSTSEC-2023-0071
@@ -212,6 +219,7 @@ jobs:
           --ignore RUSTSEC-2026-0098
           --ignore RUSTSEC-2026-0099
           --ignore RUSTSEC-2026-0104
+          --ignore RUSTSEC-2026-0118
           --ignore RUSTSEC-2026-0119
 
   e2e:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru 0.16.4",
+ "lru",
  "parking_lot",
  "pin-project",
  "reqwest 0.13.4",
@@ -1652,27 +1652,11 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive 0.5.1",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
- "asn1-rs-derive 0.6.0",
+ "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -1680,18 +1664,6 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
- "synstructure",
 ]
 
 [[package]]
@@ -1731,6 +1703,18 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1816,11 +1800,12 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attohttpc"
-version = "0.24.1"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "http 0.2.12",
+ "base64 0.22.1",
+ "http 1.4.2",
  "log",
  "url",
 ]
@@ -2679,8 +2664,7 @@ dependencies = [
 [[package]]
 name = "blueprint-anvil-testing-utils"
 version = "0.2.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9749b6f02151f379e449f5c645f857495b9974ae84ccf31c4614d16334b104da"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips 2.1.0",
@@ -2711,15 +2695,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tonic 0.13.1",
+ "tonic",
  "url",
 ]
 
 [[package]]
 name = "blueprint-auth"
 version = "0.2.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8eeddb257a5555389548d957e75cfadc630aca8cfe7109f6d4a3e4a2b4fe2a"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2764,8 +2747,7 @@ dependencies = [
 [[package]]
 name = "blueprint-chain-setup"
 version = "0.2.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77cb8c71b4cc2fb6932bc767b12187092eaa7fb4db813fbac20b8d993b852421"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "blueprint-chain-setup-anvil",
 ]
@@ -2773,8 +2755,7 @@ dependencies = [
 [[package]]
 name = "blueprint-chain-setup-anvil"
 version = "0.2.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1254f7746fe35c016ec52e7200734c9e61295859b77302131c4a1c1ed7e64ef4"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "alloy-contract",
  "alloy-provider",
@@ -2796,8 +2777,7 @@ dependencies = [
 [[package]]
 name = "blueprint-client-core"
 version = "0.2.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a05f977a62d6562f98f43e05dc5a7a7c3f57270b6ade9662721135947c8dd3"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "auto_impl",
  "blueprint-std",
@@ -2807,8 +2787,7 @@ dependencies = [
 [[package]]
 name = "blueprint-client-eigenlayer"
 version = "0.2.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d036080f26c6de904044dcb9c6f02752fe7f6432f66761112211f82711db34ce"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -2831,8 +2810,7 @@ dependencies = [
 [[package]]
 name = "blueprint-client-evm"
 version = "0.2.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc1126fc7bf1813f070030be1b592d15ad0ebfb873a5a6401a22652111b8a97"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc 1.8.3",
@@ -2859,8 +2837,7 @@ dependencies = [
 [[package]]
 name = "blueprint-client-tangle"
 version = "0.2.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10bb3030d9056e9924a596ed2bbfc054373dbc1737e430db49bf22fdaca6d135"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -2891,8 +2868,7 @@ dependencies = [
 [[package]]
 name = "blueprint-clients"
 version = "0.2.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d3a7460aa5ea36a92b8cf2426af66abbb49b5c384b4ad0f23dad6e25197"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "blueprint-client-core",
  "blueprint-client-eigenlayer",
@@ -2905,8 +2881,7 @@ dependencies = [
 [[package]]
 name = "blueprint-context-derive"
 version = "0.2.0-alpha.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c661d1281230aab9b9f4f18233c1654a7b0c486372f541710760c3aa90e0234b"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2916,8 +2891,7 @@ dependencies = [
 [[package]]
 name = "blueprint-contexts"
 version = "0.2.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca50fd0cedf85f4943b6f24911ce4fff2ad99e203e33f92c503ab04116bf394"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "blueprint-client-tangle",
  "blueprint-clients",
@@ -2930,8 +2904,7 @@ dependencies = [
 [[package]]
 name = "blueprint-core"
 version = "0.2.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30eabeda84517952417cc6244eb8851ae995aa97e49d905e253480f4d1b583b9"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2945,8 +2918,7 @@ dependencies = [
 [[package]]
 name = "blueprint-core-testing-utils"
 version = "0.2.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dc40b65fef215dda209df3ccd0858ac5ce54a3d8f630b10e594a920896be6"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "blueprint-auth",
  "blueprint-clients",
@@ -2966,8 +2938,7 @@ dependencies = [
 [[package]]
 name = "blueprint-crypto"
 version = "0.2.0-alpha.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6638da7a40fd99bfd9ebebaccc32b454dd3458e979383f4ad21e81891706da9c"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "blueprint-crypto-bls",
  "blueprint-crypto-bn254",
@@ -2982,8 +2953,7 @@ dependencies = [
 [[package]]
 name = "blueprint-crypto-bls"
 version = "0.2.0-alpha.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "376b0802ce4e8be9f84beaf6b786baeafa069c2e967be7e4313756ba448d7e14"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "ark-serialize 0.5.0",
  "blueprint-crypto-core",
@@ -3000,8 +2970,7 @@ dependencies = [
 [[package]]
 name = "blueprint-crypto-bn254"
 version = "0.2.0-alpha.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37710fc573b2969a26528b81753cd5bdf571a7c42cd6d151c16c3ffe2f32f08f"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "ark-bn254 0.6.0",
  "ark-ec 0.6.0",
@@ -3022,8 +2991,7 @@ dependencies = [
 [[package]]
 name = "blueprint-crypto-core"
 version = "0.2.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5160379ef89e4e19d96a1001686e0fd5f8b0cbc27c0359b4a46e984a8e535fd"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "blueprint-std",
  "clap",
@@ -3034,8 +3002,7 @@ dependencies = [
 [[package]]
 name = "blueprint-crypto-ed25519"
 version = "0.2.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcac3471225743a143cc579df426f0c48bb03380f6883b59774362285f6d61d1"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "blueprint-crypto-core",
  "blueprint-std",
@@ -3050,8 +3017,7 @@ dependencies = [
 [[package]]
 name = "blueprint-crypto-hashing"
 version = "0.2.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b65a769abbdbf4e5c8e5e930b1e0e2eabe37166d9ec1266af0500c6974e67f7"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "argon2",
  "blake3",
@@ -3064,8 +3030,7 @@ dependencies = [
 [[package]]
 name = "blueprint-crypto-k256"
 version = "0.2.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "594b17edade99a474816ddf64ff25f0a4acebf6c9e052c250ebacc4044e6fe69"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -3082,8 +3047,7 @@ dependencies = [
 [[package]]
 name = "blueprint-crypto-sr25519"
 version = "0.2.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f26008b65a37ae64545fa04272bce1bcc72385756956b248fa309bd8e22ac1"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "blueprint-crypto-core",
  "blueprint-std",
@@ -3098,8 +3062,7 @@ dependencies = [
 [[package]]
 name = "blueprint-eigenlayer-extra"
 version = "0.2.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06e07a1a190c25fb2c0868caf079daee680b633972846b7f5a6e67e3981b2ba"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -3132,8 +3095,7 @@ dependencies = [
 [[package]]
 name = "blueprint-evm-extra"
 version = "0.2.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02cda95444764512da67024df661ebad86b76ea0838d14ca9bf2ebe3eaf03c6"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -3164,8 +3126,7 @@ dependencies = [
 [[package]]
 name = "blueprint-keystore"
 version = "0.2.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dbb8e32c60d341fe65d3b1779ac57852258f055558c29441161f773e682502"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -3198,8 +3159,7 @@ dependencies = [
 [[package]]
 name = "blueprint-macros"
 version = "0.2.0-alpha.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9feb72af12895fe3fc93dbe64c2953ef79c2d214ac3442b115aed3bee0932ff5"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3209,8 +3169,7 @@ dependencies = [
 [[package]]
 name = "blueprint-manager-bridge"
 version = "0.2.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c869051d1974e9cf871eba3532ffbcef837df56cce5010ed3f032c1ad5cf4360"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "blueprint-auth",
  "blueprint-core",
@@ -3220,7 +3179,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-vsock",
- "tonic 0.13.1",
+ "tonic",
  "tonic-build",
  "tower",
  "zerocopy",
@@ -3229,8 +3188,7 @@ dependencies = [
 [[package]]
 name = "blueprint-metrics-rpc-calls"
 version = "0.2.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc08f2c5e7a60a5e448eeba4d2fcc513d271aff108d4a8b3fb2c2d7e8a55581"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "metrics",
 ]
@@ -3238,8 +3196,7 @@ dependencies = [
 [[package]]
 name = "blueprint-networking"
 version = "0.2.0-alpha.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09123644a13075e455bd038bed7b6efbdf0c993cd495bace3f06be93cc99d1da"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "alloy-primitives",
  "bincode",
@@ -3264,8 +3221,7 @@ dependencies = [
 [[package]]
 name = "blueprint-producers-extra"
 version = "0.2.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9146bd6edc8a990448e71eb36c1966aea56a79b12b0b1e004d85bdaff3b14910"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "blueprint-core",
  "chrono",
@@ -3278,8 +3234,7 @@ dependencies = [
 [[package]]
 name = "blueprint-qos"
 version = "0.2.0-alpha.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517ac86d4ffb910573fe4ebf54e28ad82f6482a7874bdfc9f6747418debfe136"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -3297,13 +3252,11 @@ dependencies = [
  "bollard",
  "futures",
  "k256",
- "opentelemetry 0.29.1",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-prometheus",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.29.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "prometheus",
  "prost 0.13.5",
  "rand 0.8.6",
@@ -3315,7 +3268,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tnt-core-bindings",
  "tokio",
- "tonic 0.13.1",
+ "tonic",
  "tonic-build",
  "tracing",
  "tracing-loki",
@@ -3327,8 +3280,7 @@ dependencies = [
 [[package]]
 name = "blueprint-router"
 version = "0.2.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75e90a66fe2980e6c7e6c62a9c1f570cadbee9e72ff807d51a64fb3e07a3c37"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "blueprint-core",
  "bytes",
@@ -3342,8 +3294,7 @@ dependencies = [
 [[package]]
 name = "blueprint-runner"
 version = "0.2.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9867a491ce9df024b0acb406e487dbfc7c6e025e5f119bb39ae0279d3c33436"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -3380,8 +3331,7 @@ dependencies = [
 [[package]]
 name = "blueprint-sdk"
 version = "0.2.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca89cf54ee12ab0411d6f3c151a2c9f2247821dcf0e13f65605f1a08c1698db"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "alloy",
  "blueprint-auth",
@@ -3413,8 +3363,7 @@ dependencies = [
 [[package]]
 name = "blueprint-std"
 version = "0.2.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93037d00e33e4b0669ce2a1b73135722dc0bb7818c0094c470ae988723ee12e3"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "colored",
  "num-traits",
@@ -3425,8 +3374,7 @@ dependencies = [
 [[package]]
 name = "blueprint-store-local-database"
 version = "0.2.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf9c6546c83268af7a8bad6d545aa492d9247c57ea9e8d4999237bd3688cb64"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "blueprint-std",
  "serde",
@@ -3437,8 +3385,7 @@ dependencies = [
 [[package]]
 name = "blueprint-stores"
 version = "0.2.0-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b533d63312e5e890c6dd06ce93e2834d072fd491245e5658d8ee63952aab34eb"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "blueprint-store-local-database",
  "document-features",
@@ -3448,8 +3395,7 @@ dependencies = [
 [[package]]
 name = "blueprint-tangle-extra"
 version = "0.2.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f9c934312e83d7e387d9805532d56d671844cce928bc338bd828a59231b8da"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -3473,8 +3419,7 @@ dependencies = [
 [[package]]
 name = "blueprint-testing-utils"
 version = "0.2.0-alpha.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b024c9de41da8f0f284364fe61542bcaa179c0f6cbc19d0f28986a9b73cee3"
+source = "git+https://github.com/tangle-network/blueprint.git?rev=5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c#5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c"
 dependencies = [
  "blueprint-anvil-testing-utils",
  "blueprint-core-testing-utils",
@@ -4122,6 +4067,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "cron"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4336,7 +4287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4382,7 +4333,7 @@ dependencies = [
  "ed25519-dalek",
  "p256",
  "p384",
- "ring 0.17.14",
+ "ring",
  "rsa",
  "rustls-pki-types",
  "sha2 0.10.9",
@@ -4423,25 +4374,11 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
-dependencies = [
- "asn1-rs 0.6.2",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs 0.7.2",
+ "asn1-rs",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -5087,6 +5024,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5094,6 +5052,18 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
 ]
 
 [[package]]
@@ -5343,17 +5313,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
-name = "futures-ticker"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9763058047f713632a52e916cc7f6a4b3fc6e9fc1ff8c5b1dc49e5a89041682e"
-dependencies = [
- "futures",
- "futures-timer",
- "instant",
-]
-
-[[package]]
 name = "futures-timer"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5397,7 +5356,7 @@ dependencies = [
  "hyper 1.10.1",
  "hyper-rustls 0.27.9",
  "hyper-util",
- "ring 0.17.14",
+ "ring",
  "rustls 0.23.41",
  "rustls-pki-types",
  "serde",
@@ -5562,6 +5521,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -5570,7 +5532,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -5595,6 +5556,24 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5644,9 +5623,9 @@ checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.4"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -5658,9 +5637,10 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.9.4",
+ "ring",
  "socket2 0.5.10",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -5669,21 +5649,21 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.4"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-proto",
  "ipconfig",
- "lru-cache",
+ "moka",
  "once_cell",
  "parking_lot",
- "rand 0.8.6",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -5987,7 +5967,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6143,18 +6123,20 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.14.3"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
+checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
 dependencies = [
  "async-trait",
  "attohttpc",
  "bytes",
  "futures",
- "http 0.2.12",
- "hyper 0.14.32",
+ "http 1.4.2",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
  "log",
- "rand 0.8.6",
+ "rand 0.9.4",
  "tokio",
  "url",
  "xmltree",
@@ -6216,15 +6198,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -6389,15 +6362,17 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64 0.22.1",
+ "getrandom 0.2.17",
  "js-sys",
- "ring 0.17.14",
  "serde",
  "serde_json",
+ "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -6465,7 +6440,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -6498,9 +6473,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libp2p"
-version = "0.54.1"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbe80f9c7e00526cd6b838075b9c171919404a4732cb2fa8ece0a093223bfc4"
+checksum = "ce71348bf5838e46449ae240631117b487073d5f347c06d434caddcb91dceb5a"
 dependencies = [
  "bytes",
  "either",
@@ -6531,30 +6506,28 @@ dependencies = [
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041"
+checksum = "d16ccf824ee859ca83df301e1c0205270206223fd4b1f2e512a693e1912a8f4a"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "void",
 ]
 
 [[package]]
 name = "libp2p-autonat"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a083675f189803d0682a2726131628e808144911dad076858bfbe30b13065499"
+checksum = "fab5e25c49a7d48dac83d95d8f3bac0a290d8a5df717012f6e34ce9886396c0b"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
- "bytes",
  "either",
  "futures",
  "futures-bounded",
@@ -6567,29 +6540,27 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.6",
  "rand_core 0.6.4",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d003540ee8baef0d254f7b6bfd79bac3ddf774662ca0abf69186d517ef82ad8"
+checksum = "a18b8b607cf3bfa2f8c57db9c7d8569a315d5cc0a282e6bfd5ebfc0a9840b2a0"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "void",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.42.0"
+version = "0.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61f26c83ed111104cd820fe9bc3aaabbac5f1652a1d213ed6e900b7918a1298"
+checksum = "249128cd37a2199aff30a7675dffa51caf073b51aa612d2f544b19932b9aebca"
 dependencies = [
  "either",
  "fnv",
@@ -6599,49 +6570,44 @@ dependencies = [
  "multiaddr",
  "multihash",
  "multistream-select",
- "once_cell",
  "parking_lot",
  "pin-project",
  "quick-protobuf",
  "rand 0.8.6",
  "rw-stream-sink",
- "serde",
- "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "unsigned-varint 0.8.0",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-dcutr"
-version = "0.12.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3236a2e24cbcf2d05b398b003ed920e1e8cedede13784d90fa3961b109647ce0"
+checksum = "2b4107305e12158af3e66960b6181789c547394c9c9a8696f721521602bfc73a"
 dependencies = [
  "asynchronous-codec",
  "either",
  "futures",
  "futures-bounded",
  "futures-timer",
+ "hashlink 0.10.0",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "lru 0.12.5",
  "quick-protobuf",
  "quick-protobuf-codec",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-dns"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f37f30d5c7275db282ecd86e54f29dd2176bd3ac656f06abf43bedb21eb8bd"
+checksum = "0b770c1c8476736ca98c578cba4b505104ff8e842c2876b528925f9766379f9a"
 dependencies = [
  "async-trait",
  "futures",
@@ -6655,10 +6621,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.47.0"
+version = "0.49.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e830fdf24ac8c444c12415903174d506e1e077fbe3875c404a78c5935a8543"
+checksum = "a538e571cd38f504f761c61b8f79127489ea7a7d6f05c41ca15d31ffb5726326"
 dependencies = [
+ "async-channel",
  "asynchronous-codec",
  "base64 0.22.1",
  "byteorder",
@@ -6666,30 +6633,28 @@ dependencies = [
  "either",
  "fnv",
  "futures",
- "futures-ticker",
+ "futures-timer",
  "getrandom 0.2.17",
+ "hashlink 0.9.1",
  "hex_fmt",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "prometheus-client",
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.6",
  "regex",
  "serde",
  "sha2 0.10.9",
- "smallvec",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.45.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1711b004a273be4f30202778856368683bd9a83c4c7dcc8f848847606831a4e3"
+checksum = "8ab792a8b68fdef443a62155b01970c81c3aadab5e659621b063ef252a8e65e8"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -6699,13 +6664,11 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "lru 0.12.5",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
- "void",
 ]
 
 [[package]]
@@ -6729,11 +6692,10 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.46.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced237d0bd84bbebb7c2cad4c073160dacb4fe40534963c32ed6d4c6bb7702a3"
+checksum = "13d3fd632a5872ec804d37e7413ceea20588f69d027a0fa3c46f82574f4dee60"
 dependencies = [
- "arrayvec",
  "asynchronous-codec",
  "bytes",
  "either",
@@ -6750,20 +6712,18 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
- "uint",
- "void",
+ "uint 0.10.0",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.46.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b8546b6644032565eb29046b42744aee1e9f261ed99671b2c93fb140dba417"
+checksum = "c66872d0f1ffcded2788683f76931be1c52e27f343edb93bc6d0bcd8887be443"
 dependencies = [
- "data-encoding",
  "futures",
  "hickory-proto",
  "if-watch",
@@ -6775,14 +6735,13 @@ dependencies = [
  "socket2 0.5.10",
  "tokio",
  "tracing",
- "void",
 ]
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566"
+checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -6801,25 +6760,22 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.45.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b137cb1ae86ee39f8e5d6245a296518912014eaa87427d24e6ff58cfc1b28c"
+checksum = "bc73eacbe6462a0eb92a6527cac6e63f02026e5407f8831bde8293f19217bfbf"
 dependencies = [
  "asynchronous-codec",
  "bytes",
- "curve25519-dalek",
  "futures",
  "libp2p-core",
  "libp2p-identity",
  "multiaddr",
  "multihash",
- "once_cell",
  "quick-protobuf",
  "rand 0.8.6",
- "sha2 0.10.9",
  "snow",
  "static_assertions",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -6827,11 +6783,10 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.45.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005a34420359223b974ee344457095f027e51346e992d1e0dcd35173f4cdd422"
+checksum = "74bb7fcdfd9fead4144a3859da0b49576f171a8c8c7c0bfc7c541921d25e60d3"
 dependencies = [
- "either",
  "futures",
  "futures-timer",
  "libp2p-core",
@@ -6839,39 +6794,37 @@ dependencies = [
  "libp2p-swarm",
  "rand 0.8.6",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-quic"
-version = "0.11.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46352ac5cd040c70e88e7ff8257a2ae2f891a4076abad2c439584a31c15fd24e"
+checksum = "9dcc597d70bf7f6f30cbe07081802c836184e48416e89e9ce73a0ba2c56a319e"
 dependencies = [
- "bytes",
  "futures",
  "futures-timer",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-tls",
- "parking_lot",
  "quinn",
+ "quinn-proto",
  "rand 0.8.6",
- "ring 0.17.14",
+ "ring",
  "rustls 0.23.41",
  "socket2 0.5.10",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-relay"
-version = "0.18.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10df23d7f5b5adcc129f4a69d6fbd05209e356ccf9e8f4eb10b2692b79c77247"
+checksum = "d8b9b0392ed623243ad298326b9f806d51191829ac7585cc825c54c6c67b04d9"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -6886,23 +6839,21 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.6",
  "static_assertions",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1356c9e376a94a75ae830c42cdaea3d4fe1290ba409a22c809033d1b7dcab0a6"
+checksum = "a9f1cca83488b90102abac7b67d5c36fc65bc02ed47620228af7ed002e6a1478"
 dependencies = [
  "async-trait",
  "cbor4ii",
  "futures",
  "futures-bounded",
- "futures-timer",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
@@ -6910,87 +6861,81 @@ dependencies = [
  "serde",
  "smallvec",
  "tracing",
- "void",
- "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.45.1"
+version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dd6741793d2c1fb2088f67f82cf07261f25272ebe3c0b0c311e0c6b50e851a"
+checksum = "ce88c6c4bf746c8482480345ea3edfd08301f49e026889d1cbccfa1808a9ed9e"
 dependencies = [
  "either",
  "fnv",
  "futures",
  "futures-timer",
+ "hashlink 0.10.0",
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
- "lru 0.12.5",
  "multistream-select",
- "once_cell",
  "rand 0.8.6",
  "smallvec",
  "tokio",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8"
+checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
 dependencies = [
  "heck",
- "proc-macro2",
  "quote",
  "syn 2.0.118",
 ]
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.42.0"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad964f312c59dcfcac840acd8c555de8403e295d39edf96f5240048b5fcaa314"
+checksum = "fb6585b9309699f58704ec9ab0bb102eca7a3777170fa91a8678d73ca9cafa93"
 dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
  "libc",
  "libp2p-core",
- "libp2p-identity",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-tls"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b23dddc2b9c355f73c1e36eb0c3ae86f7dc964a3715f0731cfad352db4d847"
+checksum = "96ff65a82e35375cbc31ebb99cacbbf28cb6c4fefe26bf13756ddcf708d40080"
 dependencies = [
  "futures",
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
- "rcgen 0.11.3",
- "ring 0.17.14",
+ "rcgen 0.13.2",
+ "ring",
  "rustls 0.23.41",
- "rustls-webpki 0.101.7",
- "thiserror 1.0.69",
- "x509-parser 0.16.0",
+ "rustls-webpki 0.103.13",
+ "thiserror 2.0.18",
+ "x509-parser 0.17.0",
  "yasna 0.5.2",
 ]
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01bf2d1b772bd3abca049214a3304615e6a36fa6ffc742bdd1ba774486200b8f"
+checksum = "4757e65fe69399c1a243bbb90ec1ae5a2114b907467bf09f3575e899815bb8d3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6999,19 +6944,18 @@ dependencies = [
  "libp2p-swarm",
  "tokio",
  "tracing",
- "void",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788b61c80789dba9760d8c669a5bedb642c8267555c803fabd8396e4ca5c5882"
+checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
 dependencies = [
  "either",
  "futures",
  "libp2p-core",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.10",
@@ -7099,12 +7043,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7155,29 +7093,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -7335,6 +7255,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid 1.23.4",
 ]
 
 [[package]]
@@ -7684,20 +7621,11 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
-dependencies = [
- "asn1-rs 0.6.2",
-]
-
-[[package]]
-name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs 0.7.2",
+ "asn1-rs",
 ]
 
 [[package]]
@@ -7705,6 +7633,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -7779,9 +7711,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.29.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -7792,114 +7724,83 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.2",
- "opentelemetry 0.31.0",
- "reqwest 0.12.28",
+ "opentelemetry",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http 1.4.2",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry_sdk",
  "prost 0.14.4",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "serde_json",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.29.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098a71a4430bb712be6130ed777335d2e5b19bc8566de5f2edddfce906def6ab"
+checksum = "2c0359983e7f79cf33c9abd89e5d7ddf67c46c419d0148598022d70e70c01aba"
 dependencies = [
  "once_cell",
- "opentelemetry 0.29.1",
- "opentelemetry_sdk 0.29.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prometheus",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "base64 0.22.1",
  "const-hex",
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost 0.14.4",
  "serde",
- "serde_json",
- "tonic 0.14.6",
- "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.29.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b29a9f89f1a954936d5aa92f19b2feec3c8f3971d3e96206640db7f9706ae3"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.29.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
- "opentelemetry 0.29.1",
+ "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.31.0",
- "percent-encoding",
- "rand 0.9.4",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8368,7 +8269,7 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -8446,15 +8347,14 @@ dependencies = [
  "memchr",
  "parking_lot",
  "procfs",
- "protobuf",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "prometheus-client"
-version = "0.22.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
 dependencies = [
  "dtoa",
  "itoa",
@@ -8568,32 +8468,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "3.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
-dependencies = [
- "once_cell",
- "protobuf-support",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "protobuf-src"
 version = "2.1.1+27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6217c3504da19b85a3a4b2e9a5183d635822d83507ba0986624b5c05b83bfc40"
 dependencies = [
  "cmake",
-]
-
-[[package]]
-name = "protobuf-support"
-version = "3.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
-dependencies = [
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -8653,11 +8533,12 @@ checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
+ "fastbloom",
  "getrandom 0.4.3",
  "lru-slab",
  "rand 0.10.2",
  "rand_pcg",
- "ring 0.17.14",
+ "ring",
  "rustc-hash 2.1.3",
  "rustls 0.23.41",
  "rustls-pki-types",
@@ -8837,12 +8718,13 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.11.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
  "pem",
- "ring 0.16.20",
+ "ring",
+ "rustls-pki-types",
  "time",
  "yasna 0.5.2",
 ]
@@ -8854,7 +8736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "time",
  "x509-parser 0.18.1",
@@ -9000,7 +8882,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.15",
@@ -9019,7 +8900,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.41",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -9048,7 +8928,9 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
@@ -9091,21 +8973,6 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac 0.12.1",
  "subtle",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -9346,7 +9213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.14",
+ "ring",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -9360,7 +9227,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.13",
  "subtle",
@@ -9440,7 +9307,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.14",
+ "ring",
  "untrusted 0.9.0",
 ]
 
@@ -9451,7 +9318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -9679,7 +9546,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.14",
+ "ring",
  "untrusted 0.9.0",
 ]
 
@@ -10143,6 +10010,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10174,7 +10047,7 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek",
  "rand_core 0.6.4",
- "ring 0.17.14",
+ "ring",
  "rustc_version 0.4.1",
  "sha2 0.10.9",
  "subtle",
@@ -10199,12 +10072,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -10419,6 +10286,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"
@@ -10658,9 +10531,9 @@ dependencies = [
 
 [[package]]
 name = "tnt-core-bindings"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c697c2729569879158d02242e573339e7bb6f031ba9688a801ca3cefd27c511a"
+checksum = "828c15d3fbb99ca2aab81dee20f26d0bf88f12c6c6d6368f466254997d7ff045"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -10913,27 +10786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "http 1.4.2",
- "http-body 1.0.1",
- "http-body-util",
- "percent-encoding",
- "pin-project",
- "sync_wrapper 1.0.2",
- "tokio-stream",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tonic-build"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10945,17 +10797,6 @@ dependencies = [
  "prost-types",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
-dependencies = [
- "bytes",
- "prost 0.14.4",
- "tonic 0.14.6",
 ]
 
 [[package]]
@@ -11071,7 +10912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1ad78bf74c1790b0825ddc35ad1bb9498736c51c8437796b81cadf4916cd8"
 dependencies = [
  "loki-api",
- "reqwest 0.12.28",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "snap",
@@ -11086,12 +10927,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.23",
@@ -11191,6 +11032,18 @@ name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -11372,12 +11225,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vsimd"
@@ -12097,18 +11944,18 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
 dependencies = [
- "asn1-rs 0.6.2",
+ "asn1-rs",
  "data-encoding",
- "der-parser 9.0.0",
+ "der-parser",
  "lazy_static",
  "nom",
- "oid-registry 0.7.1",
+ "oid-registry",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -12118,14 +11965,14 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
- "asn1-rs 0.7.2",
+ "asn1-rs",
  "aws-lc-rs",
  "data-encoding",
- "der-parser 10.0.0",
+ "der-parser",
  "lazy_static",
  "nom",
- "oid-registry 0.8.1",
- "ring 0.17.14",
+ "oid-registry",
+ "ring",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,48 @@ split-debuginfo = "unpacked"  # separate debug info from binaries
 
 [profile.dev.package."*"]
 debug = 1  # line tables only for dependencies (not full DWARF)
+
+# Point the blueprint SDK graph at tnt-core 0.19 bindings (#1467/#1468).
+# Pinned to commit 5a2dcbbd on tangle-network/blueprint main, which carries the
+# 0.19 Service/Blueprint struct changes while still versioned 0.2.0-alpha.10 so the
+# workspace's `=0.2.0-alpha.10` pins resolve. Remove once blueprint-sdk 0.2.0-alpha.11
+# (with 0.19 bindings) is published to crates.io.
+[patch.crates-io]
+blueprint-anvil-testing-utils = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-auth = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-chain-setup = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-chain-setup-anvil = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-client-core = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-client-eigenlayer = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-client-evm = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-client-tangle = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-clients = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-context-derive = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-contexts = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-core = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-core-testing-utils = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-crypto = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-crypto-bls = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-crypto-bn254 = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-crypto-core = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-crypto-ed25519 = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-crypto-hashing = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-crypto-k256 = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-crypto-sr25519 = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-eigenlayer-extra = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-evm-extra = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-keystore = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-macros = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-manager-bridge = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-metrics-rpc-calls = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-networking = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-producers-extra = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-qos = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-router = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-runner = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-sdk = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-std = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-store-local-database = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-stores = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-tangle-extra = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
+blueprint-testing-utils = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }

--- a/ai-agent-sandbox-blueprint-bin/src/main.rs
+++ b/ai-agent-sandbox-blueprint-bin/src/main.rs
@@ -221,17 +221,30 @@ async fn main() -> Result<(), blueprint_sdk::Error> {
     // Determine operator API port and binding address.
     // Behind BPM: request allocated port, bind 127.0.0.1 (only proxy can reach us).
     // Standalone: bind 0.0.0.0 on configured port (dev mode only).
-    let preferred_port: u16 = std::env::var("OPERATOR_API_PORT")
+    //
+    // A single operator box can run one sandbox service per blueprint (e.g. a
+    // legacy blueprint plus its redeployed successor). The BPM port allocator
+    // honours the *preferred* port verbatim and fails ("Address already in use")
+    // rather than falling back, so every sandbox service preferring the same
+    // 9090 makes all but the first-reconciled service fail to bind. Offset the
+    // preferred port by service_id (wrapping within the ephemeral range) so
+    // co-located sandbox services request distinct ports. OPERATOR_API_PORT, when
+    // set, pins an explicit base for deployments that manage ports externally.
+    let base_port: u16 = std::env::var("OPERATOR_API_PORT")
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(9090);
+    // Keep the offset small and bounded so it stays inside the manager's
+    // allocatable range; service_id is unique per operator so this is collision-free
+    // across co-located services on the same box.
+    let preferred_port: u16 = base_port.wrapping_add((service_id % 1000) as u16);
 
     let (api_port, bind_addr) = if let Some(ref b) = bridge {
         let port = b
             .request_port(Some(preferred_port))
             .await
             .map_err(|e| blueprint_sdk::Error::Other(format!("BPM port allocation failed: {e}")))?;
-        info!("BPM allocated port {port} for operator API");
+        info!("BPM allocated port {port} for operator API (service {service_id}, preferred {preferred_port})");
         (port, [127, 0, 0, 1u8])
     } else {
         (preferred_port, [0, 0, 0, 0u8])

--- a/ai-agent-sandbox-blueprint-lib/tests/tempo_decode.rs
+++ b/ai-agent-sandbox-blueprint-lib/tests/tempo_decode.rs
@@ -1,0 +1,63 @@
+//! Ground-truth decode check for the tnt-core 0.19 bindings against the live
+//! Tempo deployment. Reproduces the exact call that overran with the stale
+//! 0.18 bindings: `get_blueprint_manager(service_id)` (get_service -> get_blueprint).
+//!
+//! Run explicitly (network + live chain):
+//!   cargo test -p ai-agent-sandbox-blueprint-lib --test tempo_decode -- --ignored --nocapture
+
+use blueprint_sdk::alloy::primitives::{address, Address};
+use blueprint_sdk::clients::tangle::{TangleClient, TangleClientConfig, TangleSettings};
+use blueprint_sdk::crypto::KeyType;
+use blueprint_sdk::crypto::k256::K256Ecdsa;
+use blueprint_sdk::keystore::backends::Backend;
+use blueprint_sdk::keystore::{Keystore, KeystoreConfig};
+use reqwest::Url;
+
+const TEMPO_RPC: &str = "https://rpc.moderato.tempo.xyz";
+const TANGLE: Address = address!("ff137b9c879c47c28ce389e84501925438ab4cda");
+const EXPECTED_MANAGER: Address = address!("506483972499f7b6060d517066eb666ce9c10978");
+const SERVICE_ID: u64 = 3;
+const BLUEPRINT_ID: u64 = 4;
+
+#[tokio::test]
+#[ignore = "hits live Tempo RPC"]
+async fn get_blueprint_manager_decodes_on_tempo() {
+    let keystore = Keystore::new(KeystoreConfig::new().in_memory(true)).expect("keystore");
+    // Read-only view calls do not sign; any well-formed ECDSA key satisfies the
+    // client's `first_local::<K256Ecdsa>()` account lookup.
+    let secret = K256Ecdsa::generate_with_seed(Some(&[7u8; 32])).expect("generate key");
+    keystore.insert::<K256Ecdsa>(&secret).expect("insert key");
+
+    let settings = TangleSettings {
+        blueprint_id: BLUEPRINT_ID,
+        service_id: Some(SERVICE_ID),
+        tangle_contract: TANGLE,
+        staking_contract: Address::ZERO,
+        status_registry_contract: Address::ZERO,
+    };
+    let config = TangleClientConfig::new(
+        Url::parse(TEMPO_RPC).unwrap(),
+        Url::parse(TEMPO_RPC).unwrap(),
+        "memory://",
+        settings,
+    )
+    .test_mode(true);
+
+    let client = TangleClient::with_keystore(config, keystore)
+        .await
+        .expect("build TangleClient");
+
+    // This is the call that failed with "ABI decoding failed: buffer overrun"
+    // under tnt-core-bindings 0.18.0.
+    let manager = client
+        .get_blueprint_manager(SERVICE_ID)
+        .await
+        .expect("get_blueprint_manager must decode without buffer overrun");
+
+    println!("get_blueprint_manager({SERVICE_ID}) = {manager:?}");
+    assert_eq!(
+        manager,
+        Some(EXPECTED_MANAGER),
+        "manager address must match the on-chain BSM"
+    );
+}

--- a/ai-agent-sandbox-blueprint-lib/tests/tempo_decode.rs
+++ b/ai-agent-sandbox-blueprint-lib/tests/tempo_decode.rs
@@ -5,7 +5,7 @@
 //! Run explicitly (network + live chain):
 //!   cargo test -p ai-agent-sandbox-blueprint-lib --test tempo_decode -- --ignored --nocapture
 
-use blueprint_sdk::alloy::primitives::{address, Address};
+use blueprint_sdk::alloy::primitives::{Address, address};
 use blueprint_sdk::clients::tangle::{TangleClient, TangleClientConfig, TangleSettings};
 use blueprint_sdk::crypto::KeyType;
 use blueprint_sdk::crypto::k256::K256Ecdsa;

--- a/contracts/script/DeployTempo.s.sol
+++ b/contracts/script/DeployTempo.s.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: UNLICENSE
+pragma solidity ^0.8.26;
+
+import "forge-std/Script.sol";
+import "tnt-core/libraries/Types.sol";
+import "../src/AgentSandboxBlueprint.sol";
+
+/// @notice Minimal interface for Tangle contract blueprint registration.
+interface ITangle {
+    function createBlueprint(Types.BlueprintDefinition calldata def) external returns (uint64);
+    function blueprintCount() external view returns (uint64);
+}
+
+/// @title DeployTempo
+/// @notice Deploys ONE fresh cloud-mode `AgentSandboxBlueprint` (compiled against
+///         tnt-core 0.19 — onJobResult selector 0xe649fc03) UNBOUND and registers
+///         exactly one sandbox blueprint on the live Tempo Tangle. The manager
+///         binds to this blueprint during `createBlueprint`; do NOT pre-call
+///         onBlueprintCreated (it reverts AlreadyInitialized).
+///
+/// Deploy (Tempo, 30M per-tx gas cap):
+///   PRIVATE_KEY=<deployer> TANGLE_CORE=0xff137b9c879c47c28ce389e84501925438ab4cda \
+///   RESTAKING=0x9484d07899b98384f1d66bd5b2659f3ed346f89e \
+///   forge script contracts/script/DeployTempo.s.sol:DeployTempo \
+///     --rpc-url https://rpc.moderato.tempo.xyz --broadcast --slow \
+///     --gas-estimate-multiplier 110 --skip test
+contract DeployTempo is Script {
+    function run() external {
+        uint256 deployerKey = vm.envUint("PRIVATE_KEY");
+        address tangleAddr = vm.envAddress("TANGLE_CORE");
+        address restakingAddr = vm.envAddress("RESTAKING");
+        // Trim the on-chain-stored definition to fit the Tempo 30M per-tx cap.
+        bool compact = vm.envOr("COMPACT_DEFINITION", true);
+
+        ITangle tangle = ITangle(tangleAddr);
+        uint64 countBefore = tangle.blueprintCount();
+        console.log("blueprintCount BEFORE:", countBefore);
+
+        vm.startBroadcast(deployerKey);
+
+        // Cloud mode: capacity-weighted operator selection. UNBOUND — the master
+        // manager binds it below during createBlueprint.
+        AgentSandboxBlueprint sandbox = new AgentSandboxBlueprint(restakingAddr, false, false);
+
+        uint64 blueprintId = tangle.createBlueprint(_buildSandboxDefinition(address(sandbox), compact));
+
+        vm.stopBroadcast();
+
+        console.log("DEPLOY_SANDBOX_BSM=%s", vm.toString(address(sandbox)));
+        console.log("DEPLOY_SANDBOX_BLUEPRINT_ID=%s", vm.toString(blueprintId));
+        console.log("blueprintCount AFTER:", tangle.blueprintCount());
+        require(blueprintId == countBefore, "unexpected blueprint id");
+    }
+
+    function _buildCloudJobs() internal pure returns (Types.JobDefinition[] memory jobs) {
+        jobs = new Types.JobDefinition[](5);
+        jobs[0] = Types.JobDefinition("sandbox_create", "Create a new AI sandbox", "", "", "");
+        jobs[1] = Types.JobDefinition("sandbox_delete", "Delete an AI sandbox", "", "", "");
+        jobs[2] = Types.JobDefinition("workflow_create", "Create or update a workflow", "", "", "");
+        jobs[3] = Types.JobDefinition("workflow_trigger", "Trigger a workflow execution", "", "", "");
+        jobs[4] = Types.JobDefinition("workflow_cancel", "Cancel an active workflow", "", "", "");
+    }
+
+    /// @dev Gas-lean job set: the two lifecycle jobs the driver submits (indices
+    /// 0/1, sandbox_create/delete) with empty descriptions. Preserves the
+    /// driver's job-index contract while shrinking the stored definition.
+    function _compactJobs() internal pure returns (Types.JobDefinition[] memory jobs) {
+        jobs = new Types.JobDefinition[](2);
+        jobs[0] = Types.JobDefinition("sandbox_create", "", "", "", "");
+        jobs[1] = Types.JobDefinition("sandbox_delete", "", "", "", "");
+    }
+
+    function _compactMetadata(string memory name) internal pure returns (Types.BlueprintMetadata memory) {
+        return Types.BlueprintMetadata(name, "", "", "", "", "", "", "", "");
+    }
+
+    /// @dev createBlueprint requires >=1 source; the real binary source is wired
+    /// post-registration via setBlueprintSources (event-sourced). A minimal
+    /// placeholder source keeps the definition small under the gas cap.
+    function _compactSources() internal pure returns (Types.BlueprintSource[] memory sources) {
+        sources = new Types.BlueprintSource[](1);
+        Types.BlueprintBinary[] memory bins = new Types.BlueprintBinary[](1);
+        bins[0] = Types.BlueprintBinary({
+            arch: Types.BlueprintArchitecture.Amd64,
+            os: Types.BlueprintOperatingSystem.Linux,
+            name: "bin",
+            sha256: bytes32(uint256(0xdeadbeef))
+        });
+        sources[0] = Types.BlueprintSource({
+            kind: Types.BlueprintSourceKind.Native,
+            container: Types.ImageRegistrySource("", "", ""),
+            wasm: Types.WasmSource(Types.WasmRuntime.Unknown, Types.BlueprintFetcherKind.None, "", ""),
+            native: Types.NativeSource(Types.BlueprintFetcherKind.None, "bin", "bin"),
+            testing: Types.TestingSource("bin", "bin", "."),
+            binaries: bins
+        });
+    }
+
+    function _buildSandboxDefinition(address manager, bool compact)
+        internal
+        pure
+        returns (Types.BlueprintDefinition memory def)
+    {
+        def.metadataUri =
+            compact ? "tangle:ai-agent-sandbox" : "https://github.com/tangle-network/ai-agent-sandbox-blueprint";
+        def.metadataHash = keccak256(bytes(def.metadataUri));
+        def.manager = manager;
+        def.masterManagerRevision = 0;
+        def.hasConfig = true;
+
+        def.config = Types.BlueprintConfig({
+            membership: Types.MembershipModel.Dynamic,
+            pricing: Types.PricingModel.EventDriven,
+            minOperators: 1,
+            maxOperators: 100,
+            subscriptionRate: 0,
+            subscriptionInterval: 0,
+            eventRate: 1e15 // 0.001 TNT base rate; per-job PathUSD rates set post-registration
+        });
+
+        def.metadata = compact
+            ? _compactMetadata("AI Agent Sandbox Blueprint")
+            : Types.BlueprintMetadata({
+                name: "AI Agent Sandbox Blueprint",
+                description: "Multi-operator AI sandbox with Docker backends, workflows, and SSH access",
+                author: "Tangle",
+                category: "AI/Compute",
+                codeRepository: "https://github.com/tangle-network/ai-agent-sandbox-blueprint",
+                logo: "",
+                website: "https://tangle.network",
+                license: "UNLICENSE",
+                profilingData: ""
+            });
+
+        def.jobs = compact ? _compactJobs() : _buildCloudJobs();
+        def.registrationSchema = "";
+        def.requestSchema = "";
+        def.sources = _compactSources();
+
+        def.supportedMemberships = new Types.MembershipModel[](1);
+        def.supportedMemberships[0] = Types.MembershipModel.Dynamic;
+    }
+}

--- a/contracts/script/NewSandboxService.s.sol
+++ b/contracts/script/NewSandboxService.s.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: UNLICENSE
+pragma solidity ^0.8.26;
+
+import "forge-std/Script.sol";
+import "tnt-core/libraries/Types.sol";
+
+/// @notice Minimal interface for requesting + approving a service on blueprint 4.
+///         Mirrors the proven service-3 creation flow (deployer requests, operator approves).
+interface ITangleSvc {
+    function requestService(
+        uint64 blueprintId,
+        address[] calldata operators,
+        bytes calldata config,
+        address[] calldata permittedCallers,
+        uint64 ttl,
+        address paymentToken,
+        uint256 paymentAmount,
+        Types.ConfidentialityPolicy confidentiality
+    )
+        external
+        payable
+        returns (uint64 requestId);
+
+    function approveService(Types.ApprovalParams calldata p) external;
+
+    function serviceCount() external view returns (uint64);
+    function serviceRequestCount() external view returns (uint64);
+    function isServiceOperator(uint64 serviceId, address op) external view returns (bool);
+}
+
+/// @title NewSandboxService
+/// @notice Requests + approves a fresh service on blueprint 4 so the manager spawns
+///         it via a live ServiceActivated event (no restart, no svc-4-1 re-scan).
+///         The new service becomes the PathUSD-e2e target.
+contract NewSandboxService is Script {
+    // Overridable so the fresh 0.19-BSM blueprint (id 8 on Tempo) can be used.
+    uint64 immutable BLUEPRINT_ID = uint64(vm.envOr("BLUEPRINT_ID", uint256(4)));
+
+    function run() external {
+        address tangle = vm.envAddress("TANGLE_CONTRACT");
+        uint256 ownerKey = vm.envUint("OWNER_KEY");
+        uint256 operatorKey = vm.envUint("OPERATOR_KEY");
+        address owner = vm.addr(ownerKey);
+        address operator = vm.addr(operatorKey);
+
+        ITangleSvc t = ITangleSvc(tangle);
+
+        uint64 svcCountBefore = t.serviceCount();
+        console.log("service count BEFORE:", svcCountBefore);
+        console.log("new service id will be:", svcCountBefore);
+
+        // 1. Deployer (owner/requester) requests the service.
+        address[] memory operators = new address[](1);
+        operators[0] = operator;
+        address[] memory permitted = new address[](1);
+        permitted[0] = owner;
+
+        vm.startBroadcast(ownerKey);
+        uint64 reqId = t.requestService(
+            BLUEPRINT_ID,
+            operators,
+            "", // empty config: Cloud-mode decodes SelectionRequest, count 0 -> defaults to operators.length
+            permitted,
+            0, // ttl 0 = no expiry
+            address(0),
+            0,
+            Types.ConfidentialityPolicy.Any
+        );
+        vm.stopBroadcast();
+        console.log("requestService reqId:", reqId);
+
+        // 2. Operator approves. Empty securityCommitments OK — request has only the
+        //    default-TNT requirement, auto-filled at min. No BLS, no TEE.
+        Types.ApprovalParams memory p;
+        p.requestId = reqId;
+        p.securityCommitments = new Types.AssetSecurityCommitment[](0);
+        p.blsPubkey = [uint256(0), 0, 0, 0];
+        p.blsPopSignature = [uint256(0), 0];
+        p.teeCommitments = new Types.TeeAttestationCommitment[](0);
+
+        vm.startBroadcast(operatorKey);
+        t.approveService(p);
+        vm.stopBroadcast();
+
+        uint64 svcCountAfter = t.serviceCount();
+        console.log("service count AFTER:", svcCountAfter);
+        uint64 newServiceId = svcCountAfter - 1;
+        console.log("NEW SERVICE ID:", newServiceId);
+        bool isOp = t.isServiceOperator(newServiceId, operator);
+        console.log("operator is service operator:", isOp);
+        require(svcCountAfter == svcCountBefore + 1, "service not created");
+        require(isOp, "operator not on new service");
+    }
+}

--- a/contracts/script/SetSandboxSourcesV013.s.sol
+++ b/contracts/script/SetSandboxSourcesV013.s.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: UNLICENSE
+pragma solidity ^0.8.26;
+
+import "forge-std/Script.sol";
+import "tnt-core/libraries/Types.sol";
+
+/// @notice Minimal 0.19 interface for repointing a blueprint's cold-start sources
+///         and operator ack. Defined locally so the script builds against the
+///         soldeer-pinned 0.13 Types (identical BlueprintSource layout) without
+///         needing the full 0.19 tnt-core source tree.
+interface ITangleSources {
+    function setBlueprintSources(uint64 blueprintId, Types.BlueprintSource[] calldata sources) external;
+    function ackBlueprintSources(uint64 blueprintId, bytes32 sourcesHash) external;
+    function blueprintSourcesHash(uint64 blueprintId) external view returns (bytes32);
+    function operatorAckedCurrentSources(uint64 blueprintId, address operator) external view returns (bool);
+}
+
+/// @title SetSandboxSourcesV013
+/// @notice Repoints blueprint 4 (ai-agent-sandbox) at the v0.1.3 GitHub release
+///         carrying the tnt-core-0.19-fixed operator binary, then acks it as the
+///         operator so the cold-start manager fetches and verifies the new binary.
+/// @dev Two broadcasts: owner sets sources, operator acks. Pass keys via env.
+contract SetSandboxSourcesV013 is Script {
+    // Blueprint id defaults to 4 (legacy) but is overridable via BLUEPRINT_ID env
+    // so the same script can wire the fresh 0.19-BSM blueprint (id 8 on Tempo).
+    uint64 immutable BLUEPRINT_ID = uint64(vm.envOr("BLUEPRINT_ID", uint256(4)));
+
+    // v0.1.3 release, inner binary sha256 = the fix (41242ef4…).
+    bytes32 constant BIN_SHA = 0x41242ef4a8aa9c3420660b7969eba77b781331a677f035943babe93a60a09cf9;
+
+    string constant ARTIFACT_URI =
+        "{\"dist_url\":\"https://github.com/tangle-network/ai-agent-sandbox-blueprint/releases/download/v0.1.3/dist-manifest.json\",\"archive_url\":\"https://github.com/tangle-network/ai-agent-sandbox-blueprint/releases/download/v0.1.3/ai-agent-sandbox-blueprint-x86_64-unknown-linux-gnu.tar.xz\",\"binaries\":[]}";
+
+    function _buildSources() internal pure returns (Types.BlueprintSource[] memory sources) {
+        sources = new Types.BlueprintSource[](1);
+
+        Types.BlueprintBinary[] memory bins = new Types.BlueprintBinary[](1);
+        bins[0] = Types.BlueprintBinary({
+            arch: Types.BlueprintArchitecture.Amd64,
+            os: Types.BlueprintOperatingSystem.Linux,
+            name: "ai-agent-sandbox-blueprint",
+            sha256: BIN_SHA
+        });
+
+        sources[0] = Types.BlueprintSource({
+            kind: Types.BlueprintSourceKind.Native,
+            container: Types.ImageRegistrySource("", "", ""),
+            wasm: Types.WasmSource(Types.WasmRuntime.Unknown, Types.BlueprintFetcherKind.None, "", ""),
+            native: Types.NativeSource(Types.BlueprintFetcherKind.Http, ARTIFACT_URI, "ai-agent-sandbox-blueprint"),
+            testing: Types.TestingSource("", "", ""),
+            binaries: bins
+        });
+    }
+
+    function run() external {
+        address tangle = vm.envAddress("TANGLE_CONTRACT");
+        uint256 ownerKey = vm.envUint("OWNER_KEY");
+        uint256 operatorKey = vm.envUint("OPERATOR_KEY");
+        address operator = vm.addr(operatorKey);
+
+        ITangleSources t = ITangleSources(tangle);
+
+        bytes32 before = t.blueprintSourcesHash(BLUEPRINT_ID);
+        console.log("sources hash BEFORE:");
+        console.logBytes32(before);
+
+        Types.BlueprintSource[] memory sources = _buildSources();
+        bytes32 expected = keccak256(abi.encode(sources));
+        console.log("expected sources hash (keccak abi.encode):");
+        console.logBytes32(expected);
+
+        vm.startBroadcast(ownerKey);
+        t.setBlueprintSources(BLUEPRINT_ID, sources);
+        vm.stopBroadcast();
+
+        bytes32 live = t.blueprintSourcesHash(BLUEPRINT_ID);
+        console.log("sources hash AFTER set:");
+        console.logBytes32(live);
+        require(live == expected, "live hash != expected (encoding mismatch)");
+
+        vm.startBroadcast(operatorKey);
+        t.ackBlueprintSources(BLUEPRINT_ID, live);
+        vm.stopBroadcast();
+
+        bool acked = t.operatorAckedCurrentSources(BLUEPRINT_ID, operator);
+        console.log("operator acked current sources:", acked);
+        require(acked, "operator ack failed");
+    }
+}

--- a/contracts/src/AgentSandboxBlueprint.sol
+++ b/contracts/src/AgentSandboxBlueprint.sol
@@ -103,6 +103,8 @@ contract AgentSandboxBlueprint is OperatorSelectionBase {
     error CloudModeOnly();
     error InstanceModeOnly();
     error UnknownJobId(uint8 jobId);
+    /// @notice Cached onJobCall inputs did not hash to the inputsHash 0.19 supplied at result time.
+    error InputsHashMismatch(uint64 jobCallId, bytes32 got, bytes32 expected);
     error CannotChangeWithActiveResources();
     error CannotLeaveWithActiveResources();
     error ZeroOperatorsInRequest();
@@ -344,9 +346,15 @@ contract AgentSandboxBlueprint is OperatorSelectionBase {
             bytes32 sandboxHash = keccak256(bytes(sandboxId));
             address routed = $.sandboxOperator[sandboxHash];
             if (routed == address(0)) revert SandboxTypes.SandboxNotFound(sandboxHash);
+            // tnt-core 0.19: onJobResult only receives inputsHash, so cache the
+            // raw request here for handleDeleteResult to consume at result time.
+            $.jobCallInputs[serviceId][jobCallId] = inputs;
             emit OperatorRouted(serviceId, jobCallId, routed);
         } else if (job == JOB_WORKFLOW_CREATE || job == JOB_WORKFLOW_TRIGGER || job == JOB_WORKFLOW_CANCEL) {
-            // Supported in both cloud and instance modes.
+            // Supported in both cloud and instance modes. The workflow result
+            // handlers decode the original inputs (config / workflowId), which
+            // 0.19's onJobResult no longer forwards — cache them at call time.
+            $.jobCallInputs[serviceId][jobCallId] = inputs;
         } else {
             revert UnknownJobId(job);
         }
@@ -361,27 +369,50 @@ contract AgentSandboxBlueprint is OperatorSelectionBase {
         uint8 job,
         uint64 jobCallId,
         address operator,
-        bytes calldata inputs,
+        bytes32 inputsHash,
         bytes calldata outputs
     ) external payable override onlyFromTangle {
         SandboxStorage.Data storage $ = SandboxStorage.load();
         if (job == JOB_SANDBOX_CREATE) {
+            // CREATE derives all state from `outputs` (the sandbox id the
+            // operator returned); no cached inputs needed.
             if ($.instanceMode) revert CloudModeOnly();
             SandboxLogic.handleCreateResult(serviceId, jobCallId, operator, outputs);
         } else if (job == JOB_SANDBOX_DELETE) {
             if ($.instanceMode) revert CloudModeOnly();
+            bytes memory inputs = _consumeJobCallInputs(serviceId, jobCallId, inputsHash);
             SandboxLogic.handleDeleteResult(operator, inputs);
         } else if (job == JOB_WORKFLOW_CREATE) {
+            bytes memory inputs = _consumeJobCallInputs(serviceId, jobCallId, inputsHash);
             SandboxLogic.handleWorkflowCreateResult(serviceId, jobCallId, inputs);
         } else if (job == JOB_WORKFLOW_TRIGGER) {
+            bytes memory inputs = _consumeJobCallInputs(serviceId, jobCallId, inputsHash);
             (uint64 workflowId) = abi.decode(inputs, (uint64));
             SandboxLogic.markTriggered(workflowId);
         } else if (job == JOB_WORKFLOW_CANCEL) {
+            bytes memory inputs = _consumeJobCallInputs(serviceId, jobCallId, inputsHash);
             (uint64 workflowId) = abi.decode(inputs, (uint64));
             SandboxLogic.cancelWorkflow(workflowId);
         } else {
             revert UnknownJobId(job);
         }
+    }
+
+    /// @notice Reads the raw job inputs cached at `onJobCall`, binds them to the
+    ///         0.19 result-time `inputsHash`, and clears the cache entry.
+    /// @dev tnt-core 0.19 delivers only `inputsHash` to `onJobResult`; the raw
+    ///      inputs are stashed by `onJobCall`. Asserting keccak256 equality
+    ///      guarantees the consumed inputs are exactly those the caller hashed
+    ///      over — a defense against any storage-cache desync or a forgotten
+    ///      cache write (an empty entry hashes to keccak256("") and fails here).
+    function _consumeJobCallInputs(uint64 serviceId, uint64 jobCallId, bytes32 inputsHash)
+        internal
+        returns (bytes memory inputs)
+    {
+        SandboxStorage.Data storage $ = SandboxStorage.load();
+        inputs = $.jobCallInputs[serviceId][jobCallId];
+        if (keccak256(inputs) != inputsHash) revert InputsHashMismatch(jobCallId, keccak256(inputs), inputsHash);
+        delete $.jobCallInputs[serviceId][jobCallId];
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/contracts/src/libraries/SandboxStorage.sol
+++ b/contracts/src/libraries/SandboxStorage.sol
@@ -54,6 +54,16 @@ library SandboxStorage {
         mapping(uint64 => bytes) pendingRequestConfig;
         mapping(uint64 => bytes) serviceConfig;
         mapping(uint64 => address) serviceOwner;
+        // ── Job-call inputs cache (tnt-core 0.19) ────────────────────────
+        // 0.19's onJobResult delivers only `bytes32 inputsHash`, not the raw
+        // `bytes inputs` that 0.13 passed. The DELETE and WORKFLOW result
+        // handlers still need the original inputs, so onJobCall stashes them
+        // here keyed by [serviceId][jobCallId]; onJobResult reads, verifies
+        // against inputsHash, then clears the entry. Keyed by service too so a
+        // jobCallId that is only unique within a service cannot collide across
+        // services. Appended last to keep the ERC-7201 slot layout of every
+        // prior field unchanged.
+        mapping(uint64 => mapping(uint64 => bytes)) jobCallInputs;
     }
 
     /// keccak256(abi.encode(uint256(keccak256("tangle.sandbox.blueprint.main")) - 1)) & ~bytes32(uint256(0xff))

--- a/contracts/test/AgentInstanceBlueprint.t.sol
+++ b/contracts/test/AgentInstanceBlueprint.t.sol
@@ -382,7 +382,7 @@ contract AgentInstanceBlueprintTest is InstanceBlueprintTestSetup {
         for (uint8 jobId = 0; jobId <= 1; jobId++) {
             vm.prank(tangleCore);
             vm.expectRevert(AgentSandboxBlueprint.CloudModeOnly.selector);
-            instance.onJobResult(testServiceId, jobId, uint64(2010 + jobId), operator1, bytes(""), bytes(""));
+            instance.onJobResult(testServiceId, jobId, uint64(2010 + jobId), operator1, keccak256(bytes("")), bytes(""));
         }
     }
 
@@ -480,7 +480,7 @@ contract AgentInstanceBlueprintTest is InstanceBlueprintTestSetup {
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.InvalidWorkflowTarget.selector, uint8(1)));
         instance.onJobResult(
-            testServiceId, workflowJobId, createCallId, operator1, encodeWorkflowCreateInputs(req), bytes("")
+            testServiceId, workflowJobId, createCallId, operator1, keccak256(encodeWorkflowCreateInputs(req)), bytes("")
         );
     }
 
@@ -503,7 +503,7 @@ contract AgentInstanceBlueprintTest is InstanceBlueprintTestSetup {
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.InvalidWorkflowTarget.selector, uint8(0)));
         instance.onJobResult(
-            testServiceId, workflowJobId, createCallId, operator1, encodeWorkflowCreateInputs(req), bytes("")
+            testServiceId, workflowJobId, createCallId, operator1, keccak256(encodeWorkflowCreateInputs(req)), bytes("")
         );
     }
 
@@ -526,7 +526,7 @@ contract AgentInstanceBlueprintTest is InstanceBlueprintTestSetup {
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.InvalidWorkflowTarget.selector, uint8(2)));
         instance.onJobResult(
-            testServiceId, workflowJobId, callId2, operator1, encodeWorkflowCreateInputs(req2), bytes("")
+            testServiceId, workflowJobId, callId2, operator1, keccak256(encodeWorkflowCreateInputs(req2)), bytes("")
         );
 
         SandboxTypes.WorkflowCreateRequest memory req255 = SandboxTypes.WorkflowCreateRequest({
@@ -545,7 +545,7 @@ contract AgentInstanceBlueprintTest is InstanceBlueprintTestSetup {
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.InvalidWorkflowTarget.selector, uint8(255)));
         instance.onJobResult(
-            testServiceId, workflowJobId, callId255, operator1, encodeWorkflowCreateInputs(req255), bytes("")
+            testServiceId, workflowJobId, callId255, operator1, keccak256(encodeWorkflowCreateInputs(req255)), bytes("")
         );
     }
 
@@ -568,7 +568,7 @@ contract AgentInstanceBlueprintTest is InstanceBlueprintTestSetup {
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.InvalidWorkflowTarget.selector, uint8(1)));
         instance.onJobResult(
-            testServiceId, workflowJobId, createCallId, operator1, encodeWorkflowCreateInputs(req), bytes("")
+            testServiceId, workflowJobId, createCallId, operator1, keccak256(encodeWorkflowCreateInputs(req)), bytes("")
         );
     }
 
@@ -585,7 +585,7 @@ contract AgentInstanceBlueprintTest is InstanceBlueprintTestSetup {
     function test_unknownJobIdRevertsOnJobResultInstanceMode() public {
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(AgentSandboxBlueprint.UnknownJobId.selector, 7));
-        instance.onJobResult(testServiceId, 7, 3001, operator1, bytes(""), bytes(""));
+        instance.onJobResult(testServiceId, 7, 3001, operator1, keccak256(bytes("")), bytes(""));
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/contracts/test/AgentSandboxBlueprint.t.sol
+++ b/contracts/test/AgentSandboxBlueprint.t.sol
@@ -171,7 +171,7 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.OperatorMismatch.selector, operator1, operator2));
         blueprint.onJobResult(
-            1, 0, 30, operator2, encodeSandboxCreateInputs(), encodeSandboxCreateOutputs("sandbox-wrong", "{}")
+            1, 0, 30, operator2, keccak256(encodeSandboxCreateInputs()), encodeSandboxCreateOutputs("sandbox-wrong", "{}")
         );
     }
 
@@ -182,7 +182,7 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.OperatorMismatch.selector, address(0), operator1));
         blueprint.onJobResult(
-            1, 0, 40, operator1, encodeSandboxCreateInputs(), encodeSandboxCreateOutputs("sandbox-clear2", "{}")
+            1, 0, 40, operator1, keccak256(encodeSandboxCreateInputs()), encodeSandboxCreateOutputs("sandbox-clear2", "{}")
         );
     }
 
@@ -256,8 +256,13 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
         _createSandbox(1, 100, operator1, "sandbox-own");
 
         vm.prank(tangleCore);
+        blueprint.onJobCall(1, 1, 101, encodeSandboxIdInputs("sandbox-own")); // JOB_SANDBOX_DELETE = 1
+
+        vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.OperatorMismatch.selector, operator1, operator2));
-        blueprint.onJobResult(1, 1, 101, operator2, encodeSandboxIdInputs("sandbox-own"), encodeJsonOutputs("{}"));
+        blueprint.onJobResult(
+            1, 1, 101, operator2, keccak256(encodeSandboxIdInputs("sandbox-own")), encodeJsonOutputs("{}")
+        );
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -405,11 +410,15 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
             target_service_id: 1
         });
 
+        uint8 workflowJobId = blueprint.JOB_WORKFLOW_CREATE();
+        simulateJobCall(1, workflowJobId, 500, encodeWorkflowCreateInputs(req));
+
         vm.expectEmit(true, false, false, true);
         emit SandboxTypes.WorkflowStored(500, "cron", "0 * * * *");
 
-        simulateJobResult(
-            1, blueprint.JOB_WORKFLOW_CREATE(), 500, operator1, encodeWorkflowCreateInputs(req), encodeJsonOutputs("{}")
+        vm.prank(tangleCore);
+        blueprint.onJobResult(
+            1, workflowJobId, 500, operator1, keccak256(encodeWorkflowCreateInputs(req)), encodeJsonOutputs("{}")
         );
 
         SandboxTypes.WorkflowConfig memory config = blueprint.getWorkflow(500);
@@ -459,7 +468,7 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
 
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.InvalidWorkflowTarget.selector, uint8(0)));
-        blueprint.onJobResult(1, workflowJobId, 503, operator1, encodeWorkflowCreateInputs(req), bytes(""));
+        blueprint.onJobResult(1, workflowJobId, 503, operator1, keccak256(encodeWorkflowCreateInputs(req)), bytes(""));
     }
 
     function test_workflowCreateRevertsOnInstanceTargetKindInCloudMode() public {
@@ -479,7 +488,7 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
 
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.InvalidWorkflowTarget.selector, uint8(1)));
-        blueprint.onJobResult(1, workflowJobId, 504, operator1, encodeWorkflowCreateInputs(req), bytes(""));
+        blueprint.onJobResult(1, workflowJobId, 504, operator1, keccak256(encodeWorkflowCreateInputs(req)), bytes(""));
     }
 
     function test_workflowCreateRevertsOnInvalidTargetKind() public {
@@ -499,7 +508,7 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
         simulateJobCall(1, workflowJobId, 505, encodeWorkflowCreateInputs(req2));
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.InvalidWorkflowTarget.selector, uint8(2)));
-        blueprint.onJobResult(1, workflowJobId, 505, operator1, encodeWorkflowCreateInputs(req2), bytes(""));
+        blueprint.onJobResult(1, workflowJobId, 505, operator1, keccak256(encodeWorkflowCreateInputs(req2)), bytes(""));
 
         SandboxTypes.WorkflowCreateRequest memory req255 = SandboxTypes.WorkflowCreateRequest({
             name: "bad-kind-255",
@@ -515,7 +524,7 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
         simulateJobCall(1, workflowJobId, 506, encodeWorkflowCreateInputs(req255));
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.InvalidWorkflowTarget.selector, uint8(255)));
-        blueprint.onJobResult(1, workflowJobId, 506, operator1, encodeWorkflowCreateInputs(req255), bytes(""));
+        blueprint.onJobResult(1, workflowJobId, 506, operator1, keccak256(encodeWorkflowCreateInputs(req255)), bytes(""));
     }
 
     function test_workflowCreateRevertsOnEmptySandboxId() public {
@@ -535,7 +544,7 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
 
         vm.prank(tangleCore);
         vm.expectRevert(SandboxTypes.EmptySandboxId.selector);
-        blueprint.onJobResult(1, workflowJobId, 507, operator1, encodeWorkflowCreateInputs(req), bytes(""));
+        blueprint.onJobResult(1, workflowJobId, 507, operator1, keccak256(encodeWorkflowCreateInputs(req)), bytes(""));
     }
 
     function test_workflowCreateRevertsOnSandboxIdTooLong() public {
@@ -560,7 +569,7 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
 
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.SandboxIdTooLong.selector, uint256(256)));
-        blueprint.onJobResult(1, workflowJobId, 508, operator1, encodeWorkflowCreateInputs(req), bytes(""));
+        blueprint.onJobResult(1, workflowJobId, 508, operator1, keccak256(encodeWorkflowCreateInputs(req)), bytes(""));
     }
 
     function test_workflowCreateStoresRealisticJsonPayload() public {
@@ -610,12 +619,14 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
 
         SandboxTypes.WorkflowControlRequest memory ctrl = SandboxTypes.WorkflowControlRequest({workflow_id: 510});
 
+        uint8 triggerJobId = blueprint.JOB_WORKFLOW_TRIGGER();
+        simulateJobCall(1, triggerJobId, 511, abi.encode(ctrl));
+
         vm.expectEmit(true, false, false, true);
         emit SandboxTypes.WorkflowTriggered(510, 1000);
 
-        simulateJobResult(
-            1, blueprint.JOB_WORKFLOW_TRIGGER(), 511, operator1, abi.encode(ctrl), encodeJsonOutputs("{}")
-        );
+        vm.prank(tangleCore);
+        blueprint.onJobResult(1, triggerJobId, 511, operator1, keccak256(abi.encode(ctrl)), encodeJsonOutputs("{}"));
 
         SandboxTypes.WorkflowConfig memory config = blueprint.getWorkflow(510);
         assertEq(config.last_triggered_at, 1000);
@@ -640,10 +651,14 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
 
         SandboxTypes.WorkflowControlRequest memory ctrl = SandboxTypes.WorkflowControlRequest({workflow_id: 520});
 
+        uint8 cancelJobId = blueprint.JOB_WORKFLOW_CANCEL();
+        simulateJobCall(1, cancelJobId, 521, abi.encode(ctrl));
+
         vm.expectEmit(true, false, false, true);
         emit SandboxTypes.WorkflowCanceled(520, uint64(block.timestamp));
 
-        simulateJobResult(1, blueprint.JOB_WORKFLOW_CANCEL(), 521, operator1, abi.encode(ctrl), encodeJsonOutputs("{}"));
+        vm.prank(tangleCore);
+        blueprint.onJobResult(1, cancelJobId, 521, operator1, keccak256(abi.encode(ctrl)), encodeJsonOutputs("{}"));
 
         assertFalse(blueprint.getWorkflow(520).active);
     }
@@ -662,7 +677,7 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.SandboxAlreadyExists.selector, dupHash));
         blueprint.onJobResult(
-            1, 0, 801, operator1, encodeSandboxCreateInputs(), encodeSandboxCreateOutputs("sandbox-dup", "{}")
+            1, 0, 801, operator1, keccak256(encodeSandboxCreateInputs()), encodeSandboxCreateOutputs("sandbox-dup", "{}")
         );
     }
 
@@ -751,7 +766,7 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
         for (uint8 jobId = 5; jobId <= 6; jobId++) {
             vm.prank(tangleCore);
             vm.expectRevert(abi.encodeWithSelector(AgentSandboxBlueprint.UnknownJobId.selector, jobId));
-            blueprint.onJobResult(1, jobId, uint64(962 + jobId), operator1, bytes(""), bytes(""));
+            blueprint.onJobResult(1, jobId, uint64(962 + jobId), operator1, keccak256(bytes("")), bytes(""));
         }
     }
 
@@ -775,7 +790,7 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
 
         vm.prank(tangleCore);
         vm.expectRevert(SandboxTypes.EmptySandboxId.selector);
-        blueprint.onJobResult(1, 0, 900, operator1, encodeSandboxCreateInputs(), encodeSandboxCreateOutputs("", "{}"));
+        blueprint.onJobResult(1, 0, 900, operator1, keccak256(encodeSandboxCreateInputs()), encodeSandboxCreateOutputs("", "{}"));
     }
 
     function test_createResultRevertsTooLongSandboxId() public {
@@ -792,7 +807,7 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.SandboxIdTooLong.selector, 256));
         blueprint.onJobResult(
-            1, 0, 901, operator1, encodeSandboxCreateInputs(), encodeSandboxCreateOutputs(longId, "{}")
+            1, 0, 901, operator1, keccak256(encodeSandboxCreateInputs()), encodeSandboxCreateOutputs(longId, "{}")
         );
     }
 
@@ -865,13 +880,13 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
     function test_unknownJobIdRevertsOnJobResult() public {
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(AgentSandboxBlueprint.UnknownJobId.selector, 7));
-        blueprint.onJobResult(1, 7, 972, operator1, bytes(""), bytes(""));
+        blueprint.onJobResult(1, 7, 972, operator1, keccak256(bytes("")), bytes(""));
     }
 
     function test_unknownJobIdRevertsOnJobResultHighId() public {
         vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(AgentSandboxBlueprint.UnknownJobId.selector, 255));
-        blueprint.onJobResult(1, 255, 973, operator1, bytes(""), bytes(""));
+        blueprint.onJobResult(1, 255, 973, operator1, keccak256(bytes("")), bytes(""));
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -1066,13 +1081,16 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
         SandboxTypes.WorkflowControlRequest memory ctrl = SandboxTypes.WorkflowControlRequest({workflow_id: 99999});
 
         vm.prank(tangleCore);
+        blueprint.onJobCall(1, 3, 5000, abi.encode(ctrl)); // JOB_WORKFLOW_TRIGGER = 3
+
+        vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.WorkflowNotFound.selector, uint64(99999)));
         blueprint.onJobResult(
             1,
             3,
             5000,
             operator1, // JOB_WORKFLOW_TRIGGER = 3
-            abi.encode(ctrl),
+            keccak256(abi.encode(ctrl)),
             encodeJsonOutputs("{}")
         );
     }
@@ -1085,13 +1103,16 @@ contract AgentSandboxBlueprintTest is BlueprintTestSetup {
         SandboxTypes.WorkflowControlRequest memory ctrl = SandboxTypes.WorkflowControlRequest({workflow_id: 88888});
 
         vm.prank(tangleCore);
+        blueprint.onJobCall(1, 4, 5001, abi.encode(ctrl)); // JOB_WORKFLOW_CANCEL = 4
+
+        vm.prank(tangleCore);
         vm.expectRevert(abi.encodeWithSelector(SandboxTypes.WorkflowNotFound.selector, uint64(88888)));
         blueprint.onJobResult(
             1,
             4,
             5001,
             operator1, // JOB_WORKFLOW_CANCEL = 4
-            abi.encode(ctrl),
+            keccak256(abi.encode(ctrl)),
             encodeJsonOutputs("{}")
         );
     }

--- a/contracts/test/helpers/InstanceSetup.sol
+++ b/contracts/test/helpers/InstanceSetup.sol
@@ -55,6 +55,8 @@ contract InstanceBlueprintTestSetup is Test {
         instance.onJobCall(serviceId, jobIndex, callId, inputs);
     }
 
+    /// @dev tnt-core 0.19: onJobResult takes `bytes32 inputsHash`; the raw inputs
+    ///      are cached by a prior onJobCall. Mirror the driver: cache then hash.
     function simulateJobResult(
         uint64 serviceId,
         uint8 jobIndex,
@@ -63,8 +65,12 @@ contract InstanceBlueprintTestSetup is Test {
         bytes memory inputs,
         bytes memory outputs
     ) internal {
+        if (inputs.length > 0) {
+            vm.prank(tangleCore);
+            instance.onJobCall(serviceId, jobIndex, callId, inputs);
+        }
         vm.prank(tangleCore);
-        instance.onJobResult(serviceId, jobIndex, callId, operator, inputs, outputs);
+        instance.onJobResult(serviceId, jobIndex, callId, operator, keccak256(inputs), outputs);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -161,6 +167,8 @@ contract TeeInstanceBlueprintTestSetup is Test {
         teeInstance.onJobCall(serviceId, jobIndex, callId, inputs);
     }
 
+    /// @dev tnt-core 0.19: onJobResult takes `bytes32 inputsHash`; the raw inputs
+    ///      are cached by a prior onJobCall. Mirror the driver: cache then hash.
     function simulateJobResult(
         uint64 serviceId,
         uint8 jobIndex,
@@ -169,8 +177,12 @@ contract TeeInstanceBlueprintTestSetup is Test {
         bytes memory inputs,
         bytes memory outputs
     ) internal {
+        if (inputs.length > 0) {
+            vm.prank(tangleCore);
+            teeInstance.onJobCall(serviceId, jobIndex, callId, inputs);
+        }
         vm.prank(tangleCore);
-        teeInstance.onJobResult(serviceId, jobIndex, callId, operator, inputs, outputs);
+        teeInstance.onJobResult(serviceId, jobIndex, callId, operator, keccak256(inputs), outputs);
     }
 
     function encodeProvisionOutputs(

--- a/contracts/test/helpers/Setup.sol
+++ b/contracts/test/helpers/Setup.sol
@@ -93,6 +93,10 @@ contract BlueprintTestSetup is Test {
     }
 
     /// @dev Simulate onJobResult as tangleCore.
+    /// @dev tnt-core 0.19: onJobResult takes `bytes32 inputsHash`, and the raw
+    ///      inputs must have been cached by a prior onJobCall. This helper mirrors
+    ///      the real driver: it caches inputs via onJobCall (for the DELETE/WORKFLOW
+    ///      paths that consume them), then passes keccak256(inputs) as inputsHash.
     function simulateJobResult(
         uint64 serviceId,
         uint8 jobIndex,
@@ -101,8 +105,12 @@ contract BlueprintTestSetup is Test {
         bytes memory inputs,
         bytes memory outputs
     ) internal {
+        if (inputs.length > 0) {
+            vm.prank(tangleCore);
+            blueprint.onJobCall(serviceId, jobIndex, callId, inputs);
+        }
         vm.prank(tangleCore);
-        blueprint.onJobResult(serviceId, jobIndex, callId, operator, inputs, outputs);
+        blueprint.onJobResult(serviceId, jobIndex, callId, operator, keccak256(inputs), outputs);
     }
 
     /// @dev Encode sandbox create inputs (empty for create — no sandboxId needed on input).

--- a/contracts/test/invariant/InvariantCounters.t.sol
+++ b/contracts/test/invariant/InvariantCounters.t.sol
@@ -94,7 +94,7 @@ contract SandboxHandler is Test {
             0, // JOB_SANDBOX_CREATE
             callId,
             operator,
-            bytes(""), // inputs (empty for create)
+            keccak256(bytes("")), // inputsHash (empty for create)
             abi.encode(sandboxId, "{}") // outputs: (string sandboxId, string json)
         );
 
@@ -118,14 +118,19 @@ contract SandboxHandler is Test {
 
         uint64 callId = nextCallId++;
 
-        // onJobResult for delete — inputs carry the sandboxId, outputs carry JSON
+        // onJobCall caches the raw delete inputs (tnt-core 0.19); onJobResult
+        // then receives only the inputsHash and consumes the cached entry.
+        vm.prank(tangleCore);
+        blueprint.onJobCall(1, 1, callId, abi.encode(sandboxId)); // JOB_SANDBOX_DELETE = 1
+
+        // onJobResult for delete — inputsHash binds the cached sandboxId, outputs carry JSON
         vm.prank(tangleCore);
         blueprint.onJobResult(
             1, // serviceId
             1, // JOB_SANDBOX_DELETE
             callId,
             operator,
-            abi.encode(sandboxId), // inputs: (string sandboxId)
+            keccak256(abi.encode(sandboxId)), // inputsHash: keccak256((string sandboxId))
             abi.encode("{}") // outputs: (string json)
         );
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -21,7 +21,7 @@ remappings_location = "txt"
 remappings_version = false
 
 [dependencies]
-tnt-core = "0.13.0"
+tnt-core = "0.19.0"
 forge-std = "1.9.6"
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,4 @@
-@openzeppelin/contracts-upgradeable/=dependencies/tnt-core-0.13.0/dependencies/@openzeppelin-contracts-upgradeable-5.1.0/
-@openzeppelin/contracts/=dependencies/tnt-core-0.13.0/dependencies/@openzeppelin-contracts-5.1.0/
+@openzeppelin/contracts-upgradeable/=dependencies/tnt-core-0.19.0/dependencies/@openzeppelin-contracts-upgradeable-5.1.0/
+@openzeppelin/contracts/=dependencies/tnt-core-0.19.0/dependencies/@openzeppelin-contracts-5.1.0/
 forge-std/=dependencies/forge-std-1.9.6/src/
-tnt-core/=dependencies/tnt-core-0.13.0/src/
+tnt-core/=dependencies/tnt-core-0.19.0/src/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -7,7 +7,7 @@ integrity = "e9ecdc364d152157431e5df5aa041ffddbe9bb1c1ad81634b1e72df9e23814e8"
 
 [[dependencies]]
 name = "tnt-core"
-version = "0.13.0"
-url = "https://soldeer-revisions.s3.amazonaws.com/tnt-core/0_13_0_08-05-2026_21:58:28_tnt-core.zip"
-checksum = "b800ed4ca62ef85a7db2cbfcbfb0649459c5dfe714851581ef3069cccb595391"
-integrity = "f3a9b91524f1d24b5a3a48e47cf8576d9d965b4ac79edba67870e3f2ea9d550a"
+version = "0.19.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/tnt-core/0_19_0_09-07-2026_14:56:15_tnt-core-019.zip"
+checksum = "70c583e94f61c6cc4c4c6f5827a9f84083e269c4e34e4334b8dad8315b6ec288"
+integrity = "d5c1a30301b69e62bac407f90d2af3fb2b18b49699f39a7dbc9dfbd95fb98ec4"


### PR DESCRIPTION
## What

Migrate `AgentSandboxBlueprint` from tnt-core **0.13** to **0.19**, closing the last gap to a working agent-sandbox lifecycle (create → run → health → **delete**) on the live tnt-core 0.19 chain.

## Why

tnt-core 0.19 changed `IBlueprintServiceManager.onJobResult`'s 5th param from `bytes inputs` → `bytes32 inputsHash` (dispatch selector `c40c80d1` → `e649fc03`). The already-deployed blueprint-4 BSM was compiled against 0.13, so on the 0.19 chain its `handleCreateResult` **never fired** — sandboxes never registered on-chain (`getServiceStats().totalSandboxes == 0`) and **delete reverted `SandboxNotFound`**. Create/run/health were already green.

## Changes

- **soldeer dep 0.13.0 → 0.19.0.** Published `tnt-core~0.19.0` to Soldeer from the deployed `bindings-v0.19.0` tag (0.19 wasn't on the registry — only 0.18, which still carries the old ABI). Fixed the OZ/tnt-core remappings to 0.19.
- **`onJobResult` rewritten to the 0.19 signature.** The DELETE + WORKFLOW result paths still need the raw inputs, which 0.19 no longer forwards. `onJobCall` now caches them keyed by `[serviceId][jobCallId]`; `onJobResult` reads them back, asserts `keccak256(inputs) == inputsHash`, consumes, then clears (mirrors the existing `createAssignments` pattern). New `jobCallInputs` mapping appended last to preserve storage layout.
- **All test call sites + helpers** updated to the cache-then-hash shape. Full suite green: **168 passed / 0 failed**; the delete invariant handler ran **64,020 calls with 0 reverts** (proves the cached inputs are byte-exact vs the hash).
- **Deploy tooling:** new `DeployTempo.s.sol` (deploys one *unbound* 0.19 sandbox BSM + registers exactly one blueprint — the manager binds it during `createBlueprint`). Made `SetSandboxSourcesV013` / `NewSandboxService` blueprint-id-configurable via env.
- **Port fix (operator binary):** give each co-located sandbox service a distinct preferred operator-API port (`base + service_id`). The BPM port allocator honours the preferred port verbatim and fails (`Address already in use`) rather than falling back, so multiple sandbox services all preferring `9090` collide and only the lowest-service-id one binds.

## Live Tempo (chain 42431) deploy — proven on-chain

| Artifact | Value |
|---|---|
| New 0.19 sandbox BSM | `0x1CA83d16d3f823D60D678eb17bBe4c675d81c548` |
| New blueprint id | **8** (bound: BSM `blueprintId()` returns 8) |
| On-chain selector check | BSM has `e649fc03`, zero `c40c80d1` |
| New service id | **5** (operator `0x5Af6…e0ED` approved) |
| Sources | v0.1.3, sha `41242ef4…`, operator acked; manager fetched the fixed binary |
| Settlement / rates | PathUSD `0x20c0…`, jobs [0,1] = 5 PathUSD each |

Key tx hashes: BSM deploy `0x6a2101…`, createBlueprint `0x285efe…`, registerOperator `0xa2b664…`, setSources `0xd8ce64…`, ack `0xd4bfd8…`, settlement `0xbaa1e1…`, rates `0x0d7595…`, requestService `0xb7255d…`, approveService `0x2b6e17…`.

## Remaining live-box step (documented, not force-greened)

The manager auto-discovered service 5, fetched the fixed binary (sha `41242ef4…`), and spawns `svc-8-5` — but the process exits with `Address already in use` because a legacy blueprint-4 sandbox service already holds `9090`. This is the pre-existing single-sandbox-per-port limitation. The port fix in this PR resolves it, but takes effect only after a new operator-binary **release + on-chain source update** for blueprint 8. The two protected operators (trading `svc-0-0`, inference `svc-7-2`) were untouched and remain healthy.
