### PR TITLE
chore(deps): deliver microvm-runtime FC-perf wins to the operator (UFFD auto-default + snapshot/socket backoff)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10073,9 +10073,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2476,16 +2476,16 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.68.1"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
- "peeking_take_while",
  "proc-macro2",
  "quote",
  "regex",
@@ -4287,7 +4287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7192,16 +7192,15 @@ dependencies = [
 
 [[package]]
 name = "microvm-runtime"
-version = "0.4.0-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9133803bf92f4d43da70ac99314ad3a5485d920a06914826d83eaed2399c0306"
+version = "0.4.0-alpha.4"
+source = "git+https://github.com/tangle-network/microvm-runtime?rev=611111ffe5696e3dd319924b52631349ea97c6ec#611111ffe5696e3dd319924b52631349ea97c6ec"
 dependencies = [
  "base64 0.22.1",
  "libc",
- "nix 0.30.1",
+ "nix 0.31.3",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "userfaultfd",
 ]
@@ -7422,7 +7421,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -11145,9 +11143,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "userfaultfd"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d8b176d4d3e420685e964f87c25df5fdd5b26d7eb0d0e7c892d771f5b81035"
+checksum = "5b3a8a0cb358f7d1b7ee9b6784be122b6f51248a6d9e214d555beb9b44c72aea"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -11159,11 +11157,11 @@ dependencies = [
 
 [[package]]
 name = "userfaultfd-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75595d2a62b7db16bd47f5a1ce14e1fe05ccbe27d6c96721a958e0a027cad41"
+checksum = "dc91d95a797a81604af22946d0e86656f27feb0b9665c60665cf3554df12d1a8"
 dependencies = [
- "bindgen 0.68.1",
+ "bindgen 0.69.5",
  "cc",
  "cfg-if",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ debug = 1  # line tables only for dependencies (not full DWARF)
 # workspace's `=0.2.0-alpha.10` pins resolve. Remove once blueprint-sdk 0.2.0-alpha.11
 # (with 0.19 bindings) is published to crates.io.
 [patch.crates-io]
+microvm-runtime = { git = "https://github.com/tangle-network/microvm-runtime", rev = "611111ffe5696e3dd319924b52631349ea97c6ec" }
 blueprint-anvil-testing-utils = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
 blueprint-auth = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }
 blueprint-chain-setup = { git = "https://github.com/tangle-network/blueprint.git", rev = "5a2dcbbdbf57a8dc1b2d210bdd6ff0d85361237c" }

--- a/ai-agent-sandbox-blueprint-bin/src/main.rs
+++ b/ai-agent-sandbox-blueprint-bin/src/main.rs
@@ -244,7 +244,9 @@ async fn main() -> Result<(), blueprint_sdk::Error> {
             .request_port(Some(preferred_port))
             .await
             .map_err(|e| blueprint_sdk::Error::Other(format!("BPM port allocation failed: {e}")))?;
-        info!("BPM allocated port {port} for operator API (service {service_id}, preferred {preferred_port})");
+        info!(
+            "BPM allocated port {port} for operator API (service {service_id}, preferred {preferred_port})"
+        );
         (port, [127, 0, 0, 1u8])
     } else {
         (preferred_port, [0, 0, 0, 0u8])

--- a/deny.toml
+++ b/deny.toml
@@ -158,4 +158,6 @@ allow-git = [
     "https://github.com/tangle-network/blueprint.git",
     "https://github.com/tangle-network/tnt-core",
     "https://github.com/tangle-network/tnt-core.git",
+    "https://github.com/tangle-network/microvm-runtime",
+    "https://github.com/tangle-network/microvm-runtime.git",
 ]


### PR DESCRIPTION
Unifies **microvm-runtime** across `sandbox-runtime` and its transitive `microvm-warm-pool` onto the merged FC-perf work ([microvm-runtime #28](https://github.com/tangle-network/microvm-runtime/pull/28), `0.4.0-alpha.4`, rev `611111f`) via a one-line `[patch.crates-io]` git pin — the same pattern #134 established for `blueprint-*`.

## What this delivers to the operator
The firecracker boot-path improvements that were merged in microvm-runtime but not yet consumed here:
- **UFFD memory backend auto-selected** when the host allows it (probes `/proc/sys/vm/unprivileged_userfaultfd`); `MICROVM_MEM_BACKEND` override still wins — faster restore + lower memory duplication vs the File backend.
- **Exponential socket-poll backoff** on the Firecracker API socket (was a tight spin).
- `track_dirty_pages=false` on the snapshot path; rootfs full-copy now WARNs instead of silently paying the copy.

## Why a patch, not a version bump
`sandbox-runtime` depends on `microvm-runtime` directly **and** transitively through `microvm-warm-pool`. Cargo will not unify a git source with a crates.io source, so before this change the tree carried two `microvm-runtime` builds — which is exactly the `VmProvider`/`VmQuery` trait-mismatch that made `firecracker_warm/serving.rs` fail to compile. The `[patch.crates-io]` pin collapses both onto the single git rev.

## Verification
- `cargo update -p microvm-runtime` → `Removing 0.4.0-alpha.3` → `Adding 0.4.0-alpha.4 (git 611111f)`; `microvm-warm-pool` unifies onto the same rev.
- `cargo check -p sandbox-runtime` → `Finished`, **zero errors** (the 11 `serving.rs` trait-mismatch errors are gone).

## Scope
Two files: `Cargo.toml` (+1 patch line) and `Cargo.lock` (re-resolved). No source changes. Independent of #137 (docker/admission/bench perf).