### PR TITLE
feat(admission): resource-based host CPU budget so a box can't be oversubscribed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,13 @@ SIDECAR_PULL_IMAGE=true
 # accounted at SANDBOX_MAX_MEMORY_MB when set) over budget → 503 Unavailable.
 # SANDBOX_HOST_MEMORY_BUDGET_MB=0
 
+# Total CPU cores admissible across all running sandboxes. 0 = disabled.
+# At admission, committed CPU (running + incoming; unlimited sandboxes accounted
+# at SANDBOX_MAX_CPU_CORES when set) over budget → 503 Unavailable. Set this so
+# a burst of creates can't oversubscribe host CPU even under the count cap.
+# SANDBOX_CPU_BUDGET is accepted as an alias.
+# SANDBOX_HOST_CPU_BUDGET=0
+
 # ── Firecracker Warm Pool / Snapshot Restore (optional) ──────────────────────
 
 # Number of pre-restored Firecracker VMs kept claimable (0 = disabled, the

--- a/sandbox-runtime/src/reaper/tests.rs
+++ b/sandbox-runtime/src/reaper/tests.rs
@@ -71,6 +71,7 @@ fn test_config() -> SidecarRuntimeConfig {
         sandbox_max_memory_mb: 0,
         sandbox_max_disk_gb: 0,
         sandbox_host_memory_budget_mb: 0,
+        sandbox_host_cpu_budget: 0,
     }
 }
 

--- a/sandbox-runtime/src/runtime/admission.rs
+++ b/sandbox-runtime/src/runtime/admission.rs
@@ -192,7 +192,107 @@ pub(crate) fn enforce_host_memory_budget(
     )
 }
 
-/// Per-sandbox resource maxima + host memory budget, applied under
+/// CPU cores a sandbox is accounted at for the host CPU budget.
+///
+/// Symmetric with [`accounted_memory_mb`]: `None` means the footprint is
+/// unknowable — the sandbox requests unlimited CPU (0) and no
+/// `SANDBOX_MAX_CPU_CORES` clamp is configured — callers skip it (with a
+/// one-time warning) rather than guessing.
+pub(crate) fn accounted_cpu_cores(cpu_cores: u64, sandbox_max_cpu_cores: u64) -> Option<u64> {
+    if cpu_cores > 0 {
+        Some(cpu_cores)
+    } else if sandbox_max_cpu_cores > 0 {
+        Some(sandbox_max_cpu_cores)
+    } else {
+        None
+    }
+}
+
+pub(crate) static UNACCOUNTABLE_CPU_WARN: std::sync::Once = std::sync::Once::new();
+
+/// Decision core of the host CPU budget, separated from store access so it is
+/// unit-testable. `budget == 0` disables the check. Records (and an incoming
+/// request) with unknowable footprint are skipped with a one-time warning —
+/// see [`accounted_cpu_cores`]. Mirrors [`check_host_memory_budget`]; there is
+/// no CPU analogue of the warm-pool memory reservation because warm VMs pin
+/// host RAM but time-share CPU.
+pub(crate) fn check_host_cpu_budget(
+    running_cpu_cores: impl IntoIterator<Item = u64>,
+    incoming_cpu_cores: u64,
+    sandbox_max_cpu_cores: u64,
+    budget: u64,
+) -> Result<()> {
+    if budget == 0 {
+        return Ok(());
+    }
+
+    let mut live_cores: u64 = 0;
+    let mut unaccounted = 0usize;
+    for cpu_cores in running_cpu_cores {
+        match accounted_cpu_cores(cpu_cores, sandbox_max_cpu_cores) {
+            Some(cores) => live_cores = live_cores.saturating_add(cores),
+            None => unaccounted += 1,
+        }
+    }
+    let incoming = match accounted_cpu_cores(incoming_cpu_cores, sandbox_max_cpu_cores) {
+        Some(cores) => cores,
+        None => {
+            unaccounted += 1;
+            0
+        }
+    };
+    if unaccounted > 0 {
+        UNACCOUNTABLE_CPU_WARN.call_once(|| {
+            tracing::warn!(
+                unaccounted,
+                "Host CPU budget cannot account for sandboxes with unlimited CPU; \
+                 set SANDBOX_MAX_CPU_CORES so every sandbox has a bounded footprint"
+            );
+        });
+    }
+
+    let committed = live_cores.saturating_add(incoming);
+    if committed > budget {
+        return Err(SandboxError::Unavailable(format!(
+            "Host CPU budget exceeded: {committed} cores committed ({live_cores} running + \
+             {incoming} requested) > SANDBOX_HOST_CPU_BUDGET={budget}. Retry on another operator."
+        )));
+    }
+
+    Ok(())
+}
+
+/// Enforce `SANDBOX_HOST_CPU_BUDGET` at admission. Must be called with
+/// [`CREATION_PERMIT`] held so the running-CPU sum cannot race a concurrent
+/// create. Mirrors [`enforce_host_memory_budget`].
+pub(crate) fn enforce_host_cpu_budget(
+    config: &SidecarRuntimeConfig,
+    incoming_cpu_cores: u64,
+    reused_sandbox_id: Option<&str>,
+) -> Result<()> {
+    if config.sandbox_host_cpu_budget == 0 {
+        return Ok(());
+    }
+
+    let running_cpu_cores: Vec<u64> = sandboxes()?
+        .values()?
+        .into_iter()
+        .filter(|record| record.state == SandboxState::Running)
+        // A create that replaces an existing record (recreate / image upgrade)
+        // frees the old container's CPU, so it doesn't count against the budget.
+        .filter(|record| reused_sandbox_id != Some(record.id.as_str()))
+        .map(|record| record.cpu_cores)
+        .collect();
+
+    check_host_cpu_budget(
+        running_cpu_cores,
+        incoming_cpu_cores,
+        config.sandbox_max_cpu_cores,
+        config.sandbox_host_cpu_budget,
+    )
+}
+
+/// Per-sandbox resource maxima + host memory/CPU budgets, applied under
 /// [`CREATION_PERMIT`] before backend dispatch. Returns the request with
 /// effective (possibly clamped) resource values so the container, the stored
 /// record, and the budget accounting all agree.
@@ -209,6 +309,7 @@ pub(crate) fn admit_sandbox_resources(
     admitted.disk_gb =
         enforce_resource_max(request.disk_gb, config.sandbox_max_disk_gb, "disk_gb")?;
     enforce_host_memory_budget(config, admitted.memory_mb, sandbox_id_override)?;
+    enforce_host_cpu_budget(config, admitted.cpu_cores, sandbox_id_override)?;
     Ok(admitted)
 }
 

--- a/sandbox-runtime/src/runtime/mod.rs
+++ b/sandbox-runtime/src/runtime/mod.rs
@@ -196,6 +196,8 @@ pub struct SidecarRuntimeConfig {
     pub sandbox_max_disk_gb: u64,
     /// Total memory (MB) admissible across all running sandboxes. 0 = disabled.
     pub sandbox_host_memory_budget_mb: u64,
+    /// Total CPU cores admissible across all running sandboxes. 0 = disabled.
+    pub sandbox_host_cpu_budget: u64,
 }
 
 static RUNTIME_CONFIG: OnceCell<SidecarRuntimeConfig> = OnceCell::new();
@@ -318,6 +320,14 @@ impl SidecarRuntimeConfig {
                 .ok()
                 .and_then(|v| v.parse::<u64>().ok())
                 .unwrap_or(0);
+            // Total CPU cores admissible across all running sandboxes. Primary
+            // name mirrors SANDBOX_HOST_MEMORY_BUDGET_MB; SANDBOX_CPU_BUDGET is
+            // accepted as an alias. 0 = disabled (unlimited).
+            let sandbox_host_cpu_budget = env::var("SANDBOX_HOST_CPU_BUDGET")
+                .or_else(|_| env::var("SANDBOX_CPU_BUDGET"))
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(0);
 
             // Validate critical configuration values. Panics are intentional here —
             // these represent unrecoverable startup misconfigurations. Unlike process::exit,
@@ -339,6 +349,7 @@ impl SidecarRuntimeConfig {
                 max_memory_mb = sandbox_max_memory_mb,
                 max_disk_gb = sandbox_max_disk_gb,
                 host_memory_budget_mb = sandbox_host_memory_budget_mb,
+                host_cpu_budget = sandbox_host_cpu_budget,
                 "Runtime configuration loaded"
             );
 
@@ -366,6 +377,7 @@ impl SidecarRuntimeConfig {
                 sandbox_max_memory_mb,
                 sandbox_max_disk_gb,
                 sandbox_host_memory_budget_mb,
+                sandbox_host_cpu_budget,
             }
         })
     }

--- a/sandbox-runtime/src/runtime/tests.rs
+++ b/sandbox-runtime/src/runtime/tests.rs
@@ -989,6 +989,7 @@ mod core_logic_tests {
             sandbox_max_memory_mb: 0,
             sandbox_max_disk_gb: 0,
             sandbox_host_memory_budget_mb: 0,
+            sandbox_host_cpu_budget: 0,
         }
     }
 
@@ -1111,6 +1112,55 @@ mod core_logic_tests {
         assert!(check_host_memory_budget([0u64; 0], 1, 2048, 2048, 2048).is_err());
         // A zero budget still disables the check even with a reservation set.
         assert!(check_host_memory_budget([0u64; 0], 0, 0, 0, 4096).is_ok());
+    }
+
+    // ── admission control: host CPU budget (symmetric with memory budget) ──
+
+    #[test]
+    fn accounted_cpu_prefers_request_then_max_then_unknown() {
+        assert_eq!(accounted_cpu_cores(4, 8), Some(4));
+        assert_eq!(accounted_cpu_cores(0, 8), Some(8));
+        assert_eq!(accounted_cpu_cores(0, 0), None);
+    }
+
+    #[test]
+    fn cpu_budget_disabled_when_zero() {
+        // budget == 0 is unlimited: any committed load admits (back-compat with
+        // deployments that never set SANDBOX_HOST_CPU_BUDGET).
+        assert!(check_host_cpu_budget([u64::MAX, u64::MAX], 999_999, 0, 0).is_ok());
+    }
+
+    #[test]
+    fn cpu_budget_rejects_over_budget_as_unavailable() {
+        // 2 + 4 running + 4 requested = 10 > 8.
+        let err = check_host_cpu_budget([2, 4], 4, 0, 8).unwrap_err();
+        assert!(matches!(err, SandboxError::Unavailable(_)), "got {err:?}");
+        assert!(err.to_string().contains("CPU budget"), "got {err}");
+    }
+
+    #[test]
+    fn cpu_budget_admits_exactly_at_budget() {
+        // 2 + 4 running + 2 requested = 8 == 8 boundary admits.
+        assert!(check_host_cpu_budget([2, 4], 2, 0, 8).is_ok());
+        // One more core over the boundary rejects.
+        assert!(check_host_cpu_budget([2, 4], 3, 0, 8).is_err());
+    }
+
+    #[test]
+    fn cpu_budget_counts_unlimited_records_at_max() {
+        // A running record with cpu_cores=0 is accounted at SANDBOX_MAX_CPU_CORES:
+        // 4 (0→max) + 4 requested = 8 ≤ 8 passes…
+        assert!(check_host_cpu_budget([0], 4, 4, 8).is_ok());
+        // …and one extra running core rejects.
+        assert!(check_host_cpu_budget([0, 1], 4, 4, 8).is_err());
+    }
+
+    #[test]
+    fn cpu_budget_skips_unaccountable_records() {
+        // Without SANDBOX_MAX_CPU_CORES, unlimited records can't be accounted
+        // and are skipped (warned once) rather than guessed.
+        assert!(check_host_cpu_budget([0, 0], 2, 0, 4).is_ok());
+        assert!(check_host_cpu_budget([3, 0], 2, 0, 4).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A box can be exhausted by a burst of sandbox creates. Today the only admission gate on aggregate load is a sandbox **count** cap (`SANDBOX_MAX_COUNT`) plus a host **memory** budget (`SANDBOX_HOST_MEMORY_BUDGET_MB`). There is no equivalent for **CPU**: many small-memory-but-CPU-heavy sandboxes can pass the count and memory gates yet oversubscribe host cores.

## Change

Add a host CPU budget, symmetric with the existing host memory budget. At admission (under `CREATION_PERMIT`, before backend dispatch and store insertion), committed CPU — running sandboxes plus the incoming request — is checked against the operator's budget. Over budget → `503 Unavailable` so the caller retries on an operator with headroom.

- `accounted_cpu_cores(cpu_cores, sandbox_max_cpu_cores)` — mirrors `accounted_memory_mb`; an unlimited (0) request is accounted at `SANDBOX_MAX_CPU_CORES` when set, else skipped with a one-time warning rather than guessed.
- `check_host_cpu_budget(running, incoming, max, budget)` — pure decision core, unit-tested. `budget == 0` disables the check (unlimited).
- `enforce_host_cpu_budget(config, incoming, reused_id)` — reads Running records from the store (excluding a reused/recreated slot), calls the decision core. Called from `admit_sandbox_resources`.
- Config `sandbox_host_cpu_budget` from `SANDBOX_HOST_CPU_BUDGET` (alias `SANDBOX_CPU_BUDGET`), default `0` = unlimited so existing deployments are unchanged.

No warm-pool reservation term for CPU: warm Firecracker VMs pin host RAM (hence the memory reservation) but time-share CPU.

## Why this shape

Mirrors the memory-budget trio exactly — same fail-closed accounting, same `Unavailable` rejection class, same permit ordering — so the two host budgets read as one pattern. The store is the admission source of truth (it filters by `Running` and excludes the reused slot); the metrics `allocated_cpu_cores` atomic remains the QoS gauge.

## Ordering / race safety

`admit_sandbox_resources` (which now calls `enforce_host_cpu_budget`) runs in `create_sidecar_with_token` **after** `acquire_creation_permit()` and **before** any `sandboxes()?.insert(...)`, identical to the count-limit and memory-budget checks — concurrent creates cannot both pass.

## Tests

`sandbox-runtime` lib suite: **474 passed, 0 failed, 2 ignored**. New CPU-budget unit tests (in `runtime/tests.rs`, alongside the memory-budget tests):

- over-budget rejects as `Unavailable`
- exact-boundary admits, one core over rejects
- `budget == 0` always admits (back-compat)
- unlimited records accounted at `SANDBOX_MAX_CPU_CORES`
- unaccountable records skipped when no per-sandbox max set
- `accounted_cpu_cores` request→max→unknown precedence

`cargo check -p ai-agent-sandbox-blueprint-bin` compiles clean.
