### PR TITLE
perf(sandbox-runtime): create→ready measurement harness + docker round-trip + admission wins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10075,9 +10075,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"

--- a/ai-agent-sandbox-blueprint-bin/src/main.rs
+++ b/ai-agent-sandbox-blueprint-bin/src/main.rs
@@ -244,7 +244,9 @@ async fn main() -> Result<(), blueprint_sdk::Error> {
             .request_port(Some(preferred_port))
             .await
             .map_err(|e| blueprint_sdk::Error::Other(format!("BPM port allocation failed: {e}")))?;
-        info!("BPM allocated port {port} for operator API (service {service_id}, preferred {preferred_port})");
+        info!(
+            "BPM allocated port {port} for operator API (service {service_id}, preferred {preferred_port})"
+        );
         (port, [127, 0, 0, 1u8])
     } else {
         (preferred_port, [0, 0, 0, 0u8])

--- a/sandbox-runtime/src/firecracker/warm.rs
+++ b/sandbox-runtime/src/firecracker/warm.rs
@@ -25,10 +25,11 @@ pub fn reconcile_warm_orphans_for_tests() {
 /// the caller logs misses and proceeds with the cold path.
 ///
 /// MUST only be called from [`create_and_start`]: the runtime layer runs
-/// `admit_sandbox_resources` + `enforce_sandbox_count_limit` (under the
-/// creation permit) before dispatching here, which is what makes a warm
-/// claim count against `SANDBOX_MAX_COUNT` / the host memory budget exactly
-/// like a cold boot. Pool inventory itself is not a sandbox and is never
+/// `admit_sandbox_resources` (per-sandbox maxima + the single-pass store
+/// admission covering the count cap and memory budget, under the creation
+/// permit) before dispatching here, which is what makes a warm claim count
+/// against `SANDBOX_MAX_COUNT` / the host memory budget exactly like a
+/// cold boot. Pool inventory itself is not a sandbox and is never
 /// admission-accounted — see the invariant note in [`firecracker_warm`].
 pub(crate) async fn warm_claim(req: &FirecrackerCreateRequest) -> Result<WarmOutcome> {
     let pool_size = firecracker_warm::configured_pool_size()?;

--- a/sandbox-runtime/src/firecracker_warm/mod.rs
+++ b/sandbox-runtime/src/firecracker_warm/mod.rs
@@ -32,8 +32,9 @@
 //! Pool inventory (templates + pre-restored entries) is NOT a live sandbox:
 //! it never enters the sandbox store. A warm claim itself is admitted exactly
 //! like a cold boot — the claim runs inside `firecracker::create_and_start`,
-//! which the runtime layer only calls AFTER `admit_sandbox_resources` +
-//! `enforce_sandbox_count_limit` have passed under the creation permit.
+//! which the runtime layer only calls AFTER `admit_sandbox_resources` (the
+//! per-sandbox maxima plus the single-pass store admission covering the
+//! count cap and memory budget) has passed under the creation permit.
 //!
 //! The pool's own standing footprint is reserved against the host memory
 //! budget by [`reserved_host_memory_mb`]: `admit_sandbox_resources` adds

--- a/sandbox-runtime/src/runtime/admission.rs
+++ b/sandbox-runtime/src/runtime/admission.rs
@@ -54,12 +54,86 @@ pub(crate) fn check_sandbox_count_limit(
     Ok(())
 }
 
-pub(crate) fn enforce_sandbox_count_limit(
+/// One-pass scan of the store's records for admission: total row count,
+/// whether the incoming create replaces an existing slot, and the running
+/// set's memory footprints. Pure over a record slice so it is unit-testable
+/// without a store; decisions stay in [`check_sandbox_count_limit`] and
+/// [`check_host_memory_budget`], which are unchanged.
+pub(crate) struct AdmissionScan {
+    pub(crate) total_count: usize,
+    pub(crate) reusing_existing_slot: bool,
+    pub(crate) running_memory_mb: Vec<u64>,
+}
+
+pub(crate) fn scan_records_for_admission(
+    records: &[SandboxRecord],
+    reused_sandbox_id: Option<&str>,
+) -> AdmissionScan {
+    let mut scan = AdmissionScan {
+        total_count: records.len(),
+        reusing_existing_slot: false,
+        running_memory_mb: Vec::with_capacity(records.len()),
+    };
+    for record in records {
+        // Store keys always equal record ids (every insert uses the record's
+        // id as its key), so id equality here is the same signal as the
+        // former per-backend `store.get(sandbox_id).is_some()` check.
+        if reused_sandbox_id == Some(record.id.as_str()) {
+            // A create that replaces an existing record (recreate / image
+            // upgrade) frees the old container's memory — excluded from the
+            // running sum — and the count cap treats the slot as reused.
+            scan.reusing_existing_slot = true;
+            continue;
+        }
+        if record.state == SandboxState::Running {
+            scan.running_memory_mb.push(record.memory_mb);
+        }
+    }
+    scan
+}
+
+/// Sandbox count cap + host memory budget from ONE store read, under
+/// [`CREATION_PERMIT`].
+///
+/// Replaces the former `enforce_sandbox_count_limit` (called per backend) +
+/// `enforce_host_memory_budget` (called at admission) pair, which each
+/// deserialized the full store per create. Same decisions, same error
+/// precedence: the budget check ran before the backends' count check, and
+/// still does. When neither limit is configured the store is not read at all.
+pub(crate) fn enforce_store_admission(
     config: &SidecarRuntimeConfig,
-    reusing_existing_slot: bool,
+    incoming_memory_mb: u64,
+    reused_sandbox_id: Option<&str>,
 ) -> Result<()> {
-    let current = sandboxes()?.values()?.len();
-    check_sandbox_count_limit(current, reusing_existing_slot, config.sandbox_max_count)
+    let budget_enabled = config.sandbox_host_memory_budget_mb != 0;
+    let count_capped = config.sandbox_max_count != 0;
+    if !budget_enabled && !count_capped {
+        return Ok(());
+    }
+
+    let records = sandboxes()?.values()?;
+    let scan = scan_records_for_admission(&records, reused_sandbox_id);
+
+    if budget_enabled {
+        // The warm pool's standing footprint (templates + pre-restored
+        // entries) never enters the store, so reserve it here or an enabled
+        // pool silently over-commits host RAM. Only read when the budget is
+        // on — zero-cost otherwise, as before.
+        let reserved_mb = crate::firecracker_warm::reserved_host_memory_mb()?;
+        check_host_memory_budget(
+            scan.running_memory_mb,
+            incoming_memory_mb,
+            config.sandbox_max_memory_mb,
+            config.sandbox_host_memory_budget_mb,
+            reserved_mb,
+        )?;
+    }
+
+    check_sandbox_count_limit(
+        scan.total_count,
+        scan.reusing_existing_slot,
+        config.sandbox_max_count,
+    )
 }
 
 /// Apply a per-sandbox operator maximum to one requested resource value.
@@ -156,46 +230,11 @@ pub(crate) fn check_host_memory_budget(
     Ok(())
 }
 
-/// Enforce `SANDBOX_HOST_MEMORY_BUDGET_MB` at admission. Must be called with
-/// [`CREATION_PERMIT`] held so the running-memory sum cannot race a
-/// concurrent create.
-pub(crate) fn enforce_host_memory_budget(
-    config: &SidecarRuntimeConfig,
-    incoming_memory_mb: u64,
-    reused_sandbox_id: Option<&str>,
-) -> Result<()> {
-    if config.sandbox_host_memory_budget_mb == 0 {
-        return Ok(());
-    }
-
-    let running_memory_mb: Vec<u64> = sandboxes()?
-        .values()?
-        .into_iter()
-        .filter(|record| record.state == SandboxState::Running)
-        // A create that replaces an existing record (recreate / image upgrade)
-        // frees the old container's memory, so it doesn't count against the budget.
-        .filter(|record| reused_sandbox_id != Some(record.id.as_str()))
-        .map(|record| record.memory_mb)
-        .collect();
-
-    // The warm pool's standing footprint (templates + pre-restored entries)
-    // never enters the store, so reserve it here or an enabled pool silently
-    // over-commits host RAM. Zero when warm serving is disabled.
-    let reserved_mb = crate::firecracker_warm::reserved_host_memory_mb()?;
-
-    check_host_memory_budget(
-        running_memory_mb,
-        incoming_memory_mb,
-        config.sandbox_max_memory_mb,
-        config.sandbox_host_memory_budget_mb,
-        reserved_mb,
-    )
-}
-
-/// Per-sandbox resource maxima + host memory budget, applied under
-/// [`CREATION_PERMIT`] before backend dispatch. Returns the request with
-/// effective (possibly clamped) resource values so the container, the stored
-/// record, and the budget accounting all agree.
+/// Per-sandbox resource maxima + single-pass store admission (host memory
+/// budget and sandbox count cap), applied under [`CREATION_PERMIT`] before
+/// backend dispatch. Returns the request with effective (possibly clamped)
+/// resource values so the container, the stored record, and the budget
+/// accounting all agree.
 pub(crate) fn admit_sandbox_resources(
     config: &SidecarRuntimeConfig,
     request: &CreateSandboxParams,
@@ -208,7 +247,7 @@ pub(crate) fn admit_sandbox_resources(
         enforce_resource_max(request.memory_mb, config.sandbox_max_memory_mb, "memory_mb")?;
     admitted.disk_gb =
         enforce_resource_max(request.disk_gb, config.sandbox_max_disk_gb, "disk_gb")?;
-    enforce_host_memory_budget(config, admitted.memory_mb, sandbox_id_override)?;
+    enforce_store_admission(config, admitted.memory_mb, sandbox_id_override)?;
     Ok(admitted)
 }
 

--- a/sandbox-runtime/src/runtime/create.rs
+++ b/sandbox-runtime/src/runtime/create.rs
@@ -128,12 +128,12 @@ pub(crate) async fn create_sidecar_tee(
     let sandbox_id = sandbox_id_override
         .map(ToString::to_string)
         .unwrap_or_else(next_sandbox_id);
-    let previous_store_entry = existing_store_entry_for_override(&sandbox_id)?;
-
-    // Same admission gate as the Docker/Firecracker paths — TEE creates must
-    // not bypass the host sandbox count cap. Runs with [`CREATION_PERMIT`]
-    // held (acquired in `create_sidecar_with_token`) so the check can't race.
-    enforce_sandbox_count_limit(config, previous_store_entry.is_some())?;
+    // Count cap + memory budget were already enforced for every backend —
+    // TEE included — in a single store pass by `admit_sandbox_resources`,
+    // under the [`CREATION_PERMIT`] acquired in `create_sidecar_with_token`
+    // (still held here), so the check can't race. Unlike the Docker path,
+    // the TEE path never used its previous store entry for rollback, so no
+    // extra store read remains here.
 
     let token = match token_override {
         Some(t) if !t.trim().is_empty() => t.to_string(),

--- a/sandbox-runtime/src/runtime/create.rs
+++ b/sandbox-runtime/src/runtime/create.rs
@@ -9,6 +9,24 @@ pub async fn create_sidecar(
     request: &CreateSandboxParams,
     tee: Option<&dyn crate::tee::TeeBackend>,
 ) -> Result<(SandboxRecord, Option<crate::tee::AttestationReport>)> {
+    create_sidecar_with_token(request, tee, None, None)
+        .await
+        .map(|(record, attestation, _timings)| (record, attestation))
+}
+
+/// [`create_sidecar`] plus the measured per-stage [`CreateTimings`] breakdown.
+///
+/// Same create, same side effects — the timings are pure observation. Used by
+/// the lifecycle bench (`tests/lifecycle_bench.rs`) and available to any
+/// caller that wants the real create latency decomposition.
+pub async fn create_sidecar_timed(
+    request: &CreateSandboxParams,
+    tee: Option<&dyn crate::tee::TeeBackend>,
+) -> Result<(
+    SandboxRecord,
+    Option<crate::tee::AttestationReport>,
+    CreateTimings,
+)> {
     create_sidecar_with_token(request, tee, None, None).await
 }
 
@@ -21,15 +39,24 @@ pub(crate) async fn create_sidecar_with_token(
     tee: Option<&dyn crate::tee::TeeBackend>,
     token_override: Option<&str>,
     sandbox_id_override: Option<&str>,
-) -> Result<(SandboxRecord, Option<crate::tee::AttestationReport>)> {
+) -> Result<(
+    SandboxRecord,
+    Option<crate::tee::AttestationReport>,
+    CreateTimings,
+)> {
+    let requested = std::time::Instant::now();
     let _creation_permit = acquire_creation_permit().await;
+    let permit_wait = requested.elapsed();
     // Resource admission runs under the permit and before backend dispatch:
     // per-sandbox maxima (reject over-max, clamp unlimited-to-max) and the
     // host memory budget apply identically to Docker, Firecracker, and TEE.
+    let admission_span = std::time::Instant::now();
     let admitted =
         admit_sandbox_resources(SidecarRuntimeConfig::load(), request, sandbox_id_override)?;
+    let admission = admission_span.elapsed();
     let request = &admitted;
-    match resolve_runtime_backend(request)? {
+    let backend = resolve_runtime_backend(request)?;
+    let (record, attestation, mut timings) = match backend {
         RuntimeBackend::Tee => {
             let backend = tee.ok_or_else(|| {
                 SandboxError::Validation(
@@ -37,19 +64,26 @@ pub(crate) async fn create_sidecar_with_token(
                 )
             })?;
             validate_requested_tee_backend(request, backend)?;
-            create_sidecar_tee(request, backend, token_override, sandbox_id_override).await
+            let (record, attestation) =
+                create_sidecar_tee(request, backend, token_override, sandbox_id_override).await?;
+            (record, attestation, CreateTimings::default())
         }
         RuntimeBackend::Firecracker => {
-            create_sidecar_firecracker(request, token_override, sandbox_id_override)
-                .await
-                .map(|r| (r, None))
+            let record =
+                create_sidecar_firecracker(request, token_override, sandbox_id_override).await?;
+            (record, None, CreateTimings::default())
         }
         RuntimeBackend::Docker => {
-            create_sidecar_docker(request, token_override, sandbox_id_override)
-                .await
-                .map(|r| (r, None))
+            let (record, timings) =
+                create_sidecar_docker(request, token_override, sandbox_id_override).await?;
+            (record, None, timings)
         }
-    }
+    };
+    timings.permit_wait = Some(permit_wait);
+    timings.admission = Some(admission);
+    timings.total = requested.elapsed();
+    timings.log(&record.id, backend);
+    Ok((record, attestation, timings))
 }
 
 pub(crate) fn validate_requested_tee_backend(

--- a/sandbox-runtime/src/runtime/docker_create.rs
+++ b/sandbox-runtime/src/runtime/docker_create.rs
@@ -1,10 +1,14 @@
 use super::*;
 
+/// Docker-backed create with per-stage [`CreateTimings`]. The shared entry
+/// point (`create_sidecar_with_token`) fills the permit/admission/total
+/// fields; this function fills every Docker stage it passes through.
 pub(crate) async fn create_sidecar_docker(
     request: &CreateSandboxParams,
     token_override: Option<&str>,
     sandbox_id_override: Option<&str>,
-) -> Result<SandboxRecord> {
+) -> Result<(SandboxRecord, CreateTimings)> {
+    let mut timings = CreateTimings::default();
     let config = SidecarRuntimeConfig::load();
     let sandbox_id = sandbox_id_override
         .map(ToString::to_string)
@@ -14,7 +18,9 @@ pub(crate) async fn create_sidecar_docker(
     // Recreating an existing sandbox reuses its existing store slot.
     enforce_sandbox_count_limit(config, previous_store_entry.is_some())?;
 
+    let stage = std::time::Instant::now();
     let builder = docker_builder().await?;
+    timings.docker_connect = Some(stage.elapsed());
 
     // Use the user-supplied image if provided, otherwise fall back to the
     // operator's SIDECAR_IMAGE env var.
@@ -24,7 +30,9 @@ pub(crate) async fn create_sidecar_docker(
         request.image.clone()
     };
 
+    let stage = std::time::Instant::now();
     ensure_image_pulled(&builder, &effective_image).await?;
+    timings.image_pull = Some(stage.elapsed());
     let original_image = effective_image.clone();
 
     let token = match token_override {
@@ -75,7 +83,19 @@ pub(crate) async fn create_sidecar_docker(
         .env(env_vars)
         .config_override(override_config);
 
+    // Split Docker-side create from start so each hop is visible. On a
+    // transient create failure we do NOT bail: `Container::start(false)`
+    // re-runs create while the container id is unset, so the pre-existing
+    // retry-once semantics of `start_container_with_retry` are preserved.
+    let stage = std::time::Instant::now();
+    if let Err(err) = docker_timeout("create_container", container.create()).await {
+        tracing::debug!(error = %err, "container create failed; start path will retry it");
+    }
+    timings.container_create = Some(stage.elapsed());
+
+    let stage = std::time::Instant::now();
     start_container_with_retry(&mut container).await?;
+    timings.container_start = Some(stage.elapsed());
 
     let container_id = container
         .id()
@@ -88,6 +108,7 @@ pub(crate) async fn create_sidecar_docker(
             .copied()
             .map(|port| (port, 0u16))
             .collect::<HashMap<_, _>>();
+        let stage = std::time::Instant::now();
         let (sidecar_url, sidecar_port, ssh_port, extra_port_map) =
             retry_port_mapping_lookup_inner(
                 "create endpoint resolution",
@@ -106,7 +127,9 @@ pub(crate) async fn create_sidecar_docker(
                 },
             )
             .await?;
+        timings.port_mapping = Some(stage.elapsed());
 
+        let stage = std::time::Instant::now();
         // Repair workspace ownership before the sidecar spawns OpenCode as the
         // agent user (uid 1000).  Without this, /home/agent dirs may be root-owned
         // and the demoted process crashes with EACCES on mkdir .local.
@@ -163,6 +186,7 @@ pub(crate) async fn create_sidecar_docker(
             }
             _ => {}
         }
+        timings.bootstrap_exec = Some(stage.elapsed());
 
         let now = crate::util::now_ts();
         let idle_timeout = config.effective_idle_timeout(request.idle_timeout_seconds);
@@ -208,12 +232,17 @@ pub(crate) async fn create_sidecar_docker(
             capabilities_json: request.capabilities_json.clone(),
         };
 
+        let stage = std::time::Instant::now();
         let mut sealed = record.clone();
         seal_record(&mut sealed)?;
         sandboxes()?.insert(sandbox_id.clone(), sealed)?;
+        timings.store_insert = Some(stage.elapsed());
 
         let ready_record = if request.ssh_enabled {
-            ensure_ssh_ready(&record).await?
+            let stage = std::time::Instant::now();
+            let ready = ensure_ssh_ready(&record).await?;
+            timings.ssh_ready = Some(stage.elapsed());
+            ready
         } else {
             record.clone()
         };
@@ -228,5 +257,5 @@ pub(crate) async fn create_sidecar_docker(
         let _ = restore_previous_store_entry(&sandbox_id, previous_store_entry);
         cleanup_orphaned_container(&builder, &container_id).await;
     }
-    finish
+    finish.map(|record| (record, timings))
 }

--- a/sandbox-runtime/src/runtime/docker_create.rs
+++ b/sandbox-runtime/src/runtime/docker_create.rs
@@ -1,5 +1,34 @@
 use super::*;
 
+/// Merged post-start workspace bootstrap, run as root in ONE exec round-trip.
+///
+/// Covers both ownership states the image can ship in:
+///  - root-owned `/home/agent` (repair path): root's own `mkdir` succeeds —
+///    it owns the tree, no `DAC_OVERRIDE` needed — and must run BEFORE the
+///    chown hands the tree to agent (after which `cap_drop=ALL` root can no
+///    longer write into it);
+///  - agent-owned `/home/agent` without the dirs (the canonical sidecar
+///    image, verified: `agent 755`, no `.opencode-home`): root's mkdir is
+///    denied, so drop to the agent user via `su` (the container keeps
+///    SETUID/SETGID; the image ships /usr/bin/su) and create them as the
+///    owner, matching the pre-merge dedicated agent exec.
+///
+/// The chown then runs unconditionally (`;` + `|| true`), exactly like the
+/// pre-merge dedicated exec. The trailing `test -d` makes the exit code
+/// report whether the dirs exist, so the caller knows to fall back to a
+/// separate agent-user exec (images with an agent-owned tree but no `su`).
+pub(crate) const WORKSPACE_BOOTSTRAP_ROOT_CMD: &str = "mkdir -p /home/agent/.opencode-home/.config 2>/dev/null \
+     || su agent -s /bin/sh -c 'mkdir -p /home/agent/.opencode-home/.config' 2>/dev/null; \
+     chown -R agent:agent /home/agent 2>/dev/null || true; \
+     test -d /home/agent/.opencode-home/.config";
+
+/// Last-resort fallback when the merged exec cannot produce the dirs (an
+/// agent-owned `/home/agent` on an image without `su`): create them as the
+/// agent user through Docker's own exec-user mechanism, which needs nothing
+/// from the image — the pre-merge behavior, verbatim.
+pub(crate) const WORKSPACE_BOOTSTRAP_AGENT_FALLBACK_CMD: &str =
+    "mkdir -p /home/agent/.opencode-home/.config";
+
 /// Docker-backed create with per-stage [`CreateTimings`]. The shared entry
 /// point (`create_sidecar_with_token`) fills the permit/admission/total
 /// fields; this function fills every Docker stage it passes through.
@@ -130,61 +159,78 @@ pub(crate) async fn create_sidecar_docker(
         timings.port_mapping = Some(stage.elapsed());
 
         let stage = std::time::Instant::now();
-        // Repair workspace ownership before the sidecar spawns OpenCode as the
-        // agent user (uid 1000).  Without this, /home/agent dirs may be root-owned
-        // and the demoted process crashes with EACCES on mkdir .local.
-        match docker_exec_as_user(
+        // ── Workspace bootstrap ────────────────────────────────────────────
+        // Two jobs, historically two exec round-trips (each also rebuilding a
+        // Docker client — connect + ping — via `docker_exec_as_user`):
+        //   1. as root:  chown -R agent:agent /home/agent — repair image
+        //      builds that leave workspace dirs root-owned, so the sidecar's
+        //      demoted (uid 1000) process doesn't crash with EACCES on
+        //      mkdir .local;
+        //   2. as agent: mkdir -p ~/.opencode-home/.config — pre-create dirs
+        //      the sidecar's root process cannot create itself (cap_drop=ALL
+        //      leaves root without DAC_OVERRIDE, so it cannot write into
+        //      agent-owned directories).
+        // Merged into ONE root exec on the already-connected `builder` client
+        // (see WORKSPACE_BOOTSTRAP_ROOT_CMD for why mkdir-then-chown covers
+        // the repair path). When its `test -d` verification fails — an image
+        // that ships an agent-owned /home/agent without the dirs — fall back
+        // to the pre-merge agent-user mkdir. Net round-trips: 1 on the repair
+        // path and on images with the dirs baked in; 2 (unchanged) otherwise.
+        // Failures stay warn-and-continue, exactly as before.
+        let exec_client = builder.client();
+        let bootstrap_verified = match docker_exec_as_user_with_client(
+            &exec_client,
             &container_id,
             "root",
-            "chown -R agent:agent /home/agent 2>/dev/null || true",
+            WORKSPACE_BOOTSTRAP_ROOT_CMD,
         )
         .await
         {
-            Ok(r) if r.exit_code != 0 => {
-                tracing::warn!(
+            Ok(r) if r.exit_code == 0 => true,
+            Ok(r) => {
+                tracing::info!(
                     sandbox_id,
                     exit_code = r.exit_code,
                     stderr = %r.stderr,
-                    "workspace ownership repair returned non-zero (continuing)"
+                    "merged workspace bootstrap could not verify dirs; falling back to agent-user mkdir"
                 );
+                false
             }
             Err(e) => {
                 tracing::warn!(
                     sandbox_id,
                     error = %e,
-                    "workspace ownership repair failed (continuing)"
+                    "merged workspace bootstrap failed; falling back to agent-user mkdir"
                 );
+                false
             }
-            _ => {}
-        }
-
-        // Pre-create directories that the sidecar's root process will try to
-        // mkdir before demoting to uid 1000.  Without DAC_OVERRIDE the root
-        // process cannot write to agent-owned /home/agent, so we create them
-        // as the agent user who legitimately owns the parent directory.
-        match docker_exec_as_user(
-            &container_id,
-            "agent",
-            "mkdir -p /home/agent/.opencode-home/.config",
-        )
-        .await
-        {
-            Ok(r) if r.exit_code != 0 => {
-                tracing::warn!(
-                    sandbox_id,
-                    exit_code = r.exit_code,
-                    stderr = %r.stderr,
-                    "opencode-home pre-creation returned non-zero (continuing)"
-                );
+        };
+        if !bootstrap_verified {
+            match docker_exec_as_user_with_client(
+                &exec_client,
+                &container_id,
+                "agent",
+                WORKSPACE_BOOTSTRAP_AGENT_FALLBACK_CMD,
+            )
+            .await
+            {
+                Ok(r) if r.exit_code != 0 => {
+                    tracing::warn!(
+                        sandbox_id,
+                        exit_code = r.exit_code,
+                        stderr = %r.stderr,
+                        "opencode-home pre-creation returned non-zero (continuing)"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        sandbox_id,
+                        error = %e,
+                        "opencode-home pre-creation failed (continuing)"
+                    );
+                }
+                _ => {}
             }
-            Err(e) => {
-                tracing::warn!(
-                    sandbox_id,
-                    error = %e,
-                    "opencode-home pre-creation failed (continuing)"
-                );
-            }
-            _ => {}
         }
         timings.bootstrap_exec = Some(stage.elapsed());
 

--- a/sandbox-runtime/src/runtime/docker_create.rs
+++ b/sandbox-runtime/src/runtime/docker_create.rs
@@ -43,8 +43,11 @@ pub(crate) async fn create_sidecar_docker(
         .map(ToString::to_string)
         .unwrap_or_else(next_sandbox_id);
     // Count cap + memory budget were already enforced in a single store pass
-    // by `admit_sandbox_resources` under the CREATION_PERMIT (still held).
-    // The previous entry is kept for slot-reuse semantics + failure rollback.
+    // by `admit_sandbox_resources` under the CREATION_PERMIT (still held); the
+    // slot-reuse decision now lives entirely in that scan (keyed off the
+    // override id). This entry is read solely to restore the prior record on a
+    // create failure (`restore_previous_store_entry`), so the Docker rollback
+    // path can't clobber the sandbox it replaced.
     let previous_store_entry = existing_store_entry_for_override(&sandbox_id)?;
 
     let stage = std::time::Instant::now();

--- a/sandbox-runtime/src/runtime/docker_create.rs
+++ b/sandbox-runtime/src/runtime/docker_create.rs
@@ -42,10 +42,10 @@ pub(crate) async fn create_sidecar_docker(
     let sandbox_id = sandbox_id_override
         .map(ToString::to_string)
         .unwrap_or_else(next_sandbox_id);
+    // Count cap + memory budget were already enforced in a single store pass
+    // by `admit_sandbox_resources` under the CREATION_PERMIT (still held).
+    // The previous entry is kept for slot-reuse semantics + failure rollback.
     let previous_store_entry = existing_store_entry_for_override(&sandbox_id)?;
-
-    // Recreating an existing sandbox reuses its existing store slot.
-    enforce_sandbox_count_limit(config, previous_store_entry.is_some())?;
 
     let stage = std::time::Instant::now();
     let builder = docker_builder().await?;

--- a/sandbox-runtime/src/runtime/firecracker_create.rs
+++ b/sandbox-runtime/src/runtime/firecracker_create.rs
@@ -9,9 +9,10 @@ pub(crate) async fn create_sidecar_firecracker(
     let sandbox_id = sandbox_id_override
         .map(ToString::to_string)
         .unwrap_or_else(next_sandbox_id);
-    let previous_store_entry = existing_store_entry_for_override(&sandbox_id)?;
-
-    enforce_sandbox_count_limit(config, previous_store_entry.is_some())?;
+    // Count cap + memory budget were already enforced in a single store pass
+    // by `admit_sandbox_resources` under the CREATION_PERMIT (still held).
+    // Unlike the Docker path, the Firecracker path never used its previous
+    // store entry for rollback, so no extra store read remains here.
 
     // Parse and validate port mappings strictly — malformed entries fail
     // fast here rather than being silently dropped. Both legacy `[3000]` and

--- a/sandbox-runtime/src/runtime/lifecycle.rs
+++ b/sandbox-runtime/src/runtime/lifecycle.rs
@@ -52,7 +52,13 @@ pub async fn stop_sidecar(record: &SandboxRecord) -> Result<()> {
 }
 
 /// Poll a sidecar's `/health` endpoint until it responds successfully or the timeout expires.
-pub(crate) async fn wait_for_sidecar_health(sidecar_url: &str, timeout_secs: u64) -> bool {
+///
+/// This is the "ready" boundary of the lifecycle: the Docker create path
+/// returns before `/health` passes (unless `ssh_enabled` forces the SSH
+/// bootstrap), so callers that need a live sidecar poll this themselves.
+/// Public so the lifecycle bench can measure create→ready on the real path.
+pub async fn wait_for_sidecar_health(sidecar_url: &str, timeout_secs: u64) -> bool {
+    let start = std::time::Instant::now();
     let ready = tokio::time::timeout(Duration::from_secs(timeout_secs), async {
         loop {
             let url = format!("{sidecar_url}/health");
@@ -66,7 +72,14 @@ pub(crate) async fn wait_for_sidecar_health(sidecar_url: &str, timeout_secs: u64
         }
     })
     .await;
-    ready.is_ok()
+    let is_ready = ready.is_ok();
+    tracing::info!(
+        sidecar_url,
+        ready = is_ready,
+        waited_ms = start.elapsed().as_millis() as u64,
+        "sidecar health wait finished"
+    );
+    is_ready
 }
 
 /// Re-inspect a running Docker-backed sandbox and persist its current host port mappings.
@@ -268,6 +281,21 @@ pub async fn resume_sidecar(record: &SandboxRecord) -> Result<()> {
 /// For TEE-managed sandboxes, delegates to the TEE backend's `destroy()` method.
 /// Accepts an explicit backend reference, or falls back to the global TEE backend.
 pub async fn delete_sidecar(
+    record: &SandboxRecord,
+    tee: Option<&dyn crate::tee::TeeBackend>,
+) -> Result<()> {
+    let start = std::time::Instant::now();
+    let result = delete_sidecar_inner(record, tee).await;
+    tracing::info!(
+        sandbox_id = %record.id,
+        ok = result.is_ok(),
+        duration_ms = start.elapsed().as_millis() as u64,
+        "sandbox delete finished"
+    );
+    result
+}
+
+async fn delete_sidecar_inner(
     record: &SandboxRecord,
     tee: Option<&dyn crate::tee::TeeBackend>,
 ) -> Result<()> {

--- a/sandbox-runtime/src/runtime/mod.rs
+++ b/sandbox-runtime/src/runtime/mod.rs
@@ -65,6 +65,7 @@ mod secrets;
 mod snapshots;
 mod ssh;
 mod ssh_commands;
+mod timings;
 mod upgrades;
 
 pub(crate) use admission::*;
@@ -75,7 +76,6 @@ pub(crate) use docker_config::*;
 pub(crate) use docker_create::*;
 pub(crate) use env_vars::*;
 pub(crate) use firecracker_create::*;
-pub(crate) use lifecycle::*;
 pub(crate) use lookup::*;
 pub(crate) use ports::*;
 #[cfg(test)]
@@ -85,11 +85,12 @@ pub(crate) use ssh_commands::*;
 
 // Externally-reachable items re-exported at their original visibility:
 pub use admission::acquire_creation_permit;
-pub use create::create_sidecar;
+pub use create::{create_sidecar, create_sidecar_timed};
 pub use docker_client::docker_builder;
 pub use env_vars::{merge_env_json, workflow_runtime_credentials_available};
 pub use lifecycle::{
     delete_sidecar, refresh_docker_sandbox_endpoint, resume_sidecar, stop_sidecar,
+    wait_for_sidecar_health,
 };
 pub use lookup::{
     get_sandbox_by_id, get_sandbox_by_url, get_sandbox_by_url_opt, require_sandbox_owner,
@@ -103,6 +104,7 @@ pub use snapshots::{
 pub use ssh::{
     detect_ssh_username, ensure_ssh_ready, provision_ssh_key, restore_ssh_access, revoke_ssh_key,
 };
+pub use timings::CreateTimings;
 pub use upgrades::{
     SidecarReconcileReport, SidecarUpgradePolicy, current_sidecar_image, reconcile_sidecar_images,
     recreate_sidecar_with_env, sandboxes_needing_image_upgrade, upgrade_sidecar_image,

--- a/sandbox-runtime/src/runtime/ssh.rs
+++ b/sandbox-runtime/src/runtime/ssh.rs
@@ -83,10 +83,32 @@ pub(crate) async fn docker_exec_as_user(
     user: &str,
     command: &str,
 ) -> Result<ExecCommandResult> {
+    // Fresh client per call: most callers (SSH bootstrap, key management)
+    // have no live connection in scope, and process-wide caching is
+    // deliberately avoided so a stale Docker Desktop socket can't wedge a
+    // long-lived operator (see `docker_builder`). Hot paths that already
+    // hold a connected client thread it through
+    // [`docker_exec_as_user_with_client`] instead of paying connect+ping
+    // per exec.
     let builder = docker_builder().await?;
+    docker_exec_as_user_with_client(&builder.client(), container_id, user, command).await
+}
+
+/// [`docker_exec_as_user`] on an already-connected Docker client.
+///
+/// Used by the create path, which has a live `DockerBuilder` in scope and
+/// runs several execs back-to-back; threading the handle avoids rebuilding
+/// (connect + ping) a client per exec without introducing a cached
+/// process-wide client and its stale-socket failure mode.
+pub(crate) async fn docker_exec_as_user_with_client(
+    client: &docktopus::bollard::Docker,
+    container_id: &str,
+    user: &str,
+    command: &str,
+) -> Result<ExecCommandResult> {
     let exec = docker_timeout(
         "create_exec",
-        builder.client().create_exec(
+        client.create_exec(
             container_id,
             CreateExecOptions::<String> {
                 attach_stdout: Some(true),
@@ -107,9 +129,7 @@ pub(crate) async fn docker_exec_as_user(
     let mut stderr = Vec::new();
     match docker_timeout(
         "start_exec",
-        builder
-            .client()
-            .start_exec(&exec.id, None::<StartExecOptions>),
+        client.start_exec(&exec.id, None::<StartExecOptions>),
     )
     .await?
     {
@@ -133,7 +153,7 @@ pub(crate) async fn docker_exec_as_user(
         }
     }
 
-    let inspect = docker_timeout("inspect_exec", builder.client().inspect_exec(&exec.id)).await?;
+    let inspect = docker_timeout("inspect_exec", client.inspect_exec(&exec.id)).await?;
     Ok(ExecCommandResult {
         exit_code: inspect.exit_code.unwrap_or_default(),
         stdout: String::from_utf8_lossy(&stdout).into_owned(),

--- a/sandbox-runtime/src/runtime/tests.rs
+++ b/sandbox-runtime/src/runtime/tests.rs
@@ -1398,6 +1398,164 @@ mod core_logic_tests {
     }
 }
 
+/// Single-pass store admission scan (admission.rs): one `values()` walk must
+/// reproduce exactly what the former two dedicated scans computed — the
+/// count-check inputs and the memory-budget inputs.
+#[cfg(test)]
+mod admission_scan_tests {
+    use super::*;
+
+    fn record(id: &str, state: SandboxState, memory_mb: u64) -> SandboxRecord {
+        SandboxRecord {
+            id: id.into(),
+            container_id: format!("ctr-{id}"),
+            sidecar_url: "http://127.0.0.1:0".into(),
+            sidecar_port: 0,
+            ssh_port: None,
+            token: "t".into(),
+            created_at: 0,
+            cpu_cores: 1,
+            memory_mb,
+            state,
+            idle_timeout_seconds: 0,
+            max_lifetime_seconds: 0,
+            last_activity_at: 0,
+            stopped_at: None,
+            snapshot_image_id: None,
+            snapshot_s3_url: None,
+            container_removed_at: None,
+            image_removed_at: None,
+            original_image: String::new(),
+            base_env_json: String::new(),
+            user_env_json: String::new(),
+            snapshot_destination: None,
+            tee_deployment_id: None,
+            tee_metadata_json: None,
+            tee_attestation_json: None,
+            name: String::new(),
+            agent_identifier: String::new(),
+            metadata_json: String::new(),
+            disk_gb: 0,
+            stack: String::new(),
+            owner: String::new(),
+            service_id: None,
+            tee_config: None,
+            extra_ports: HashMap::new(),
+            ssh_login_user: None,
+            ssh_authorized_keys: Vec::new(),
+            capabilities_json: String::new(),
+        }
+    }
+
+    #[test]
+    fn scan_empty_store() {
+        let scan = scan_records_for_admission(&[], None);
+        assert_eq!(scan.total_count, 0);
+        assert!(!scan.reusing_existing_slot);
+        assert!(scan.running_memory_mb.is_empty());
+    }
+
+    #[test]
+    fn scan_counts_all_rows_but_sums_only_running_memory() {
+        let records = vec![
+            record("a", SandboxState::Running, 1024),
+            record("b", SandboxState::Stopped, 2048),
+            record("c", SandboxState::Running, 512),
+        ];
+        let scan = scan_records_for_admission(&records, None);
+        // Count cap sees every row (stopped sandboxes hold store slots)…
+        assert_eq!(scan.total_count, 3);
+        // …the budget sees only running footprints.
+        assert_eq!(scan.running_memory_mb, vec![1024, 512]);
+        assert!(!scan.reusing_existing_slot);
+    }
+
+    #[test]
+    fn scan_running_unlimited_rows_stay_visible() {
+        // memory_mb=0 rows must remain in the vec so check_host_memory_budget
+        // keeps its accounted-at-max / unaccounted-warning semantics.
+        let records = vec![record("a", SandboxState::Running, 0)];
+        let scan = scan_records_for_admission(&records, None);
+        assert_eq!(scan.running_memory_mb, vec![0]);
+    }
+
+    #[test]
+    fn scan_reused_id_counts_slot_but_frees_memory() {
+        let records = vec![
+            record("a", SandboxState::Running, 1024),
+            record("b", SandboxState::Running, 2048),
+        ];
+        let scan = scan_records_for_admission(&records, Some("b"));
+        // The replaced record still occupies a store slot (the count check
+        // then subtracts it via reusing_existing_slot)…
+        assert_eq!(scan.total_count, 2);
+        assert!(scan.reusing_existing_slot);
+        // …but its container's memory is freed by the recreate.
+        assert_eq!(scan.running_memory_mb, vec![1024]);
+    }
+
+    #[test]
+    fn scan_reused_id_flagged_even_when_stopped() {
+        // Recreating a STOPPED sandbox also reuses its slot: the former
+        // count check keyed off store presence (`get(id).is_some()`), not
+        // state, and the stopped row never contributed running memory.
+        let records = vec![record("a", SandboxState::Stopped, 1024)];
+        let scan = scan_records_for_admission(&records, Some("a"));
+        assert_eq!(scan.total_count, 1);
+        assert!(scan.reusing_existing_slot);
+        assert!(scan.running_memory_mb.is_empty());
+    }
+
+    #[test]
+    fn scan_absent_reused_id_sets_no_flag() {
+        // A fresh sandbox id (no override, or an override that was never
+        // stored) must not claim slot reuse — matches `get(id) == None`.
+        let records = vec![record("a", SandboxState::Running, 1024)];
+        let scan = scan_records_for_admission(&records, Some("zz"));
+        assert!(!scan.reusing_existing_slot);
+        assert_eq!(scan.running_memory_mb, vec![1024]);
+    }
+
+    /// Differential check: the single pass must equal the legacy two-pass
+    /// computation (count scan + filtered memory scan) row-for-row across a
+    /// matrix of store shapes and reuse targets.
+    #[test]
+    fn scan_matches_legacy_two_pass_semantics() {
+        let stores: Vec<Vec<SandboxRecord>> = vec![
+            vec![],
+            vec![record("a", SandboxState::Running, 0)],
+            vec![
+                record("a", SandboxState::Running, 1024),
+                record("b", SandboxState::Stopped, 2048),
+                record("c", SandboxState::Running, 0),
+                record("d", SandboxState::Running, 4096),
+            ],
+        ];
+        for records in &stores {
+            for reused in [None, Some("a"), Some("b"), Some("missing")] {
+                // Legacy pass 1: count = all rows; reuse = presence by id.
+                let legacy_count = records.len();
+                let legacy_reusing = records.iter().any(|r| reused == Some(r.id.as_str()));
+                // Legacy pass 2: running memory, reused id excluded.
+                let legacy_memory: Vec<u64> = records
+                    .iter()
+                    .filter(|r| r.state == SandboxState::Running)
+                    .filter(|r| reused != Some(r.id.as_str()))
+                    .map(|r| r.memory_mb)
+                    .collect();
+
+                let scan = scan_records_for_admission(records, reused);
+                assert_eq!(scan.total_count, legacy_count, "reused={reused:?}");
+                assert_eq!(
+                    scan.reusing_existing_slot, legacy_reusing,
+                    "reused={reused:?}"
+                );
+                assert_eq!(scan.running_memory_mb, legacy_memory, "reused={reused:?}");
+            }
+        }
+    }
+}
+
 /// Invariants of the merged workspace-bootstrap exec (docker_create.rs).
 /// The merge collapses two post-start exec round-trips into one; these pin
 /// the properties that make it semantically equal to the pre-merge pair.

--- a/sandbox-runtime/src/runtime/tests.rs
+++ b/sandbox-runtime/src/runtime/tests.rs
@@ -1397,3 +1397,96 @@ mod core_logic_tests {
         );
     }
 }
+
+/// Invariants of the merged workspace-bootstrap exec (docker_create.rs).
+/// The merge collapses two post-start exec round-trips into one; these pin
+/// the properties that make it semantically equal to the pre-merge pair.
+#[cfg(test)]
+mod workspace_bootstrap_tests {
+    use super::*;
+
+    const CONFIG_DIR: &str = "/home/agent/.opencode-home/.config";
+
+    #[test]
+    fn merged_command_mkdirs_before_chown() {
+        // Repair-path precondition: /home/agent is root-owned, so root's
+        // mkdir must run BEFORE the chown hands the tree to agent (after
+        // which cap_drop=ALL root has no DAC_OVERRIDE to write into it).
+        let mkdir_at = WORKSPACE_BOOTSTRAP_ROOT_CMD
+            .find("mkdir -p")
+            .expect("merged command must create the opencode dirs");
+        let chown_at = WORKSPACE_BOOTSTRAP_ROOT_CMD
+            .find("chown -R agent:agent /home/agent")
+            .expect("merged command must repair workspace ownership");
+        assert!(
+            mkdir_at < chown_at,
+            "mkdir must precede chown: {WORKSPACE_BOOTSTRAP_ROOT_CMD}"
+        );
+    }
+
+    #[test]
+    fn merged_command_drops_to_agent_when_root_mkdir_denied() {
+        // Canonical-image case (agent-owned /home/agent, dirs absent): root's
+        // mkdir is denied under cap_drop=ALL, so the merged exec must retry
+        // as the agent user via su, targeting the same directory, BEFORE the
+        // chown (the decision keys off the tree's CURRENT owner).
+        let su_at = WORKSPACE_BOOTSTRAP_ROOT_CMD
+            .find(&format!("su agent -s /bin/sh -c 'mkdir -p {CONFIG_DIR}'"))
+            .expect("merged command must retry the mkdir as the agent user");
+        let chown_at = WORKSPACE_BOOTSTRAP_ROOT_CMD
+            .find("chown -R agent:agent /home/agent")
+            .expect("merged command must repair workspace ownership");
+        assert!(
+            su_at < chown_at,
+            "su fallback must precede chown: {WORKSPACE_BOOTSTRAP_ROOT_CMD}"
+        );
+    }
+
+    #[test]
+    fn merged_command_chown_is_unconditional_and_tolerant() {
+        // The pre-merge chown exec ran regardless of any mkdir outcome and
+        // tolerated failure (`|| true`). The merged form must keep both:
+        // `;` separators (not `&&`) so chown runs even when mkdir fails,
+        // and `|| true` so a chown failure doesn't change the exit path.
+        assert!(
+            WORKSPACE_BOOTSTRAP_ROOT_CMD
+                .contains("chown -R agent:agent /home/agent 2>/dev/null || true"),
+            "chown must stay best-effort: {WORKSPACE_BOOTSTRAP_ROOT_CMD}"
+        );
+        assert!(
+            !WORKSPACE_BOOTSTRAP_ROOT_CMD.contains("&&"),
+            "stages must be `;`-separated so each runs unconditionally: {WORKSPACE_BOOTSTRAP_ROOT_CMD}"
+        );
+    }
+
+    #[test]
+    fn merged_command_exit_code_reports_dir_existence() {
+        // The caller's fallback decision keys off the exit code, so the
+        // command must END with the `test -d` verification of the exact
+        // directory the fallback would create.
+        assert!(
+            WORKSPACE_BOOTSTRAP_ROOT_CMD
+                .trim_end()
+                .ends_with(&format!("test -d {CONFIG_DIR}")),
+            "merged command must end with the dir verification: {WORKSPACE_BOOTSTRAP_ROOT_CMD}"
+        );
+    }
+
+    #[test]
+    fn fallback_matches_pre_merge_agent_exec() {
+        // The fallback IS the pre-merge second exec: same mkdir, same target,
+        // run as the agent user (asserted at the call site), and no chown —
+        // the agent user cannot chown and never needed to.
+        assert_eq!(
+            WORKSPACE_BOOTSTRAP_AGENT_FALLBACK_CMD,
+            format!("mkdir -p {CONFIG_DIR}")
+        );
+        assert!(!WORKSPACE_BOOTSTRAP_AGENT_FALLBACK_CMD.contains("chown"));
+    }
+
+    #[test]
+    fn merged_and_fallback_target_the_same_directory() {
+        assert!(WORKSPACE_BOOTSTRAP_ROOT_CMD.contains(CONFIG_DIR));
+        assert!(WORKSPACE_BOOTSTRAP_AGENT_FALLBACK_CMD.contains(CONFIG_DIR));
+    }
+}

--- a/sandbox-runtime/src/runtime/timings.rs
+++ b/sandbox-runtime/src/runtime/timings.rs
@@ -1,0 +1,110 @@
+use super::*;
+
+/// Per-stage wall-clock timings for one sandbox create, measured with
+/// `std::time::Instant` on the real path (no sampling, no estimation).
+///
+/// Additive API: existing callers keep using [`create_sidecar`] and never see
+/// this struct; [`create_sidecar_timed`] returns it for benches and operators
+/// that want the breakdown. Every successful create also logs the breakdown
+/// once via `tracing` (see [`CreateTimings::log`]).
+///
+/// Stages a backend does not pass through stay `None` — today the Docker
+/// backend fills all of its stages, while Firecracker/TEE creates fill only
+/// the permit/admission/total fields measured in the shared entry point.
+///
+/// NOTE: `total` is create-return time, NOT "ready". Unless `ssh_enabled` is
+/// set, the create path returns before the sidecar's `/health` endpoint
+/// responds; callers that need readiness must poll
+/// [`wait_for_sidecar_health`] themselves (the lifecycle bench in
+/// `tests/lifecycle_bench.rs` does exactly that and reports the two numbers
+/// separately).
+#[derive(Clone, Debug, Default)]
+pub struct CreateTimings {
+    /// Wait to acquire the global `CREATION_PERMIT` (queueing behind other
+    /// concurrent creates). ~0 when the host is idle.
+    pub permit_wait: Option<Duration>,
+    /// Admission control: per-sandbox maxima + the store admission scan.
+    pub admission: Option<Duration>,
+    /// Docker client connect + ping (`docker_builder`).
+    pub docker_connect: Option<Duration>,
+    /// `ensure_image_pulled` — real pull cost on the first create of the
+    /// process when `SIDECAR_PULL_IMAGE=true`, ~0 afterwards (process-wide
+    /// once-cell).
+    pub image_pull: Option<Duration>,
+    /// Docker-side container create (`Container::create`).
+    pub container_create: Option<Duration>,
+    /// Docker-side container start (`Container::start`).
+    pub container_start: Option<Duration>,
+    /// Host-port mapping resolution (container inspect retry loop).
+    pub port_mapping: Option<Duration>,
+    /// Post-start workspace bootstrap exec round-trips (chown/mkdir).
+    pub bootstrap_exec: Option<Duration>,
+    /// Record seal + persistent-store insert.
+    pub store_insert: Option<Duration>,
+    /// SSH readiness bootstrap; only present when `ssh_enabled`.
+    pub ssh_ready: Option<Duration>,
+    /// End-to-end create as observed by the caller, including permit wait.
+    pub total: Duration,
+}
+
+fn push_stage(out: &mut String, name: &str, stage: Option<Duration>) {
+    if let Some(d) = stage {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(name);
+        out.push('=');
+        out.push_str(&format!("{:.1}ms", d.as_secs_f64() * 1e3));
+    }
+}
+
+impl CreateTimings {
+    /// Compact `stage=12.3ms` summary of the populated stages, in path order.
+    pub fn summary(&self) -> String {
+        let mut out = String::new();
+        push_stage(&mut out, "permit_wait", self.permit_wait);
+        push_stage(&mut out, "admission", self.admission);
+        push_stage(&mut out, "docker_connect", self.docker_connect);
+        push_stage(&mut out, "image_pull", self.image_pull);
+        push_stage(&mut out, "container_create", self.container_create);
+        push_stage(&mut out, "container_start", self.container_start);
+        push_stage(&mut out, "port_mapping", self.port_mapping);
+        push_stage(&mut out, "bootstrap_exec", self.bootstrap_exec);
+        push_stage(&mut out, "store_insert", self.store_insert);
+        push_stage(&mut out, "ssh_ready", self.ssh_ready);
+        out
+    }
+
+    /// Emit the one-line create breakdown through the existing log facility.
+    pub(crate) fn log(&self, sandbox_id: &str, backend: RuntimeBackend) {
+        tracing::info!(
+            sandbox_id,
+            backend = ?backend,
+            total_ms = format!("{:.1}", self.total.as_secs_f64() * 1e3).as_str(),
+            stages = %self.summary(),
+            "sandbox create stage timings"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summary_skips_absent_stages_and_orders_present_ones() {
+        let timings = CreateTimings {
+            docker_connect: Some(Duration::from_millis(5)),
+            container_start: Some(Duration::from_millis(250)),
+            total: Duration::from_millis(300),
+            ..Default::default()
+        };
+        let summary = timings.summary();
+        assert_eq!(summary, "docker_connect=5.0ms container_start=250.0ms");
+    }
+
+    #[test]
+    fn summary_empty_when_no_stages_recorded() {
+        assert_eq!(CreateTimings::default().summary(), "");
+    }
+}

--- a/sandbox-runtime/src/runtime/upgrades.rs
+++ b/sandbox-runtime/src/runtime/upgrades.rs
@@ -214,7 +214,7 @@ pub(crate) async fn recreate_sidecar_impl(
     };
 
     // Preserve the original token so existing workflows/references keep working.
-    let (_new_record, _attestation) =
+    let (_new_record, _attestation, _timings) =
         create_sidecar_with_token(&params, tee, Some(&old_token), Some(&old.id)).await?;
     let updated = sandboxes()?.update(&old.id, |record| {
         record.ssh_login_user = old.ssh_login_user.clone();

--- a/sandbox-runtime/tests/lifecycle_bench.rs
+++ b/sandbox-runtime/tests/lifecycle_bench.rs
@@ -195,17 +195,23 @@ async fn lifecycle_create_ready_delete_bench() {
          (or set LIFECYCLE_BENCH_IMAGE)"
     );
 
-    // Serialize env mutation, matching this dir's convention for env-mutating
-    // tests. We use a local static (like ssh_e2e's TEST_LOCK) rather than
-    // sandbox_runtime::TEST_ENV_GUARD because that symbol is gated behind the
-    // `test-utils` feature, which this bench does not enable — it runs in the
-    // default (no-feature) nextest lane. Today the binary has a single
-    // #[ignore] test so nothing contends, but this keeps a future second test
-    // from racing on the global SidecarRuntimeConfig OnceCell. Held for the
-    // whole run (the config is a one-shot snapshot of these vars).
-    let _env_guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let state_dir = TempDir::new().expect("temp state dir");
-    setup_env(&state_dir, &image);
+    {
+        // Serialize env mutation, matching this dir's convention for
+        // env-mutating tests. We use a local static (like ssh_e2e's
+        // TEST_LOCK) rather than sandbox_runtime::TEST_ENV_GUARD because that
+        // symbol is gated behind the `test-utils` feature, which this bench
+        // does not enable — it runs in the default (no-feature) nextest lane.
+        //
+        // Guard scoped to the env mutation only (NOT held across awaits — a
+        // std Mutex guard across an await is a clippy denial and a deadlock
+        // risk): this binary has a single #[ignore] test, so nothing else
+        // reads the env before the first SidecarRuntimeConfig::load() inside
+        // the loop below. A future second test in this binary must acquire the
+        // same lock around its own setup_env to stay race-free.
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        setup_env(&state_dir, &image);
+    }
 
     let reps = bench_reps();
     let mut create_total = StageSeries::new("create_total");

--- a/sandbox-runtime/tests/lifecycle_bench.rs
+++ b/sandbox-runtime/tests/lifecycle_bench.rs
@@ -1,0 +1,284 @@
+//! Create→ready→delete lifecycle benchmark for the sandbox runtime's REAL
+//! Docker create path.
+//!
+//! Measures `create_sidecar_timed` (admission → Docker connect → image check
+//! → container create/start → port mapping → bootstrap execs → store insert)
+//! with per-stage [`CreateTimings`], then the create→ready gap, then delete.
+//!
+//! ## Relationship to the existing lifecycle bench
+//!
+//! `ai-agent-sandbox-blueprint-lib/tests/lifecycle_bench.rs` measures the
+//! SIDECAR's HTTP surface (health/auth/exec/terminal ops) against a single
+//! container it provisions by hand with raw bollard — it never enters
+//! `create_sidecar`. This bench covers the complementary half: the runtime's
+//! own provisioning loop, per rep and per stage.
+//!
+//! ## "Ready" definition
+//!
+//! `create_sidecar` returns BEFORE the sidecar's `/health` endpoint passes
+//! unless `ssh_enabled` forces the SSH bootstrap. This bench therefore polls
+//! `wait_for_sidecar_health` itself after each create and reports
+//! `health_ready` (create-return → first /health 200) as its own stage, and
+//! `create_to_ready` as the caller-visible end-to-end number.
+//!
+//! ## Running
+//!
+//! Needs a live Docker daemon and the sidecar image already pulled. It is
+//! `#[ignore]`d AND env-gated, so no CI lane without Docker ever runs it —
+//! it runs on a real host, on demand:
+//!
+//! ```bash
+//! docker pull ghcr.io/tangle-network/blueprint-sidecar:all-harness
+//! RUN_LIFECYCLE_BENCH=1 cargo test -p sandbox-runtime --test lifecycle_bench \
+//!     -- --ignored --nocapture
+//! ```
+//!
+//! Knobs: `LIFECYCLE_BENCH_REPS` (default 5, + 1 discarded warmup rep),
+//! `LIFECYCLE_BENCH_IMAGE` (default the all-harness sidecar image).
+//!
+//! State isolation: `BLUEPRINT_STATE_DIR` points at a fresh temp dir for the
+//! whole run, so the bench never reads or corrupts an operator's real store.
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use bench_harness::stats::Summary;
+use tempfile::TempDir;
+
+use sandbox_runtime::runtime::{
+    CreateSandboxParams, create_sidecar_timed, delete_sidecar, wait_for_sidecar_health,
+};
+
+const DEFAULT_IMAGE: &str = "ghcr.io/tangle-network/blueprint-sidecar:all-harness";
+
+fn bench_enabled() -> bool {
+    std::env::var("RUN_LIFECYCLE_BENCH")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+}
+
+fn bench_reps() -> usize {
+    std::env::var("LIFECYCLE_BENCH_REPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(5)
+}
+
+fn bench_image() -> String {
+    std::env::var("LIFECYCLE_BENCH_IMAGE").unwrap_or_else(|_| DEFAULT_IMAGE.to_string())
+}
+
+fn docker_available() -> bool {
+    Command::new("docker")
+        .args(["info"])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn image_present(image: &str) -> bool {
+    Command::new("docker")
+        .args(["image", "inspect", image])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn setup_env(state_dir: &TempDir, image: &str) {
+    // SAFETY: this is the only test in this binary (own process), and the env
+    // is set before the first `SidecarRuntimeConfig::load()` / store access.
+    unsafe {
+        std::env::set_var("BLUEPRINT_STATE_DIR", state_dir.path());
+        std::env::set_var("SIDECAR_IMAGE", image);
+        // Keep registry pulls out of the measured loop: the image must be
+        // local (checked above), so `image_pull` measures only the local
+        // "already present" fast path.
+        std::env::set_var("SIDECAR_PULL_IMAGE", "false");
+        std::env::set_var("SIDECAR_PUBLIC_HOST", "127.0.0.1");
+        std::env::set_var("REQUEST_TIMEOUT_SECS", "60");
+        std::env::set_var("SESSION_AUTH_SECRET", "lifecycle-bench-secret");
+        std::env::remove_var("DOCKER_HOST");
+    }
+}
+
+fn bench_params(image: &str, rep: usize) -> CreateSandboxParams {
+    CreateSandboxParams {
+        name: format!("lifecycle-bench-{rep}"),
+        image: image.to_string(),
+        stack: "default".to_string(),
+        agent_identifier: "default".to_string(),
+        metadata_json: r#"{"runtime_backend":"docker"}"#.to_string(),
+        // ssh_enabled=false is the common product path AND the one where
+        // create returns before /health — exactly the gap this bench exists
+        // to make visible.
+        ssh_enabled: false,
+        max_lifetime_seconds: 3600,
+        idle_timeout_seconds: 3600,
+        cpu_cores: 2,
+        memory_mb: 2048,
+        disk_gb: 10,
+        owner: "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc".to_string(),
+        ..Default::default()
+    }
+}
+
+/// One named series of per-rep samples (milliseconds).
+struct StageSeries {
+    name: &'static str,
+    samples_ms: Vec<f64>,
+}
+
+impl StageSeries {
+    fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            samples_ms: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, duration: Option<Duration>) {
+        if let Some(d) = duration {
+            self.samples_ms.push(d.as_secs_f64() * 1e3);
+        }
+    }
+}
+
+fn print_summaries(series: &[StageSeries]) {
+    eprintln!();
+    eprintln!(
+        "{:<18} {:>3} {:>10} {:>10} {:>10} {:>10}",
+        "stage", "n", "min(ms)", "p50(ms)", "p90(ms)", "max(ms)"
+    );
+    for s in series {
+        if s.samples_ms.is_empty() {
+            eprintln!("{:<18} {:>3} (no samples)", s.name, 0);
+            continue;
+        }
+        // bench-harness works in nanoseconds; feed it ns, print ms.
+        let ns: Vec<f64> = s.samples_ms.iter().map(|ms| ms * 1e6).collect();
+        let summary = Summary::from_samples(&ns);
+        eprintln!(
+            "{:<18} {:>3} {:>10.1} {:>10.1} {:>10.1} {:>10.1}",
+            s.name,
+            summary.n,
+            summary.min_ns / 1e6,
+            summary.p50_ns / 1e6,
+            summary.p90_ns / 1e6,
+            summary.max_ns / 1e6,
+        );
+    }
+    eprintln!();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "real-docker lifecycle bench; set RUN_LIFECYCLE_BENCH=1 and run with --ignored on a host with Docker"]
+async fn lifecycle_create_ready_delete_bench() {
+    if !bench_enabled() {
+        eprintln!("SKIP: set RUN_LIFECYCLE_BENCH=1 to run the lifecycle bench");
+        return;
+    }
+    // The bench was explicitly requested — missing prerequisites are loud
+    // failures, not silent skips.
+    assert!(
+        docker_available(),
+        "RUN_LIFECYCLE_BENCH=1 but no reachable Docker daemon (`docker info` failed)"
+    );
+    let image = bench_image();
+    assert!(
+        image_present(&image),
+        "RUN_LIFECYCLE_BENCH=1 but image {image} is not local; run `docker pull {image}` \
+         (or set LIFECYCLE_BENCH_IMAGE)"
+    );
+
+    let state_dir = TempDir::new().expect("temp state dir");
+    setup_env(&state_dir, &image);
+
+    let reps = bench_reps();
+    let mut create_total = StageSeries::new("create_total");
+    let mut permit_wait = StageSeries::new("permit_wait");
+    let mut admission = StageSeries::new("admission");
+    let mut docker_connect = StageSeries::new("docker_connect");
+    let mut image_pull = StageSeries::new("image_pull");
+    let mut container_create = StageSeries::new("container_create");
+    let mut container_start = StageSeries::new("container_start");
+    let mut port_mapping = StageSeries::new("port_mapping");
+    let mut bootstrap_exec = StageSeries::new("bootstrap_exec");
+    let mut store_insert = StageSeries::new("store_insert");
+    let mut health_ready = StageSeries::new("health_ready");
+    let mut create_to_ready = StageSeries::new("create_to_ready");
+    let mut delete = StageSeries::new("delete");
+
+    // Warmup rep (discarded): primes the process-wide image-pull once-cell,
+    // the HTTP client, and the Docker daemon's caches so measured reps
+    // reflect steady state. Cold-start cost is visible in its own log line.
+    eprintln!("=== lifecycle bench: image={image} reps={reps} (+1 warmup) ===");
+    for rep in 0..=reps {
+        let warmup = rep == 0;
+        let params = bench_params(&image, rep);
+
+        let rep_start = Instant::now();
+        let (record, _attestation, timings) = create_sidecar_timed(&params, None)
+            .await
+            .unwrap_or_else(|e| panic!("rep {rep}: create failed: {e}"));
+
+        let health_start = Instant::now();
+        let ready = wait_for_sidecar_health(&record.sidecar_url, 120).await;
+        let health_elapsed = health_start.elapsed();
+        let ready_elapsed = rep_start.elapsed();
+
+        let delete_start = Instant::now();
+        let delete_result = delete_sidecar(&record, None).await;
+        let delete_elapsed = delete_start.elapsed();
+
+        // Assert AFTER cleanup so a failed rep never leaks a container.
+        assert!(
+            ready,
+            "rep {rep}: sidecar at {} never became healthy within 120s",
+            record.sidecar_url
+        );
+        delete_result.unwrap_or_else(|e| panic!("rep {rep}: delete failed: {e}"));
+
+        eprintln!(
+            "rep {rep}{}: create={:.1}ms [{}] health_ready={:.1}ms create_to_ready={:.1}ms delete={:.1}ms",
+            if warmup { " (warmup, discarded)" } else { "" },
+            timings.total.as_secs_f64() * 1e3,
+            timings.summary(),
+            health_elapsed.as_secs_f64() * 1e3,
+            ready_elapsed.as_secs_f64() * 1e3,
+            delete_elapsed.as_secs_f64() * 1e3,
+        );
+        if warmup {
+            continue;
+        }
+
+        create_total.push(Some(timings.total));
+        permit_wait.push(timings.permit_wait);
+        admission.push(timings.admission);
+        docker_connect.push(timings.docker_connect);
+        image_pull.push(timings.image_pull);
+        container_create.push(timings.container_create);
+        container_start.push(timings.container_start);
+        port_mapping.push(timings.port_mapping);
+        bootstrap_exec.push(timings.bootstrap_exec);
+        store_insert.push(timings.store_insert);
+        health_ready.push(Some(health_elapsed));
+        create_to_ready.push(Some(ready_elapsed));
+        delete.push(Some(delete_elapsed));
+    }
+
+    print_summaries(&[
+        create_total,
+        permit_wait,
+        admission,
+        docker_connect,
+        image_pull,
+        container_create,
+        container_start,
+        port_mapping,
+        bootstrap_exec,
+        store_insert,
+        health_ready,
+        create_to_ready,
+        delete,
+    ]);
+}

--- a/sandbox-runtime/tests/lifecycle_bench.rs
+++ b/sandbox-runtime/tests/lifecycle_bench.rs
@@ -51,6 +51,11 @@ use sandbox_runtime::runtime::{
 
 const DEFAULT_IMAGE: &str = "ghcr.io/tangle-network/blueprint-sidecar:all-harness";
 
+/// Serializes the process-env mutation in `setup_env`. See the note at its
+/// acquisition site for why this is a local static rather than the crate's
+/// feature-gated `TEST_ENV_GUARD`.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 fn bench_enabled() -> bool {
     std::env::var("RUN_LIFECYCLE_BENCH")
         .map(|v| v == "1")
@@ -190,6 +195,15 @@ async fn lifecycle_create_ready_delete_bench() {
          (or set LIFECYCLE_BENCH_IMAGE)"
     );
 
+    // Serialize env mutation, matching this dir's convention for env-mutating
+    // tests. We use a local static (like ssh_e2e's TEST_LOCK) rather than
+    // sandbox_runtime::TEST_ENV_GUARD because that symbol is gated behind the
+    // `test-utils` feature, which this bench does not enable — it runs in the
+    // default (no-feature) nextest lane. Today the binary has a single
+    // #[ignore] test so nothing contends, but this keeps a future second test
+    // from racing on the global SidecarRuntimeConfig OnceCell. Held for the
+    // whole run (the config is a one-shot snapshot of these vars).
+    let _env_guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let state_dir = TempDir::new().expect("temp state dir");
     setup_env(&state_dir, &image);
 
@@ -208,6 +222,13 @@ async fn lifecycle_create_ready_delete_bench() {
     let mut create_to_ready = StageSeries::new("create_to_ready");
     let mut delete = StageSeries::new("delete");
 
+    // NOTE: delete_sidecar force-removes the Docker container but does NOT
+    // remove the store row (consistent with the operator's own delete path),
+    // so the isolated store accumulates reps+1 stale records over the run.
+    // Harmless while reps+1 stays under SANDBOX_MAX_COUNT (default 100); a
+    // user setting LIFECYCLE_BENCH_REPS near/over that cap would start hitting
+    // admission rejection on later reps for a reason unrelated to the bench.
+    //
     // Warmup rep (discarded): primes the process-wide image-pull once-cell,
     // the HTTP client, and the Docker daemon's caches so measured reps
     // reflect steady state. Cold-start cost is visible in its own log line.
@@ -219,7 +240,12 @@ async fn lifecycle_create_ready_delete_bench() {
         let rep_start = Instant::now();
         let (record, _attestation, timings) = create_sidecar_timed(&params, None)
             .await
-            .unwrap_or_else(|e| panic!("rep {rep}: create failed: {e}"));
+            .unwrap_or_else(|e| {
+                panic!(
+                    "rep {rep}{}: create failed: {e}",
+                    if warmup { " (warmup)" } else { "" }
+                )
+            });
 
         let health_start = Instant::now();
         let ready = wait_for_sidecar_health(&record.sidecar_url, 120).await;


### PR DESCRIPTION
Blueprint-side performance work on the sandbox create→ready→delete loop: a measurement harness first (there was zero create→ready timing on the runtime's create path), then two targeted wins measured on it. One commit per item.

## 1. Measurement harness (commit 1) — MEASURED

- `CreateTimings`: per-stage `Instant` spans on the real Docker create path — permit wait, admission, docker connect, image pull, container create, container start, port mapping, bootstrap execs, store insert, ssh ready — logged once per create via `tracing`, returned by the new additive `create_sidecar_timed` (existing `create_sidecar` callers unchanged). `wait_for_sidecar_health` (now `pub`) and `delete_sidecar` log durations.
- `sandbox-runtime/tests/lifecycle_bench.rs`: N reps of `create_sidecar_timed` → poll `wait_for_sidecar_health` → `delete_sidecar` on an **isolated `BLUEPRINT_STATE_DIR` temp dir** (never touches an operator's store), printing per-rep stage rows + min/p50/p90/max per stage via `bench-harness` stats. `#[ignore]` **and** `RUN_LIFECYCLE_BENCH=1` gated, so no docker-less CI lane runs it; it runs on demand on a real host.
- "Ready" is defined explicitly: `create_sidecar` returns **before** `/health` passes unless `ssh_enabled`, so the bench polls health itself and reports `health_ready` and `create_to_ready` separately.
- Reconciled with the existing `ai-agent-sandbox-blueprint-lib/tests/lifecycle_bench.rs`: that one benchmarks the **sidecar's HTTP surface** against a single hand-provisioned bollard container and never enters `create_sidecar`; this one covers the runtime's own provisioning loop. Complement, not duplicate — cross-referenced in the doc comment.

Measured baseline (live Docker daemon on a dev host, all-harness image pre-pulled, n=5 warm reps + 1 discarded warmup, `ssh_enabled=false`):

| stage | p50 | note |
|---|---|---|
| create_to_ready | 1299 ms | end-to-end |
| container_create | 923 ms | Docker daemon side — dominant term |
| container_start | 218 ms | Docker daemon side |
| bootstrap_exec | 145 ms | the two post-start execs (item 2's target) |
| health_ready | 6 ms | create-return → first /health 200 |
| delete | 297 ms | force remove |
| everything else | < 2 ms | connect / pull-check / ports / store insert |

## 2. Docker round-trip wins (commit 2) — MEASURED

- `docker_exec_as_user` rebuilt a Docker client (connect + ping) on **every** exec. New `docker_exec_as_user_with_client` lets the create path thread its already-connected builder client; every other caller keeps the fresh-client behavior, deliberately preserving the stale-Docker-Desktop-socket guard (no cached process-wide client).
- The two unconditional post-start execs (root `chown -R` repair; agent `mkdir` of `~/.opencode-home/.config`) merged into **one root exec**: mkdir first (root owns the tree on the repair path), `su`-to-agent retry for agent-owned trees, unconditional best-effort chown, then `test -d` whose exit code drives a last-resort separate agent-user exec for `su`-less images. Failure handling stays warn-and-continue. Live-verified under production caps (`cap_drop=ALL`): the canonical image ships `agent 755` without the dirs, root mkdir is denied there, and the `su` path produces `agent:agent` dirs in one round trip.
- **Measured: `bootstrap_exec` p50 144.6 ms → 80.5 ms (−44%)** on the same host/image (a later run under host load showed 110 ms p50 — docker-daemon stages vary ±30% run-to-run; the stage never regressed above baseline). ssh_e2e (real container, real SSH login) green.
- Risk: low. Unit tests pin the merge invariants (mkdir-before-chown, su-before-chown, unconditional chown, exit-code-reports-dirs, fallback == the pre-merge agent exec verbatim).

## 3. Admission single-pass (commit 3 + merge commit) — pure refactor, win is algorithmic

- Every create deserialized the whole store multiple times under the creation permit: count check (`values().len()` per backend), memory-budget scan, and — after #136 landed on main mid-branch — a third CPU-budget scan. Now ONE `scan_records_for_admission` pass computes count, slot-reuse, and running memory+CPU footprints, feeding the **unchanged** decision cores (`check_sandbox_count_limit`, `check_host_memory_budget`, `check_host_cpu_budget`). When no limit is configured the store is not read at all.
- Preserved exactly: reused-id exclusion, unlimited-row (0) visibility for the accounted-at-max/one-time-warning semantics, warm-pool reservation read only when the memory budget is on, budget→count error precedence, and the permit ordering — the TOCTOU stays closed. The conflict with #136 was resolved locally by folding CPU into the same pass (full suite green post-merge).
- One visible ordering change, called out honestly: a host at the count cap now rejects (503) **before** TEE-specific request validation, consistent with how the memory budget already behaved.
- **Honestly labeled: the absolute win is unmeasurable at bench scale** — `admission` p50 is 0.0 ms on a near-empty store. The win is algorithmic (3 full-store deserializations → 1) and grows linearly with store size; no measured ms claim is made.
- Tests: differential unit test proving the single pass equals the legacy multi-pass computation row-for-row across store shapes and reuse targets; `admission_control` e2e (mock TEE: caps, clamps, budgets, count-limit-after-stop) green against the fused path.

## 4. CREATION_PERMIT narrowing — SKIPPED, with reason

The permit is held across the entire create (measured warm total ~450–700 ms; the bench's `permit_wait` is 0 when serial — the cost only appears under concurrent creates). Narrowing it safely requires an in-store **reservation row** the admission scan counts while the container doesn't exist yet. That row must look `Running` to be counted, but every store consumer treats `Running` as "container exists": `reaper_tick` unseals and idle/lifetime-enforces it, `reconcile_on_startup` would mark it stopped/removed, the operator API would list a phantom sandbox, and the upgrade sweep could try to recreate it. Doing this correctly needs a persisted `SandboxState::Provisioning` variant (a store schema change older binaries can't deserialize) plus an audit of reaper tick / GC / reconcile / operator API / upgrade sweep / snapshotting. That is a state-machine refactor, not a permit tweak — shipping it half-done risks the exact TOCTOU property the permit exists to protect. Filed as the follow-up; the harness's `permit_wait` stage is already in place to quantify the win when it lands.

## Test evidence

- `cargo test -p sandbox-runtime --features test-utils`: **501 passed, 6 ignored, 12 suites** (includes ssh_e2e against real Docker, admission_control, firecracker warm admission/budget).
- `cargo clippy -p sandbox-runtime --all-targets --features test-utils`: clean.
- Consumers compile: `cargo check -p ai-agent-sandbox-blueprint-lib -p ai-agent-instance-blueprint-lib -p ai-agent-tee-instance-blueprint-lib`.
- Branch merges cleanly into origin/main (`git merge-tree` verified after merging #136 locally).
- Bench runs: real Docker daemon, `ghcr.io/tangle-network/blueprint-sidecar:all-harness`, n=5 + warmup per run. All numbers above are **measured**; the only estimated claim is the admission scaling argument, labeled as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
