### PR TITLE
feat(sandbox-runtime): docker warm-pool to pre-pay ~1s container bring-up on the create hot path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,50 @@ SIDECAR_PULL_IMAGE=true
 # warm claims to creates requesting that stack image and disk size.
 # SANDBOX_FC_WARM_DISK_GB=0
 
+# ── Docker warm pool (analogue of the Firecracker pool, for the docker
+# backend) ────────────────────────────────────────────────────────────────────
+# Number of pre-created, pre-started, bootstrapped sidecar containers kept
+# claimable (0 = disabled, the default). When > 0, a create RENAMES one of the
+# pooled containers onto the real sandbox id instead of paying the ~1s Docker
+# bring-up (container create + start + workspace bootstrap). It erases that
+# ~1s from the request path for the DEFAULT SHAPE only — Docker bakes container
+# env/ports at create time and cannot mutate them afterward, so a warm claim
+# serves ONLY requests that match the pooled shape (default image, matching
+# cpu/mem, matching base env, no user env, no extra ports, ssh disabled). Any
+# other request misses to a normal cold create with the typed reason logged.
+# Claims are admission-accounted exactly like cold boots (SANDBOX_MAX_COUNT /
+# SANDBOX_HOST_MEMORY_BUDGET_MB); the pool's own standing footprint is reserved
+# against the memory budget as pool_size × SANDBOX_DOCKER_WARM_MEMORY_MB. An
+# unparseable value is a startup error, never a silent disable.
+# SANDBOX_DOCKER_WARM_POOL_SIZE=0
+
+# Per-container memory (MB) the pool holds. REQUIRED when the pool is enabled —
+# the Docker backend has no default per-container memory, and the host memory
+# budget must be able to account for the pool. A request qualifies for a warm
+# claim only if it asks for this memory (or leaves memory unset).
+# SANDBOX_DOCKER_WARM_MEMORY_MB=2048
+
+# Per-container CPU cores the pool holds. 0 (default) leaves warm containers
+# uncapped and matches requests that also leave cpu unset.
+# SANDBOX_DOCKER_WARM_CPU_CORES=0
+
+# Sidecar image the pool is built on. Defaults to SIDECAR_IMAGE. A warm claim
+# serves only requests naming this image (or leaving image empty).
+# SANDBOX_DOCKER_WARM_IMAGE=
+
+# Base env JSON baked into every warm container. Default empty ({}). A request
+# qualifies only if its base env matches this AND it carries no user env.
+# SANDBOX_DOCKER_WARM_BASE_ENV_JSON=
+
+# Capabilities JSON baked into every warm container (drives SIDECAR_CAPABILITIES,
+# which is immutable after create). Default empty. A request qualifies only if
+# its capabilities parse to the same set.
+# SANDBOX_DOCKER_WARM_CAPABILITIES_JSON=
+
+# Max age (seconds) of a pooled container before it is reaped and refilled.
+# Default 3600.
+# SANDBOX_DOCKER_WARM_MAX_AGE_SECS=3600
+
 # Guest-memory backend for Firecracker snapshot restore (read by the
 # microvm-runtime primitive). `file` (default) loads the snapshot's memory
 # file eagerly; `uffd` serves guest pages lazily through a userfaultfd

--- a/sandbox-runtime/src/docker_warm/config.rs
+++ b/sandbox-runtime/src/docker_warm/config.rs
@@ -1,0 +1,208 @@
+//! Warm-pool configuration knobs + host-memory reservation.
+//!
+//! Every knob mirrors an `SANDBOX_FC_WARM_*` sibling in
+//! [`crate::firecracker_warm::config`]; the parsing discipline is identical
+//! (absent/empty/`0` disables, unparseable is a hard [`SandboxError::Validation`],
+//! never a silent disable).
+
+use super::*;
+
+/// Parse `SANDBOX_DOCKER_WARM_POOL_SIZE`. Absent/empty/`0` disables warm
+/// serving; anything unparseable is a hard configuration error — a typo must
+/// never silently disable the pool. Mirror of
+/// [`crate::firecracker_warm::configured_pool_size`].
+pub(crate) fn configured_pool_size() -> Result<usize> {
+    match std::env::var("SANDBOX_DOCKER_WARM_POOL_SIZE") {
+        Err(_) => Ok(0),
+        Ok(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                return Ok(0);
+            }
+            trimmed.parse::<usize>().map_err(|_| {
+                SandboxError::Validation(format!(
+                    "SANDBOX_DOCKER_WARM_POOL_SIZE must be a non-negative integer, got {trimmed:?}"
+                ))
+            })
+        }
+    }
+}
+
+/// The pooled per-container memory (MB).
+///
+/// Unlike Firecracker — whose warm pool reads `mem_size_mib` from
+/// `FirecrackerConfig::from_env()` — the Docker backend has no per-container
+/// memory default in [`SidecarRuntimeConfig`] (`SANDBOX_MAX_MEMORY_MB` defaults
+/// to `0` = unlimited). So when the pool is enabled this value is **required**:
+/// the host-memory-budget reservation ([`reserved_host_memory_mb`]) cannot be
+/// computed without it, and a warm container created with no memory cap would
+/// let the pool over-commit host RAM invisibly. Requiring it is the fail-closed
+/// choice — never a silent `0`.
+///
+/// Returns `0` only when the pool is disabled (`pool_size == 0`), so a
+/// Firecracker-only or plain-Docker host that never sets the pool size pays
+/// nothing and sees no error.
+pub(crate) fn configured_warm_memory_mb(pool_size: usize) -> Result<u64> {
+    if pool_size == 0 {
+        return Ok(0);
+    }
+    match std::env::var("SANDBOX_DOCKER_WARM_MEMORY_MB") {
+        Ok(raw) if !raw.trim().is_empty() => {
+            let mb = raw.trim().parse::<u64>().map_err(|_| {
+                SandboxError::Validation(format!(
+                    "SANDBOX_DOCKER_WARM_MEMORY_MB must be a non-negative integer, got {:?}",
+                    raw.trim()
+                ))
+            })?;
+            if mb == 0 {
+                return Err(SandboxError::Validation(
+                    "SANDBOX_DOCKER_WARM_MEMORY_MB must be > 0 when SANDBOX_DOCKER_WARM_POOL_SIZE \
+                     is set: the host memory budget reserves pool_size × memory_mb, and a warm \
+                     container with no memory cap would over-commit host RAM."
+                        .to_string(),
+                ));
+            }
+            Ok(mb)
+        }
+        _ => Err(SandboxError::Validation(
+            "SANDBOX_DOCKER_WARM_MEMORY_MB is required when SANDBOX_DOCKER_WARM_POOL_SIZE is set: \
+             the Docker backend has no default per-container memory, and the host memory budget \
+             must be able to account for the warm pool's standing footprint."
+                .to_string(),
+        )),
+    }
+}
+
+/// The pooled per-container CPU cores. `0` (default) leaves the warm container
+/// uncapped, matching a request that also leaves `cpu_cores` unset (0). No
+/// budget reservation is made for CPU — idle warm containers time-share CPU and
+/// pin only RAM, the same rationale the Firecracker pool uses.
+pub(crate) fn configured_warm_cpu_cores() -> Result<u64> {
+    match std::env::var("SANDBOX_DOCKER_WARM_CPU_CORES") {
+        Err(_) => Ok(0),
+        Ok(raw) if raw.trim().is_empty() => Ok(0),
+        Ok(raw) => raw.trim().parse::<u64>().map_err(|_| {
+            SandboxError::Validation(format!(
+                "SANDBOX_DOCKER_WARM_CPU_CORES must be a non-negative integer, got {:?}",
+                raw.trim()
+            ))
+        }),
+    }
+}
+
+/// The pooled sidecar image. Defaults to the operator's `SIDECAR_IMAGE`
+/// ([`SidecarRuntimeConfig::image`]). A request must name this image (or leave
+/// `image` empty and default to it) to claim from the pool.
+pub(crate) fn configured_warm_image() -> String {
+    match std::env::var("SANDBOX_DOCKER_WARM_IMAGE") {
+        Ok(raw) if !raw.trim().is_empty() => raw.trim().to_string(),
+        _ => SidecarRuntimeConfig::load().image.clone(),
+    }
+}
+
+/// The base env JSON baked into every warm container. A request qualifies for a
+/// warm claim only if its `env_json` matches this AND it carries no user env
+/// (see the shape gate). Defaults to empty (`{}`) — the "no custom base env"
+/// default shape. Operators whose common request carries a fixed base env set
+/// this so warm can serve it.
+pub(crate) fn configured_warm_base_env_json() -> String {
+    std::env::var("SANDBOX_DOCKER_WARM_BASE_ENV_JSON")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_default()
+}
+
+/// The capabilities JSON baked into every warm container (drives
+/// `SIDECAR_CAPABILITIES`, which is create-time immutable). Defaults to empty
+/// (no extra capabilities). A request qualifies only if its capabilities parse
+/// to the same set.
+pub(crate) fn configured_warm_capabilities_json() -> String {
+    std::env::var("SANDBOX_DOCKER_WARM_CAPABILITIES_JSON")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_default()
+}
+
+/// Parse `SANDBOX_DOCKER_WARM_MAX_AGE_SECS` (pool-entry age eviction). Default
+/// 3600s. An over-age warm container is reaped and refilled so pooled entries
+/// never drift arbitrarily stale. Mirror of
+/// `SANDBOX_FC_WARM_MAX_AGE_SECS`.
+pub(crate) fn configured_entry_max_age() -> Result<Duration> {
+    match std::env::var("SANDBOX_DOCKER_WARM_MAX_AGE_SECS") {
+        Err(_) => Ok(Duration::from_secs(3600)),
+        Ok(raw) => raw
+            .trim()
+            .parse::<u64>()
+            .map(Duration::from_secs)
+            .map_err(|_| {
+                SandboxError::Validation(format!(
+                    "SANDBOX_DOCKER_WARM_MAX_AGE_SECS must be a non-negative integer, got {raw:?}"
+                ))
+            }),
+    }
+}
+
+/// Standing host-memory footprint the warm pool reserves against
+/// `SANDBOX_HOST_MEMORY_BUDGET_MB`, so admission accounts for pool inventory
+/// that never enters the sandbox store. Zero when warm serving is disabled
+/// (`SANDBOX_DOCKER_WARM_POOL_SIZE` unset/0), so Firecracker-only hosts are
+/// unaffected.
+///
+/// Factor 1 (not Firecracker's 2): a Docker warm entry is a single container,
+/// with no separate paused-template + pre-restored-entry pair.
+///
+/// Deterministic from config — a fixed reservation, not a live pool query: the
+/// engine is lazily built only on the first Docker create (after admission), so
+/// a live query would report 0 reserved on the very create that seeds the pool
+/// and let it over-commit (identical reasoning to
+/// [`crate::firecracker_warm::reserved_host_memory_mb`]).
+pub(crate) fn reserved_host_memory_mb() -> Result<u64> {
+    let pool_size = configured_pool_size()?;
+    if pool_size == 0 {
+        return Ok(0);
+    }
+    let memory_mb = configured_warm_memory_mb(pool_size)?;
+    Ok((pool_size as u64).saturating_mul(memory_mb))
+}
+
+/// Load the full warm-pool settings, or `None` when the pool is disabled.
+///
+/// Called on every Docker create (cheap env reads). A misconfiguration
+/// (unparseable pool size, or pool enabled without a memory value) is a hard
+/// error that fails the create loudly rather than silently degrading — the same
+/// fail-loud contract as the Firecracker pool.
+pub(crate) fn load_settings() -> Result<Option<DockerWarmSettings>> {
+    let pool_size = configured_pool_size()?;
+    if pool_size == 0 {
+        return Ok(None);
+    }
+    Ok(Some(DockerWarmSettings {
+        pool_size,
+        image: configured_warm_image(),
+        cpu_cores: configured_warm_cpu_cores()?,
+        memory_mb: configured_warm_memory_mb(pool_size)?,
+        base_env_json: configured_warm_base_env_json(),
+        capabilities_json: configured_warm_capabilities_json(),
+        entry_max_age: configured_entry_max_age()?,
+    }))
+}
+
+/// The shape a warm container is seeded at and a create request must match (or
+/// leave unset) to be servable from the pool.
+#[derive(Debug, Clone)]
+pub(crate) struct DockerWarmSettings {
+    /// Number of warm containers to keep claimable.
+    pub pool_size: usize,
+    /// Sidecar image baked into every warm container.
+    pub image: String,
+    /// CPU cores the warm container is capped at (`0` = uncapped).
+    pub cpu_cores: u64,
+    /// Memory (MB) the warm container is capped at (always `> 0` when enabled).
+    pub memory_mb: u64,
+    /// Base env JSON baked into the warm container (immutable after create).
+    pub base_env_json: String,
+    /// Capabilities JSON baked into the warm container (immutable after create).
+    pub capabilities_json: String,
+    /// Pool-entry age eviction window.
+    pub entry_max_age: Duration,
+}

--- a/sandbox-runtime/src/docker_warm/host.rs
+++ b/sandbox-runtime/src/docker_warm/host.rs
@@ -1,0 +1,183 @@
+//! The production [`DockerWarmHost`]: real bollard I/O for seeding, claiming,
+//! and reaping warm containers. Split out of [`super::serving`] so the engine
+//! (pool state + claim/refill/reconcile policy) stays separate from the concrete
+//! Docker calls — mirroring [`crate::firecracker_warm`]'s `host.rs`.
+
+use super::*;
+
+/// Health-wait budget while seeding a warm container (background, off the
+/// request path).
+const WARM_SEED_HEALTH_TIMEOUT_SECS: u64 = 60;
+
+/// Health probe budget at claim. Short: the container was proven healthy at
+/// seed, so a failure here means it died while idle — fail fast to cold.
+const WARM_CLAIM_HEALTH_TIMEOUT_SECS: u64 = 5;
+
+/// The production [`DockerWarmHost`]: fresh Docker client per operation (never
+/// cached process-wide, matching `docker_builder`'s stale-socket rationale).
+pub(crate) struct BollardDockerWarmHost;
+
+#[async_trait]
+impl DockerWarmHost for BollardDockerWarmHost {
+    async fn seed_container(&self, spec: &WarmSeedSpec) -> Result<String> {
+        let config = SidecarRuntimeConfig::load();
+        let builder = crate::runtime::docker_builder().await?;
+
+        // Env baked identically to the cold path (build_env_vars), carrying the
+        // warm token — a random operator↔sidecar secret copied verbatim into
+        // the store record at claim, so no post-create mutation is needed.
+        let env_vars = crate::runtime::build_env_vars(
+            &spec.base_env_json,
+            &spec.token,
+            config.container_port,
+            &spec.capabilities_json,
+        )?;
+
+        let mut labels = std::collections::HashMap::new();
+        labels.insert(WARM_POOL_LABEL.to_string(), "1".to_string());
+        labels.insert(WARM_IMAGE_LABEL.to_string(), spec.image.clone());
+        labels.insert(WARM_SEQ_LABEL.to_string(), spec.seq.to_string());
+
+        // SSH disabled + no extra ports = the warm default shape.
+        let override_config = crate::runtime::build_docker_config(
+            config,
+            false,
+            spec.cpu_cores,
+            spec.memory_mb,
+            Some(labels),
+            &[],
+        );
+
+        let mut container = Container::new(builder.client(), spec.image.clone())
+            .with_name(spec.name.clone())
+            .env(env_vars)
+            .config_override(override_config);
+
+        // Create + start — the ~700ms + ~200ms pre-paid off the request path.
+        if let Err(err) =
+            crate::runtime::docker_timeout("warm_create_container", container.create()).await
+        {
+            tracing::debug!(error = %err, "warm container create failed; start path will retry it");
+        }
+        crate::runtime::start_container_with_retry(&mut container).await?;
+
+        let container_id = container
+            .id()
+            .ok_or_else(|| SandboxError::Docker("warm container missing id after start".into()))?
+            .to_string();
+
+        // On any post-start failure, reap the half-seeded container so it does
+        // not leak (it is not yet in the ready pool).
+        let seeded = async {
+            // Pre-pay the workspace bootstrap exec (chown + mkdir .opencode-home).
+            crate::runtime::run_workspace_bootstrap(&builder.client(), &container_id, &spec.name)
+                .await;
+
+            // Prove the pooled sidecar is live before it can ever be claimed.
+            let (sidecar_url, _port, _ssh, _extra) =
+                crate::runtime::refresh_port_mapping_with_retry(
+                    "warm seed endpoint",
+                    builder.client(),
+                    &container_id,
+                    config.container_port,
+                    false,
+                    &config.public_host,
+                    &std::collections::HashMap::new(),
+                )
+                .await?;
+            if !crate::runtime::wait_for_sidecar_health(&sidecar_url, WARM_SEED_HEALTH_TIMEOUT_SECS)
+                .await
+            {
+                return Err(SandboxError::Unavailable(format!(
+                    "warm container {container_id} sidecar at {sidecar_url} never became healthy"
+                )));
+            }
+            Ok(())
+        }
+        .await;
+
+        if let Err(err) = seeded {
+            self.reap_container(&container_id).await;
+            return Err(err);
+        }
+        Ok(container_id)
+    }
+
+    async fn claim_container(
+        &self,
+        container_id: &str,
+        sandbox_id: &str,
+    ) -> std::result::Result<ClaimResolved, ClaimFailure> {
+        let config = SidecarRuntimeConfig::load();
+        let builder = crate::runtime::docker_builder()
+            .await
+            .map_err(|e| ClaimFailure::Rename(e.to_string()))?;
+
+        // Rename by id (stable, unambiguous) onto the real sandbox id. No
+        // recreate — the container keeps its baked env, token, and host ports.
+        let new_name = format!("sidecar-{sandbox_id}");
+        crate::runtime::docker_timeout(
+            "warm_rename_container",
+            builder.client().rename_container(
+                container_id,
+                RenameContainerOptions {
+                    name: new_name.clone(),
+                },
+            ),
+        )
+        .await
+        .map_err(|e| ClaimFailure::Rename(e.to_string()))?;
+
+        // Read back the already-assigned host ports (container is already
+        // started, so this resolves immediately — no start latency).
+        let (sidecar_url, sidecar_port, ssh_port, extra_ports) =
+            crate::runtime::refresh_port_mapping_with_retry(
+                "warm claim endpoint",
+                builder.client(),
+                container_id,
+                config.container_port,
+                false,
+                &config.public_host,
+                &std::collections::HashMap::new(),
+            )
+            .await
+            .map_err(|e| ClaimFailure::PortResolve(e.to_string()))?;
+
+        // A container idle for minutes could have a dead sidecar behind a live
+        // process; prove it before handing it out.
+        if !crate::runtime::wait_for_sidecar_health(&sidecar_url, WARM_CLAIM_HEALTH_TIMEOUT_SECS)
+            .await
+        {
+            return Err(ClaimFailure::Unhealthy(format!(
+                "sidecar at {sidecar_url} not healthy within {WARM_CLAIM_HEALTH_TIMEOUT_SECS}s"
+            )));
+        }
+
+        Ok(ClaimResolved {
+            sidecar_url,
+            sidecar_port,
+            ssh_port,
+            extra_ports,
+        })
+    }
+
+    async fn reap_container(&self, container_id: &str) {
+        match crate::runtime::docker_builder().await {
+            Ok(builder) => {
+                if let Ok(c) = Container::from_id(builder.client(), container_id).await {
+                    let _ = c
+                        .remove(Some(RemoveContainerOptions {
+                            force: true,
+                            ..Default::default()
+                        }))
+                        .await;
+                }
+            }
+            Err(err) => tracing::warn!(
+                container_id,
+                %err,
+                "docker warm-pool reap: Docker connect failed"
+            ),
+        }
+    }
+}

--- a/sandbox-runtime/src/docker_warm/mod.rs
+++ b/sandbox-runtime/src/docker_warm/mod.rs
@@ -36,8 +36,10 @@
 //! Warm containers are identified on the Docker side by the label
 //! `tangle.warm-pool=1` and named `sidecar-warm-<seq>` (distinct from the live
 //! `sidecar-<uuid>`). [`reconcile_docker_warm_orphans`] lists them by label and
-//! reaps every one that is not a live store record (the data-loss guard) BEFORE
-//! the first refill — from the pool's lazy init and from
+//! reaps every one whose name still carries the `sidecar-warm-` prefix BEFORE
+//! the first refill — a purely structural guard that never consults the store,
+//! so no store failure can misclassify a live claimed sandbox as reapable (see
+//! [`reconcile`]). Runs from the pool's lazy init and from
 //! [`crate::reaper::reconcile_on_startup`].
 //!
 //! ## Fail-loud boundaries
@@ -66,11 +68,13 @@ use crate::error::{Result, SandboxError};
 use crate::runtime::{CreateSandboxParams, SidecarRuntimeConfig};
 
 mod config;
+mod host;
 mod reconcile;
 mod serving;
 mod types;
 
 pub(crate) use config::*;
+pub(crate) use host::*;
 pub(crate) use reconcile::*;
 pub(crate) use serving::*;
 pub(crate) use types::*;

--- a/sandbox-runtime/src/docker_warm/mod.rs
+++ b/sandbox-runtime/src/docker_warm/mod.rs
@@ -1,0 +1,79 @@
+//! Docker warm-pool: pre-created, pre-started, bootstrapped sidecar containers
+//! kept idle and renamed onto the real `sandbox_id` per request.
+//!
+//! It pre-pays the ~902ms of Docker bring-up (container create ~698ms +
+//! container start ~204ms) plus the ~104ms workspace bootstrap exec that the
+//! cold path pays on the request. A warm hit does only: rename the container,
+//! read back its already-assigned host ports, health-probe, and insert the
+//! store record — tens of milliseconds instead of ~1s.
+//!
+//! The shape mirrors [`crate::firecracker_warm`] 1:1, with one difference
+//! Docker forces: **container env is immutable after `docker create`**, so a
+//! warm container cannot receive per-request user secrets / base env the way
+//! Firecracker injects them over vsock at claim. v1 resolves this honestly with
+//! a **shape gate** (see [`serving::DockerWarmServing::shape_gate`]): warm
+//! serves ONLY the default shape (default image, default cpu/mem, no user env,
+//! matching base env + capabilities, no extra ports, SSH disabled); any other
+//! request misses to cold. The auth **token** is still bound at claim because
+//! it is a random operator↔sidecar secret (not request-derived): baked at seed,
+//! copied verbatim into the store record at claim, no container mutation.
+//!
+//! ## Admission-control invariant
+//!
+//! Pool inventory is NOT a live sandbox: it never enters the sandbox store
+//! (`sandboxes.json`), so the reaper, GC, `list`, and count cap all stay
+//! correct with zero changes — they iterate store records and warm has none. A
+//! warm claim itself is admitted exactly like a cold boot: the claim hook sits
+//! inside the Docker create arm, which the runtime only reaches AFTER
+//! `admit_sandbox_resources` (count cap + host memory budget, under the creation
+//! permit) has passed. The pool's own standing RAM footprint is reserved against
+//! `SANDBOX_HOST_MEMORY_BUDGET_MB` by [`reserved_host_memory_mb`]
+//! (`pool_size × memory_mb`, factor 1 — a Docker warm entry is one container),
+//! summed alongside the Firecracker reservation at admission.
+//!
+//! ## Restart reconciliation
+//!
+//! Warm containers are identified on the Docker side by the label
+//! `tangle.warm-pool=1` and named `sidecar-warm-<seq>` (distinct from the live
+//! `sidecar-<uuid>`). [`reconcile_docker_warm_orphans`] lists them by label and
+//! reaps every one that is not a live store record (the data-loss guard) BEFORE
+//! the first refill — from the pool's lazy init and from
+//! [`crate::reaper::reconcile_on_startup`].
+//!
+//! ## Fail-loud boundaries
+//!
+//! The only designed fallback is warm-miss → cold boot, and every miss carries
+//! a typed [`DockerWarmMiss`] the create path logs. A misconfigured
+//! `SANDBOX_DOCKER_WARM_POOL_SIZE`/`SANDBOX_DOCKER_WARM_MEMORY_MB` is a hard
+//! error, never a silent disable.
+//!
+//! Default OFF: `SANDBOX_DOCKER_WARM_POOL_SIZE` unset/0 disables everything —
+//! no engine init, no seeding, no memory reservation — so Firecracker-only and
+//! plain-Docker hosts pay nothing.
+
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use docktopus::DockerBuilder;
+use docktopus::bollard::container::{
+    ListContainersOptions, RemoveContainerOptions, RenameContainerOptions,
+};
+use docktopus::container::Container;
+
+use crate::error::{Result, SandboxError};
+use crate::runtime::{CreateSandboxParams, SidecarRuntimeConfig};
+
+mod config;
+mod reconcile;
+mod serving;
+mod types;
+
+pub(crate) use config::*;
+pub(crate) use reconcile::*;
+pub(crate) use serving::*;
+pub(crate) use types::*;
+
+#[cfg(test)]
+mod tests;

--- a/sandbox-runtime/src/docker_warm/reconcile.rs
+++ b/sandbox-runtime/src/docker_warm/reconcile.rs
@@ -19,17 +19,30 @@
 //! clean same-image restart (to skip the reseed cost) is a possible follow-up,
 //! not v1.
 //!
-//! ## The data-loss guard
+//! ## The data-loss guard (purely structural — never trusts the store)
 //!
 //! A claimed container keeps the (immutable) `tangle.warm-pool` label after the
-//! claim renames it, so the label filter also returns live sandboxes. The guard
-//! is `reap iff label present AND container id is NOT a live store record's
-//! container_id`. A successfully-claimed container ALWAYS has a durable store
-//! record with its id, so it is classified live and left untouched — the Docker
-//! analogue of Firecracker's socket-exists live-vs-orphan guard. This guard is
-//! stronger than a name check: it also reaps a container that was renamed but
-//! crashed before its record was inserted (label present, id not in store),
-//! closing that leak window.
+//! claim renames it, so the label filter alone ALSO returns live customer
+//! sandboxes. Force-removing one would destroy a running customer's work — and
+//! this runs at operator startup, right after a crash/redeploy, exactly when the
+//! store is most likely partial or unreadable.
+//!
+//! The guard is therefore purely STRUCTURAL and depends on nothing but the
+//! container's own name: a container is a reap candidate only if its name still
+//! carries the [`WARM_NAME_PREFIX`] (`sidecar-warm-`). A claim renames the
+//! container to `sidecar-<sandbox_id>` BEFORE it is served, so a live claimed
+//! sandbox can NEVER match this prefix. Reconcile also only ever runs before the
+//! first seed (the in-memory pool is empty), so every `sidecar-warm-` container
+//! it sees is necessarily an orphan from a previous process.
+//!
+//! We deliberately do NOT cross-check container ids against the store to reap
+//! renamed orphans. Deriving "not live" from the store is unsafe: a corrupt
+//! `sandboxes.json` silently loads as an EMPTY map (`Ok(empty)`, not `Err`), and
+//! a poisoned lock / IO error yields `Err` — in every one of those failure modes
+//! a live claimed sandbox looks "not in the store" and would be reaped. The only
+//! thing that costs is a leaked container from a claim that crashed in the
+//! microsecond window between the rename and the store insert; that is a rare,
+//! recoverable wasted-RAM leak, never customer data loss. Safety wins.
 
 use super::*;
 
@@ -49,8 +62,10 @@ pub(crate) async fn reconcile_docker_warm_orphans(builder: &DockerBuilder) {
         return;
     }
 
-    let live_ids = live_store_container_ids();
-    let to_reap = containers_to_reap(&listings, &live_ids);
+    // Reap decision is purely structural (name prefix) — it never reads the
+    // store, so no store failure mode can misclassify a live claimed sandbox as
+    // reapable. See the module doc's data-loss guard.
+    let to_reap = containers_to_reap(&listings);
     if to_reap.is_empty() {
         return;
     }
@@ -83,27 +98,22 @@ pub(crate) async fn reconcile_docker_warm_orphans(builder: &DockerBuilder) {
 #[derive(Debug, Clone)]
 pub(crate) struct WarmContainerListing {
     pub id: String,
+    /// Primary container name with the leading `/` stripped (empty if Docker
+    /// returned none). `sidecar-warm-<seq>` while pooled; `sidecar-<id>` once
+    /// claimed — the structural signal the reap guard keys on.
+    pub name: String,
 }
 
-/// Container ids of every live store record (all backends). A warm-labelled
-/// container whose id is in this set was claimed and is a live sandbox.
-fn live_store_container_ids() -> std::collections::HashSet<String> {
-    crate::runtime::sandboxes()
-        .and_then(|s| s.values())
-        .map(|records| records.into_iter().map(|r| r.container_id).collect())
-        .unwrap_or_default()
-}
-
-/// Pure reap decision: a warm-labelled container is reaped iff its id is NOT a
-/// live store record's container_id. Separated from Docker I/O so the guard is
-/// unit-testable without a daemon.
-pub(crate) fn containers_to_reap(
-    listings: &[WarmContainerListing],
-    live_ids: &std::collections::HashSet<String>,
-) -> Vec<String> {
+/// Pure reap decision (unit-testable without a daemon). A warm-labelled
+/// container is reaped iff its name still carries [`WARM_NAME_PREFIX`]
+/// (`sidecar-warm-`) — i.e. it is an unclaimed pooled container orphaned by a
+/// previous process. A claimed container was renamed to `sidecar-<id>` before
+/// being served, so it never matches and is never reaped, regardless of store
+/// state. See the module doc for why the store is deliberately not consulted.
+pub(crate) fn containers_to_reap(listings: &[WarmContainerListing]) -> Vec<String> {
     listings
         .iter()
-        .filter(|c| !live_ids.contains(&c.id))
+        .filter(|c| c.name.starts_with(WARM_NAME_PREFIX))
         .map(|c| c.id.clone())
         .collect()
 }
@@ -124,6 +134,18 @@ async fn list_warm_containers(builder: &DockerBuilder) -> Result<Vec<WarmContain
     .await?;
     Ok(summaries
         .into_iter()
-        .filter_map(|s| s.id.map(|id| WarmContainerListing { id }))
+        .filter_map(|s| {
+            s.id.map(|id| {
+                // Docker returns names with a leading `/`; the reap guard matches
+                // on the bare `sidecar-warm-` prefix.
+                let name = s
+                    .names
+                    .as_ref()
+                    .and_then(|n| n.first())
+                    .map(|n| n.trim_start_matches('/').to_string())
+                    .unwrap_or_default();
+                WarmContainerListing { id, name }
+            })
+        })
         .collect())
 }

--- a/sandbox-runtime/src/docker_warm/reconcile.rs
+++ b/sandbox-runtime/src/docker_warm/reconcile.rs
@@ -1,0 +1,129 @@
+//! Restart reconciliation: reap warm containers orphaned by a previous
+//! operator process.
+//!
+//! Warm containers persist across an operator restart, but the fresh process's
+//! in-memory pool is empty and the store reconcile
+//! ([`crate::reaper::reconcile_on_startup`]) only walks store records — a warm
+//! container never entered the store, so without this it orphans invisibly and
+//! holds RAM + a host port forever. This lists containers by the
+//! `tangle.warm-pool=1` label and reaps every one that is NOT a live sandbox.
+//!
+//! ## Reap-always (not adopt) — a deliberate v1 choice
+//!
+//! Unlike the design's adopt-or-reap sketch, this reaps every warm orphan and
+//! lets the pool reseed on the current image. That is exactly what the
+//! Firecracker pool does (its process-local templates are reaped every
+//! restart), it is strictly simpler, and it makes image-staleness a non-issue:
+//! a warm container built on a superseded `SIDECAR_IMAGE` is reaped on restart,
+//! so the pool never hands out a stale sidecar. Re-adopting the pool across a
+//! clean same-image restart (to skip the reseed cost) is a possible follow-up,
+//! not v1.
+//!
+//! ## The data-loss guard
+//!
+//! A claimed container keeps the (immutable) `tangle.warm-pool` label after the
+//! claim renames it, so the label filter also returns live sandboxes. The guard
+//! is `reap iff label present AND container id is NOT a live store record's
+//! container_id`. A successfully-claimed container ALWAYS has a durable store
+//! record with its id, so it is classified live and left untouched — the Docker
+//! analogue of Firecracker's socket-exists live-vs-orphan guard. This guard is
+//! stronger than a name check: it also reaps a container that was renamed but
+//! crashed before its record was inserted (label present, id not in store),
+//! closing that leak window.
+
+use super::*;
+
+/// Reap warm containers orphaned by a previous operator process. Runs BEFORE
+/// the first seed — from the pool's lazy init closure, and from
+/// [`crate::reaper::reconcile_on_startup`] (covering the "warm disabled now, but
+/// a prior process left orphans" case the lazy init never reaches).
+pub(crate) async fn reconcile_docker_warm_orphans(builder: &DockerBuilder) {
+    let listings = match list_warm_containers(builder).await {
+        Ok(l) => l,
+        Err(err) => {
+            tracing::warn!(%err, "docker warm-pool reconcile: list_containers failed");
+            return;
+        }
+    };
+    if listings.is_empty() {
+        return;
+    }
+
+    let live_ids = live_store_container_ids();
+    let to_reap = containers_to_reap(&listings, &live_ids);
+    if to_reap.is_empty() {
+        return;
+    }
+
+    for id in to_reap {
+        tracing::warn!(
+            container_id = %id,
+            "reaping orphaned warm-pool container from a previous operator process"
+        );
+        let container = match Container::from_id(builder.client(), &id).await {
+            Ok(c) => c,
+            Err(err) => {
+                tracing::warn!(container_id = %id, %err, "warm reconcile: load container failed");
+                continue;
+            }
+        };
+        if let Err(err) = container
+            .remove(Some(RemoveContainerOptions {
+                force: true,
+                ..Default::default()
+            }))
+            .await
+        {
+            tracing::warn!(container_id = %id, %err, "warm reconcile: force-remove failed");
+        }
+    }
+}
+
+/// A warm-labelled container as seen by `list_containers`.
+#[derive(Debug, Clone)]
+pub(crate) struct WarmContainerListing {
+    pub id: String,
+}
+
+/// Container ids of every live store record (all backends). A warm-labelled
+/// container whose id is in this set was claimed and is a live sandbox.
+fn live_store_container_ids() -> std::collections::HashSet<String> {
+    crate::runtime::sandboxes()
+        .and_then(|s| s.values())
+        .map(|records| records.into_iter().map(|r| r.container_id).collect())
+        .unwrap_or_default()
+}
+
+/// Pure reap decision: a warm-labelled container is reaped iff its id is NOT a
+/// live store record's container_id. Separated from Docker I/O so the guard is
+/// unit-testable without a daemon.
+pub(crate) fn containers_to_reap(
+    listings: &[WarmContainerListing],
+    live_ids: &std::collections::HashSet<String>,
+) -> Vec<String> {
+    listings
+        .iter()
+        .filter(|c| !live_ids.contains(&c.id))
+        .map(|c| c.id.clone())
+        .collect()
+}
+
+/// List all containers (any state) carrying the `tangle.warm-pool=1` label.
+async fn list_warm_containers(builder: &DockerBuilder) -> Result<Vec<WarmContainerListing>> {
+    let mut filters = std::collections::HashMap::new();
+    filters.insert("label".to_string(), vec![format!("{WARM_POOL_LABEL}=1")]);
+    let options = ListContainersOptions {
+        all: true,
+        filters,
+        ..Default::default()
+    };
+    let summaries = crate::runtime::docker_timeout(
+        "warm_list_containers",
+        builder.client().list_containers(Some(options)),
+    )
+    .await?;
+    Ok(summaries
+        .into_iter()
+        .filter_map(|s| s.id.map(|id| WarmContainerListing { id }))
+        .collect())
+}

--- a/sandbox-runtime/src/docker_warm/serving.rs
+++ b/sandbox-runtime/src/docker_warm/serving.rs
@@ -1,0 +1,598 @@
+//! The warm-serving engine: seed / refill / claim / evict, plus the
+//! process-wide handle and the production Docker host.
+//!
+//! Structure mirrors [`crate::firecracker_warm::serving`]:
+//!
+//! - the engine ([`DockerWarmServing`]) owns the ready pool
+//!   (`Mutex<Vec<WarmContainer>>`), the seed throttle (`seeds_in_flight`), and
+//!   the claim gate; it is generic over a [`DockerWarmHost`] so tests drive it
+//!   with an in-memory fake and production wires the real bollard host;
+//! - the CLAIM pops the entry out of `ready` **before any await** so two
+//!   concurrent claims can never receive the same container;
+//! - seeding runs in DETACHED tasks OUTSIDE the creation permit (refilling the
+//!   pool must never serialize behind — the up-front memory reservation, not a
+//!   per-seed budget check, keeps it fail-closed).
+
+use super::*;
+
+/// Docker container labels stamped at seed. `tangle.warm-pool` is the reconcile
+/// filter; the other two are provenance/observability. Labels are create-time
+/// immutable, so a claimed container keeps them — the reconcile guard keys on
+/// "warm label AND no matching store record", which is why that is safe.
+pub(crate) const WARM_POOL_LABEL: &str = "tangle.warm-pool";
+pub(crate) const WARM_IMAGE_LABEL: &str = "tangle.warm-image";
+pub(crate) const WARM_SEQ_LABEL: &str = "tangle.warm-seq";
+
+/// Never seed more than this many containers concurrently, so a cold-start
+/// burst does not create the entire pool at once (each seed is a ~700ms Docker
+/// create + a `memory_mb` RAM spike). The pool still fills across subsequent
+/// creates; the total in-flight can never exceed `pool_size` (the
+/// `seeds_in_flight` compare-exchange guarantees that separately).
+const MAX_CONCURRENT_SEEDS: usize = 2;
+
+/// Health-wait budget while seeding a warm container (background, off the
+/// request path).
+const WARM_SEED_HEALTH_TIMEOUT_SECS: u64 = 60;
+
+/// Health probe budget at claim. Short: the container was proven healthy at
+/// seed, so a failure here means it died while idle — fail fast to cold.
+const WARM_CLAIM_HEALTH_TIMEOUT_SECS: u64 = 5;
+
+/// Everything a host needs to seed one warm container.
+#[derive(Debug, Clone)]
+pub(crate) struct WarmSeedSpec {
+    pub seq: u64,
+    /// Container name (`sidecar-warm-<seq>`).
+    pub name: String,
+    /// Random operator↔sidecar token baked into the env.
+    pub token: String,
+    pub image: String,
+    pub cpu_cores: u64,
+    pub memory_mb: u64,
+    pub base_env_json: String,
+    pub capabilities_json: String,
+}
+
+/// Host-side Docker operations the engine delegates. Production wires
+/// [`BollardDockerWarmHost`]; tests substitute an in-memory fake so the pool's
+/// lifecycle (seed → refill → claim → evict) is exercised without a daemon.
+#[async_trait]
+pub(crate) trait DockerWarmHost: Send + Sync + 'static {
+    /// Cold-create + start + bootstrap + health-prove a warm-labelled container
+    /// on the pooled shape. Returns the container id once it is claimable.
+    async fn seed_container(&self, spec: &WarmSeedSpec) -> Result<String>;
+
+    /// Rename the pooled container onto `sidecar-<sandbox_id>`, read back its
+    /// (already-assigned) host ports, and health-probe the sidecar.
+    async fn claim_container(
+        &self,
+        container_id: &str,
+        sandbox_id: &str,
+    ) -> std::result::Result<ClaimResolved, ClaimFailure>;
+
+    /// Force-remove a container (a failed/evicted/orphaned warm entry).
+    async fn reap_container(&self, container_id: &str);
+}
+
+#[derive(Debug, Default)]
+struct WarmCounters {
+    claims: AtomicU64,
+    misses: AtomicU64,
+    seed_failures: AtomicU64,
+}
+
+/// The warm-serving engine.
+pub(crate) struct DockerWarmServing {
+    host: Arc<dyn DockerWarmHost>,
+    settings: DockerWarmSettings,
+    ready: Mutex<Vec<WarmContainer>>,
+    seeds_in_flight: Arc<AtomicUsize>,
+    seq: AtomicU64,
+    counters: WarmCounters,
+}
+
+impl DockerWarmServing {
+    pub(crate) fn new(host: Arc<dyn DockerWarmHost>, settings: DockerWarmSettings) -> Self {
+        Self {
+            host,
+            settings,
+            ready: Mutex::new(Vec::new()),
+            seeds_in_flight: Arc::new(AtomicUsize::new(0)),
+            seq: AtomicU64::new(0),
+            counters: WarmCounters::default(),
+        }
+    }
+
+    pub(crate) fn ready_count(&self) -> usize {
+        lock_ready(&self.ready).len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn seeds_in_flight(&self) -> usize {
+        self.seeds_in_flight.load(Ordering::SeqCst)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn claims(&self) -> u64 {
+        self.counters.claims.load(Ordering::Relaxed)
+    }
+
+    /// Top the pool back up to `pool_size`. Called on every create: cheap when
+    /// saturated, and it doubles as the retry loop for failed seeds (no
+    /// supervisor thread). Verbatim shape of
+    /// [`crate::firecracker_warm::WarmServing::ensure_seeding`], plus a
+    /// concurrent-seed cap and lazy age eviction.
+    pub(crate) fn ensure_seeding(self: &Arc<Self>) {
+        self.evict_over_age();
+        loop {
+            let ready = self.ready_count();
+            let in_flight = self.seeds_in_flight.load(Ordering::SeqCst);
+            if ready + in_flight >= self.settings.pool_size {
+                return;
+            }
+            // Bound the concurrent seed burst.
+            if in_flight >= MAX_CONCURRENT_SEEDS.min(self.settings.pool_size) {
+                return;
+            }
+            // Reserve the slot before spawning so concurrent creates cannot
+            // over-seed past pool_size.
+            if self
+                .seeds_in_flight
+                .compare_exchange(in_flight, in_flight + 1, Ordering::SeqCst, Ordering::SeqCst)
+                .is_err()
+            {
+                continue;
+            }
+            let this = Arc::clone(self);
+            tokio::spawn(async move {
+                let outcome = this.seed_one().await;
+                this.seeds_in_flight.fetch_sub(1, Ordering::SeqCst);
+                if let Err(err) = outcome {
+                    this.counters.seed_failures.fetch_add(1, Ordering::Relaxed);
+                    tracing::error!(%err, "docker warm-pool container seed failed");
+                }
+            });
+        }
+    }
+
+    async fn seed_one(&self) -> Result<()> {
+        let seq = self.seq.fetch_add(1, Ordering::SeqCst);
+        let token = crate::auth::generate_token();
+        let spec = WarmSeedSpec {
+            seq,
+            name: format!("sidecar-warm-{seq}"),
+            token: token.clone(),
+            image: self.settings.image.clone(),
+            cpu_cores: self.settings.cpu_cores,
+            memory_mb: self.settings.memory_mb,
+            base_env_json: self.settings.base_env_json.clone(),
+            capabilities_json: self.settings.capabilities_json.clone(),
+        };
+        let container_id = self.host.seed_container(&spec).await?;
+        lock_ready(&self.ready).push(WarmContainer {
+            container_id,
+            token,
+            seq,
+            created_at: crate::util::now_ts(),
+        });
+        tracing::info!(
+            warm_seq = seq,
+            "docker warm-pool container seeded and ready"
+        );
+        Ok(())
+    }
+
+    /// Reap pooled containers older than the configured max age, then let
+    /// [`ensure_seeding`](Self::ensure_seeding) refill. Reaps run detached; the
+    /// ready lock is dropped before any await (a std Mutex guard across await is
+    /// both a clippy denial and a deadlock risk).
+    fn evict_over_age(&self) {
+        let max_age = self.settings.entry_max_age.as_secs();
+        if max_age == 0 {
+            return;
+        }
+        let now = crate::util::now_ts();
+        let evicted: Vec<WarmContainer> = {
+            let mut ready = lock_ready(&self.ready);
+            let (keep, evict): (Vec<WarmContainer>, Vec<WarmContainer>) =
+                std::mem::take(&mut *ready)
+                    .into_iter()
+                    .partition(|w| now.saturating_sub(w.created_at) < max_age);
+            *ready = keep;
+            evict
+        };
+        for w in evicted {
+            tracing::info!(
+                container_id = %w.container_id,
+                warm_seq = w.seq,
+                "docker warm-pool evicting over-age container"
+            );
+            let host = Arc::clone(&self.host);
+            tokio::spawn(async move { host.reap_container(&w.container_id).await });
+        }
+    }
+
+    /// Try to serve `request` from the pool. Never cold-falls-back internally —
+    /// the caller owns the (logged) fallback.
+    pub(crate) async fn claim(&self, request: &DockerWarmClaimRequest) -> DockerWarmOutcome {
+        if let Some(miss) = self.shape_gate(request) {
+            return self.miss(miss);
+        }
+
+        // Pop a ready container synchronously BEFORE any await so a concurrent
+        // claim cannot double-serve it. On a downstream failure the container
+        // was possibly already renamed and cannot return to the pool — it is
+        // reaped, not pushed back.
+        let warm = {
+            let mut ready = lock_ready(&self.ready);
+            match ready.pop() {
+                Some(w) => w,
+                None => {
+                    drop(ready);
+                    let reason = if self.seeds_in_flight.load(Ordering::SeqCst) > 0 {
+                        DockerWarmMiss::NotReady
+                    } else {
+                        DockerWarmMiss::Empty
+                    };
+                    return self.miss(reason);
+                }
+            }
+        };
+
+        match self
+            .host
+            .claim_container(&warm.container_id, &request.sandbox_id)
+            .await
+        {
+            Ok(resolved) => {
+                self.counters.claims.fetch_add(1, Ordering::Relaxed);
+                tracing::info!(
+                    sandbox_id = %request.sandbox_id,
+                    container_id = %warm.container_id,
+                    warm_seq = warm.seq,
+                    "docker warm-pool claim served (warm container renamed onto sandbox id)"
+                );
+                DockerWarmOutcome::Claimed(DockerWarmClaim {
+                    container_id: warm.container_id,
+                    token: warm.token,
+                    sidecar_url: resolved.sidecar_url,
+                    sidecar_port: resolved.sidecar_port,
+                    ssh_port: resolved.ssh_port,
+                    extra_ports: resolved.extra_ports,
+                })
+            }
+            Err(failure) => {
+                self.host.reap_container(&warm.container_id).await;
+                self.miss(DockerWarmMiss::from_claim_failure(failure))
+            }
+        }
+    }
+
+    /// `None` = request matches the pooled shape. Every branch is a distinct
+    /// typed miss so the create path can log exactly why it fell to cold.
+    pub(crate) fn shape_gate(&self, request: &DockerWarmClaimRequest) -> Option<DockerWarmMiss> {
+        if request.image.trim() != self.settings.image.trim() {
+            return Some(DockerWarmMiss::ImageMismatch {
+                requested: request.image.clone(),
+                pooled: self.settings.image.clone(),
+            });
+        }
+        if request.ssh_enabled {
+            return Some(DockerWarmMiss::SshRequested);
+        }
+        if has_user_env(&request.user_env_json) {
+            return Some(DockerWarmMiss::UserEnvPresent);
+        }
+        if request.extra_ports_len > 0 {
+            return Some(DockerWarmMiss::ExtraPortsRequested);
+        }
+        if request.cpu_cores != 0 && request.cpu_cores != self.settings.cpu_cores {
+            return Some(DockerWarmMiss::CpuMismatch {
+                requested: request.cpu_cores,
+                pooled: self.settings.cpu_cores,
+            });
+        }
+        if request.memory_mb != 0 && request.memory_mb != self.settings.memory_mb {
+            return Some(DockerWarmMiss::MemoryMismatch {
+                requested: request.memory_mb,
+                pooled: self.settings.memory_mb,
+            });
+        }
+        if !env_json_matches(&request.env_json, &self.settings.base_env_json) {
+            return Some(DockerWarmMiss::BaseEnvMismatch);
+        }
+        if crate::runtime::parse_sidecar_capabilities(&request.capabilities_json)
+            != crate::runtime::parse_sidecar_capabilities(&self.settings.capabilities_json)
+        {
+            return Some(DockerWarmMiss::CapabilitiesMismatch);
+        }
+        None
+    }
+
+    fn miss(&self, miss: DockerWarmMiss) -> DockerWarmOutcome {
+        self.counters.misses.fetch_add(1, Ordering::Relaxed);
+        DockerWarmOutcome::Miss(miss)
+    }
+}
+
+/// A request carries user env if its `user_env_json` is a non-empty, non-`{}`
+/// object — mirrors [`crate::SandboxRecord::has_user_secrets`].
+fn has_user_env(user_env_json: &str) -> bool {
+    let s = user_env_json.trim();
+    !s.is_empty() && s != "{}"
+}
+
+/// Structural equality of two base-env JSON strings (order-independent; empty
+/// parses to `{}`). Unparseable input never silently matches — it is treated as
+/// a mismatch so a malformed base env falls to the cold path.
+fn env_json_matches(a: &str, b: &str) -> bool {
+    fn normalized(s: &str) -> Option<serde_json::Value> {
+        let t = s.trim();
+        if t.is_empty() {
+            return Some(serde_json::json!({}));
+        }
+        serde_json::from_str::<serde_json::Value>(t).ok()
+    }
+    match (normalized(a), normalized(b)) {
+        (Some(va), Some(vb)) => va == vb,
+        _ => false,
+    }
+}
+
+fn lock_ready(m: &Mutex<Vec<WarmContainer>>) -> std::sync::MutexGuard<'_, Vec<WarmContainer>> {
+    match m.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process-wide handle + entry point
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Process-wide warm-serving engine. Unset until the first Docker create with
+/// `SANDBOX_DOCKER_WARM_POOL_SIZE > 0`. A `tokio::sync::OnceCell` (async init)
+/// rather than the Firecracker pool's `OnceLock` because the Docker restart
+/// reconcile is async (bollard `list_containers`) — the Firecracker analogue is
+/// a synchronous `/proc` scan.
+static DOCKER_WARM: tokio::sync::OnceCell<Arc<DockerWarmServing>> =
+    tokio::sync::OnceCell::const_new();
+
+/// Try to serve a Docker create from the warm pool.
+///
+/// MUST only be called from the Docker create arm, which the runtime dispatches
+/// AFTER `admit_sandbox_resources` (count cap + host memory budget, under the
+/// creation permit). That is what makes a warm claim count against
+/// `SANDBOX_MAX_COUNT` / the host budget exactly like a cold boot — pool
+/// inventory itself is never admission-accounted (its standing RAM is reserved
+/// via [`reserved_host_memory_mb`]).
+///
+/// A hard configuration error (unparseable pool size, or the pool enabled with
+/// no memory value) propagates — it must fail the create loudly, never silently
+/// fall through to cold.
+pub(crate) async fn claim_docker_warm(
+    request: &CreateSandboxParams,
+    sandbox_id: &str,
+) -> Result<DockerWarmOutcome> {
+    let settings = match load_settings()? {
+        Some(s) => s,
+        None => return Ok(DockerWarmOutcome::Miss(DockerWarmMiss::Disabled)),
+    };
+
+    let serving = DOCKER_WARM
+        .get_or_init(|| async move {
+            // Reap warm containers orphaned by a previous operator process
+            // BEFORE the first seed (mirrors firecracker/warm.rs). Best-effort:
+            // a Docker/reconcile failure is logged, never blocks pool init.
+            match crate::runtime::docker_builder().await {
+                Ok(builder) => reconcile_docker_warm_orphans(&builder).await,
+                Err(err) => tracing::warn!(
+                    %err,
+                    "docker warm-pool: startup reconcile skipped (Docker connect failed)"
+                ),
+            }
+            Arc::new(DockerWarmServing::new(
+                Arc::new(BollardDockerWarmHost),
+                settings,
+            ))
+        })
+        .await;
+
+    serving.ensure_seeding();
+
+    let config = SidecarRuntimeConfig::load();
+    let effective_image = if request.image.trim().is_empty() {
+        config.image.clone()
+    } else {
+        request.image.clone()
+    };
+    let claim_req = DockerWarmClaimRequest {
+        sandbox_id: sandbox_id.to_string(),
+        image: effective_image,
+        cpu_cores: request.cpu_cores,
+        memory_mb: request.memory_mb,
+        ssh_enabled: request.ssh_enabled,
+        env_json: request.env_json.clone(),
+        user_env_json: request.user_env_json.clone(),
+        capabilities_json: request.capabilities_json.clone(),
+        extra_ports_len: crate::runtime::parse_extra_ports(
+            &request.metadata_json,
+            &request.port_mappings,
+        )
+        .len(),
+    };
+    Ok(serving.claim(&claim_req).await)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Production host — real bollard I/O
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The production [`DockerWarmHost`]: fresh Docker client per operation (never
+/// cached process-wide, matching `docker_builder`'s stale-socket rationale).
+pub(crate) struct BollardDockerWarmHost;
+
+#[async_trait]
+impl DockerWarmHost for BollardDockerWarmHost {
+    async fn seed_container(&self, spec: &WarmSeedSpec) -> Result<String> {
+        let config = SidecarRuntimeConfig::load();
+        let builder = crate::runtime::docker_builder().await?;
+
+        // Env baked identically to the cold path (build_env_vars), carrying the
+        // warm token — a random operator↔sidecar secret copied verbatim into
+        // the store record at claim, so no post-create mutation is needed.
+        let env_vars = crate::runtime::build_env_vars(
+            &spec.base_env_json,
+            &spec.token,
+            config.container_port,
+            &spec.capabilities_json,
+        )?;
+
+        let mut labels = std::collections::HashMap::new();
+        labels.insert(WARM_POOL_LABEL.to_string(), "1".to_string());
+        labels.insert(WARM_IMAGE_LABEL.to_string(), spec.image.clone());
+        labels.insert(WARM_SEQ_LABEL.to_string(), spec.seq.to_string());
+
+        // SSH disabled + no extra ports = the warm default shape.
+        let override_config = crate::runtime::build_docker_config(
+            config,
+            false,
+            spec.cpu_cores,
+            spec.memory_mb,
+            Some(labels),
+            &[],
+        );
+
+        let mut container = Container::new(builder.client(), spec.image.clone())
+            .with_name(spec.name.clone())
+            .env(env_vars)
+            .config_override(override_config);
+
+        // Create + start — the ~700ms + ~200ms pre-paid off the request path.
+        if let Err(err) =
+            crate::runtime::docker_timeout("warm_create_container", container.create()).await
+        {
+            tracing::debug!(error = %err, "warm container create failed; start path will retry it");
+        }
+        crate::runtime::start_container_with_retry(&mut container).await?;
+
+        let container_id = container
+            .id()
+            .ok_or_else(|| SandboxError::Docker("warm container missing id after start".into()))?
+            .to_string();
+
+        // On any post-start failure, reap the half-seeded container so it does
+        // not leak (it is not yet in the ready pool).
+        let seeded = async {
+            // Pre-pay the workspace bootstrap exec (chown + mkdir .opencode-home).
+            crate::runtime::run_workspace_bootstrap(&builder.client(), &container_id, &spec.name)
+                .await;
+
+            // Prove the pooled sidecar is live before it can ever be claimed.
+            let (sidecar_url, _port, _ssh, _extra) =
+                crate::runtime::refresh_port_mapping_with_retry(
+                    "warm seed endpoint",
+                    builder.client(),
+                    &container_id,
+                    config.container_port,
+                    false,
+                    &config.public_host,
+                    &std::collections::HashMap::new(),
+                )
+                .await?;
+            if !crate::runtime::wait_for_sidecar_health(&sidecar_url, WARM_SEED_HEALTH_TIMEOUT_SECS)
+                .await
+            {
+                return Err(SandboxError::Unavailable(format!(
+                    "warm container {container_id} sidecar at {sidecar_url} never became healthy"
+                )));
+            }
+            Ok(())
+        }
+        .await;
+
+        if let Err(err) = seeded {
+            self.reap_container(&container_id).await;
+            return Err(err);
+        }
+        Ok(container_id)
+    }
+
+    async fn claim_container(
+        &self,
+        container_id: &str,
+        sandbox_id: &str,
+    ) -> std::result::Result<ClaimResolved, ClaimFailure> {
+        let config = SidecarRuntimeConfig::load();
+        let builder = crate::runtime::docker_builder()
+            .await
+            .map_err(|e| ClaimFailure::Rename(e.to_string()))?;
+
+        // Rename by id (stable, unambiguous) onto the real sandbox id. No
+        // recreate — the container keeps its baked env, token, and host ports.
+        let new_name = format!("sidecar-{sandbox_id}");
+        crate::runtime::docker_timeout(
+            "warm_rename_container",
+            builder.client().rename_container(
+                container_id,
+                RenameContainerOptions {
+                    name: new_name.clone(),
+                },
+            ),
+        )
+        .await
+        .map_err(|e| ClaimFailure::Rename(e.to_string()))?;
+
+        // Read back the already-assigned host ports (container is already
+        // started, so this resolves immediately — no start latency).
+        let (sidecar_url, sidecar_port, ssh_port, extra_ports) =
+            crate::runtime::refresh_port_mapping_with_retry(
+                "warm claim endpoint",
+                builder.client(),
+                container_id,
+                config.container_port,
+                false,
+                &config.public_host,
+                &std::collections::HashMap::new(),
+            )
+            .await
+            .map_err(|e| ClaimFailure::PortResolve(e.to_string()))?;
+
+        // A container idle for minutes could have a dead sidecar behind a live
+        // process; prove it before handing it out.
+        if !crate::runtime::wait_for_sidecar_health(&sidecar_url, WARM_CLAIM_HEALTH_TIMEOUT_SECS)
+            .await
+        {
+            return Err(ClaimFailure::Unhealthy(format!(
+                "sidecar at {sidecar_url} not healthy within {WARM_CLAIM_HEALTH_TIMEOUT_SECS}s"
+            )));
+        }
+
+        Ok(ClaimResolved {
+            sidecar_url,
+            sidecar_port,
+            ssh_port,
+            extra_ports,
+        })
+    }
+
+    async fn reap_container(&self, container_id: &str) {
+        match crate::runtime::docker_builder().await {
+            Ok(builder) => {
+                if let Ok(c) = Container::from_id(builder.client(), container_id).await {
+                    let _ = c
+                        .remove(Some(RemoveContainerOptions {
+                            force: true,
+                            ..Default::default()
+                        }))
+                        .await;
+                }
+            }
+            Err(err) => tracing::warn!(
+                container_id,
+                %err,
+                "docker warm-pool reap: Docker connect failed"
+            ),
+        }
+    }
+}

--- a/sandbox-runtime/src/docker_warm/serving.rs
+++ b/sandbox-runtime/src/docker_warm/serving.rs
@@ -23,6 +23,13 @@ pub(crate) const WARM_POOL_LABEL: &str = "tangle.warm-pool";
 pub(crate) const WARM_IMAGE_LABEL: &str = "tangle.warm-image";
 pub(crate) const WARM_SEQ_LABEL: &str = "tangle.warm-seq";
 
+/// Container-name prefix for an UNCLAIMED warm entry (`sidecar-warm-<seq>`). A
+/// claim renames the container to `sidecar-<sandbox_id>`, so this prefix is the
+/// structural signal that a container is still pooled and never handed to a
+/// customer — the reconcile guard uses it so a claimed live sandbox can never
+/// be a reap candidate even if the store is unreadable (see [`reconcile`]).
+pub(crate) const WARM_NAME_PREFIX: &str = "sidecar-warm-";
+
 /// Never seed more than this many containers concurrently, so a cold-start
 /// burst does not create the entire pool at once (each seed is a ~700ms Docker
 /// create + a `memory_mb` RAM spike). The pool still fills across subsequent
@@ -103,6 +110,7 @@ impl DockerWarmServing {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn ready_count(&self) -> usize {
         lock_ready(&self.ready).len()
     }
@@ -125,8 +133,16 @@ impl DockerWarmServing {
     pub(crate) fn ensure_seeding(self: &Arc<Self>) {
         self.evict_over_age();
         loop {
-            let ready = self.ready_count();
-            let in_flight = self.seeds_in_flight.load(Ordering::SeqCst);
+            // Sample `ready` and `in_flight` TOGETHER under the ready lock. The
+            // seed-completion path below publishes the container and clears its
+            // in-flight slot inside this same lock, so a completing seed is
+            // always visible in exactly one of the two counts — never neither
+            // (which would let a concurrent create over-seed past pool_size and
+            // exceed the up-front memory reservation) and never both.
+            let (ready, in_flight) = {
+                let guard = lock_ready(&self.ready);
+                (guard.len(), self.seeds_in_flight.load(Ordering::SeqCst))
+            };
             if ready + in_flight >= self.settings.pool_size {
                 return;
             }
@@ -145,22 +161,33 @@ impl DockerWarmServing {
             }
             let this = Arc::clone(self);
             tokio::spawn(async move {
-                let outcome = this.seed_one().await;
-                this.seeds_in_flight.fetch_sub(1, Ordering::SeqCst);
-                if let Err(err) = outcome {
-                    this.counters.seed_failures.fetch_add(1, Ordering::Relaxed);
-                    tracing::error!(%err, "docker warm-pool container seed failed");
+                match this.seed_one().await {
+                    Ok(container) => {
+                        // Publish the container and release the in-flight slot as
+                        // ONE critical section (the fetch_sub is a non-blocking
+                        // atomic, so no await is held under the lock). This makes
+                        // the (push, decrement) pair atomic against
+                        // `ensure_seeding`'s paired read above.
+                        let mut guard = lock_ready(&this.ready);
+                        guard.push(container);
+                        this.seeds_in_flight.fetch_sub(1, Ordering::SeqCst);
+                    }
+                    Err(err) => {
+                        this.seeds_in_flight.fetch_sub(1, Ordering::SeqCst);
+                        this.counters.seed_failures.fetch_add(1, Ordering::Relaxed);
+                        tracing::error!(%err, "docker warm-pool container seed failed");
+                    }
                 }
             });
         }
     }
 
-    async fn seed_one(&self) -> Result<()> {
+    async fn seed_one(&self) -> Result<WarmContainer> {
         let seq = self.seq.fetch_add(1, Ordering::SeqCst);
         let token = crate::auth::generate_token();
         let spec = WarmSeedSpec {
             seq,
-            name: format!("sidecar-warm-{seq}"),
+            name: format!("{WARM_NAME_PREFIX}{seq}"),
             token: token.clone(),
             image: self.settings.image.clone(),
             cpu_cores: self.settings.cpu_cores,
@@ -169,17 +196,16 @@ impl DockerWarmServing {
             capabilities_json: self.settings.capabilities_json.clone(),
         };
         let container_id = self.host.seed_container(&spec).await?;
-        lock_ready(&self.ready).push(WarmContainer {
-            container_id,
-            token,
-            seq,
-            created_at: crate::util::now_ts(),
-        });
         tracing::info!(
             warm_seq = seq,
             "docker warm-pool container seeded and ready"
         );
-        Ok(())
+        Ok(WarmContainer {
+            container_id,
+            token,
+            seq,
+            created_at: crate::util::now_ts(),
+        })
     }
 
     /// Reap pooled containers older than the configured max age, then let

--- a/sandbox-runtime/src/docker_warm/serving.rs
+++ b/sandbox-runtime/src/docker_warm/serving.rs
@@ -1,5 +1,5 @@
 //! The warm-serving engine: seed / refill / claim / evict, plus the
-//! process-wide handle and the production Docker host.
+//! process-wide handle. The production Docker host lives in [`super::host`].
 //!
 //! Structure mirrors [`crate::firecracker_warm::serving`]:
 //!
@@ -16,9 +16,10 @@
 use super::*;
 
 /// Docker container labels stamped at seed. `tangle.warm-pool` is the reconcile
-/// filter; the other two are provenance/observability. Labels are create-time
-/// immutable, so a claimed container keeps them — the reconcile guard keys on
-/// "warm label AND no matching store record", which is why that is safe.
+/// listing filter; the other two are provenance/observability. Labels are
+/// create-time immutable, so a claimed container keeps them — which is why the
+/// reconcile reap decision keys on the container NAME (`sidecar-warm-` prefix, a
+/// claim renames it away), not the label alone (see [`reconcile`]).
 pub(crate) const WARM_POOL_LABEL: &str = "tangle.warm-pool";
 pub(crate) const WARM_IMAGE_LABEL: &str = "tangle.warm-image";
 pub(crate) const WARM_SEQ_LABEL: &str = "tangle.warm-seq";
@@ -36,14 +37,6 @@ pub(crate) const WARM_NAME_PREFIX: &str = "sidecar-warm-";
 /// creates; the total in-flight can never exceed `pool_size` (the
 /// `seeds_in_flight` compare-exchange guarantees that separately).
 const MAX_CONCURRENT_SEEDS: usize = 2;
-
-/// Health-wait budget while seeding a warm container (background, off the
-/// request path).
-const WARM_SEED_HEALTH_TIMEOUT_SECS: u64 = 60;
-
-/// Health probe budget at claim. Short: the container was proven healthy at
-/// seed, so a failure here means it died while idle — fail fast to cold.
-const WARM_CLAIM_HEALTH_TIMEOUT_SECS: u64 = 5;
 
 /// Everything a host needs to seed one warm container.
 #[derive(Debug, Clone)]
@@ -448,177 +441,4 @@ pub(crate) async fn claim_docker_warm(
         .len(),
     };
     Ok(serving.claim(&claim_req).await)
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Production host — real bollard I/O
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// The production [`DockerWarmHost`]: fresh Docker client per operation (never
-/// cached process-wide, matching `docker_builder`'s stale-socket rationale).
-pub(crate) struct BollardDockerWarmHost;
-
-#[async_trait]
-impl DockerWarmHost for BollardDockerWarmHost {
-    async fn seed_container(&self, spec: &WarmSeedSpec) -> Result<String> {
-        let config = SidecarRuntimeConfig::load();
-        let builder = crate::runtime::docker_builder().await?;
-
-        // Env baked identically to the cold path (build_env_vars), carrying the
-        // warm token — a random operator↔sidecar secret copied verbatim into
-        // the store record at claim, so no post-create mutation is needed.
-        let env_vars = crate::runtime::build_env_vars(
-            &spec.base_env_json,
-            &spec.token,
-            config.container_port,
-            &spec.capabilities_json,
-        )?;
-
-        let mut labels = std::collections::HashMap::new();
-        labels.insert(WARM_POOL_LABEL.to_string(), "1".to_string());
-        labels.insert(WARM_IMAGE_LABEL.to_string(), spec.image.clone());
-        labels.insert(WARM_SEQ_LABEL.to_string(), spec.seq.to_string());
-
-        // SSH disabled + no extra ports = the warm default shape.
-        let override_config = crate::runtime::build_docker_config(
-            config,
-            false,
-            spec.cpu_cores,
-            spec.memory_mb,
-            Some(labels),
-            &[],
-        );
-
-        let mut container = Container::new(builder.client(), spec.image.clone())
-            .with_name(spec.name.clone())
-            .env(env_vars)
-            .config_override(override_config);
-
-        // Create + start — the ~700ms + ~200ms pre-paid off the request path.
-        if let Err(err) =
-            crate::runtime::docker_timeout("warm_create_container", container.create()).await
-        {
-            tracing::debug!(error = %err, "warm container create failed; start path will retry it");
-        }
-        crate::runtime::start_container_with_retry(&mut container).await?;
-
-        let container_id = container
-            .id()
-            .ok_or_else(|| SandboxError::Docker("warm container missing id after start".into()))?
-            .to_string();
-
-        // On any post-start failure, reap the half-seeded container so it does
-        // not leak (it is not yet in the ready pool).
-        let seeded = async {
-            // Pre-pay the workspace bootstrap exec (chown + mkdir .opencode-home).
-            crate::runtime::run_workspace_bootstrap(&builder.client(), &container_id, &spec.name)
-                .await;
-
-            // Prove the pooled sidecar is live before it can ever be claimed.
-            let (sidecar_url, _port, _ssh, _extra) =
-                crate::runtime::refresh_port_mapping_with_retry(
-                    "warm seed endpoint",
-                    builder.client(),
-                    &container_id,
-                    config.container_port,
-                    false,
-                    &config.public_host,
-                    &std::collections::HashMap::new(),
-                )
-                .await?;
-            if !crate::runtime::wait_for_sidecar_health(&sidecar_url, WARM_SEED_HEALTH_TIMEOUT_SECS)
-                .await
-            {
-                return Err(SandboxError::Unavailable(format!(
-                    "warm container {container_id} sidecar at {sidecar_url} never became healthy"
-                )));
-            }
-            Ok(())
-        }
-        .await;
-
-        if let Err(err) = seeded {
-            self.reap_container(&container_id).await;
-            return Err(err);
-        }
-        Ok(container_id)
-    }
-
-    async fn claim_container(
-        &self,
-        container_id: &str,
-        sandbox_id: &str,
-    ) -> std::result::Result<ClaimResolved, ClaimFailure> {
-        let config = SidecarRuntimeConfig::load();
-        let builder = crate::runtime::docker_builder()
-            .await
-            .map_err(|e| ClaimFailure::Rename(e.to_string()))?;
-
-        // Rename by id (stable, unambiguous) onto the real sandbox id. No
-        // recreate — the container keeps its baked env, token, and host ports.
-        let new_name = format!("sidecar-{sandbox_id}");
-        crate::runtime::docker_timeout(
-            "warm_rename_container",
-            builder.client().rename_container(
-                container_id,
-                RenameContainerOptions {
-                    name: new_name.clone(),
-                },
-            ),
-        )
-        .await
-        .map_err(|e| ClaimFailure::Rename(e.to_string()))?;
-
-        // Read back the already-assigned host ports (container is already
-        // started, so this resolves immediately — no start latency).
-        let (sidecar_url, sidecar_port, ssh_port, extra_ports) =
-            crate::runtime::refresh_port_mapping_with_retry(
-                "warm claim endpoint",
-                builder.client(),
-                container_id,
-                config.container_port,
-                false,
-                &config.public_host,
-                &std::collections::HashMap::new(),
-            )
-            .await
-            .map_err(|e| ClaimFailure::PortResolve(e.to_string()))?;
-
-        // A container idle for minutes could have a dead sidecar behind a live
-        // process; prove it before handing it out.
-        if !crate::runtime::wait_for_sidecar_health(&sidecar_url, WARM_CLAIM_HEALTH_TIMEOUT_SECS)
-            .await
-        {
-            return Err(ClaimFailure::Unhealthy(format!(
-                "sidecar at {sidecar_url} not healthy within {WARM_CLAIM_HEALTH_TIMEOUT_SECS}s"
-            )));
-        }
-
-        Ok(ClaimResolved {
-            sidecar_url,
-            sidecar_port,
-            ssh_port,
-            extra_ports,
-        })
-    }
-
-    async fn reap_container(&self, container_id: &str) {
-        match crate::runtime::docker_builder().await {
-            Ok(builder) => {
-                if let Ok(c) = Container::from_id(builder.client(), container_id).await {
-                    let _ = c
-                        .remove(Some(RemoveContainerOptions {
-                            force: true,
-                            ..Default::default()
-                        }))
-                        .await;
-                }
-            }
-            Err(err) => tracing::warn!(
-                container_id,
-                %err,
-                "docker warm-pool reap: Docker connect failed"
-            ),
-        }
-    }
 }

--- a/sandbox-runtime/src/docker_warm/tests.rs
+++ b/sandbox-runtime/src/docker_warm/tests.rs
@@ -367,39 +367,54 @@ async fn claim_failure_reaps_and_misses() {
 // Restart reconcile — the reap decision (data-loss guard)
 // ─────────────────────────────────────────────────────────────────────────────
 
-#[test]
-fn reconcile_reaps_orphans_and_leaves_claimed() {
-    let listings = vec![
-        WarmContainerListing {
-            id: "orphan-1".into(),
-        },
-        WarmContainerListing {
-            id: "claimed".into(),
-        }, // has a live store record
-        WarmContainerListing {
-            id: "orphan-2".into(),
-        },
-    ];
-    // "claimed" is a live sandbox: its id is a store record's container_id.
-    let live: HashSet<String> = ["claimed".to_string()].into_iter().collect();
+/// Helper: a warm-labelled listing with an explicit name.
+fn listing(id: &str, name: &str) -> WarmContainerListing {
+    WarmContainerListing {
+        id: id.into(),
+        name: name.into(),
+    }
+}
 
-    let mut reap = containers_to_reap(&listings, &live);
+#[test]
+fn reconcile_reaps_name_prefixed_orphans_and_leaves_claimed() {
+    let listings = vec![
+        listing("orphan-1", "sidecar-warm-1"), // never claimed
+        listing("claimed", "sidecar-abc-123"), // renamed by a claim → not reaped
+        listing("orphan-2", "sidecar-warm-2"),
+    ];
+    let mut reap = containers_to_reap(&listings);
     reap.sort();
     assert_eq!(
         reap,
         vec!["orphan-1".to_string(), "orphan-2".to_string()],
-        "orphans reaped, the claimed live sandbox left untouched"
+        "name-prefixed orphans reaped, the renamed (claimed) container left untouched"
     );
 }
 
 #[test]
-fn reconcile_leaves_everything_when_all_are_live() {
+fn reconcile_leaves_everything_when_none_are_name_prefixed() {
+    // All renamed (claimed) — none carry the `sidecar-warm-` prefix.
+    let listings = vec![listing("a", "sidecar-alpha"), listing("b", "sidecar-beta")];
+    assert!(containers_to_reap(&listings).is_empty());
+}
+
+/// The data-loss guard is purely structural: a claimed container (renamed to
+/// `sidecar-<id>`) is NEVER reaped, no matter the store state. This covers the
+/// catastrophic path — startup after a crash with a corrupt/unreadable
+/// `sandboxes.json` (which loads as an empty map, not an error) — that an
+/// id-in-store guard would have gotten wrong by reaping the live sandbox.
+#[test]
+fn reconcile_never_reaps_renamed_container_regardless_of_store() {
     let listings = vec![
-        WarmContainerListing { id: "a".into() },
-        WarmContainerListing { id: "b".into() },
+        listing("orphan", "sidecar-warm-7"), // pooled, safe to reap by name
+        listing("live-customer", "sidecar-xyz-999"), // a running claimed sandbox
     ];
-    let live: HashSet<String> = ["a".to_string(), "b".to_string()].into_iter().collect();
-    assert!(containers_to_reap(&listings, &live).is_empty());
+    let reap = containers_to_reap(&listings);
+    assert_eq!(
+        reap,
+        vec!["orphan".to_string()],
+        "reap only the name-prefixed orphan; the renamed live sandbox is never a candidate"
+    );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/sandbox-runtime/src/docker_warm/tests.rs
+++ b/sandbox-runtime/src/docker_warm/tests.rs
@@ -1,0 +1,556 @@
+//! Unit + engine tests for the Docker warm pool. All run without Docker: the
+//! engine is driven by an in-memory [`FakeDockerWarmHost`], config parsing is
+//! exercised under the process-wide env guard, and the reap decision + shape
+//! gate are pure. The real-Docker warm-hit is proven by the env-gated
+//! `tests/lifecycle_bench.rs`.
+
+use super::*;
+use std::collections::{HashMap, HashSet};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn test_settings(pool_size: usize) -> DockerWarmSettings {
+    DockerWarmSettings {
+        pool_size,
+        image: "test:latest".to_string(),
+        cpu_cores: 2,
+        memory_mb: 2048,
+        base_env_json: String::new(),
+        capabilities_json: String::new(),
+        entry_max_age: Duration::from_secs(3600),
+    }
+}
+
+/// A request that matches [`test_settings`]'s pooled shape.
+fn matching_req() -> DockerWarmClaimRequest {
+    DockerWarmClaimRequest {
+        sandbox_id: "sb-test".to_string(),
+        image: "test:latest".to_string(),
+        cpu_cores: 0,
+        memory_mb: 0,
+        ssh_enabled: false,
+        env_json: String::new(),
+        user_env_json: String::new(),
+        capabilities_json: String::new(),
+        extra_ports_len: 0,
+    }
+}
+
+/// In-memory host: seeds return synthetic ids, claims resolve a dummy endpoint,
+/// reaps are recorded. `fail_claim` drives the reap-on-claim-failure path.
+#[derive(Default)]
+struct FakeDockerWarmHost {
+    seeded_ids: Mutex<Vec<String>>,
+    claimed_ids: Mutex<Vec<String>>,
+    reaped_ids: Mutex<Vec<String>>,
+    fail_claim: bool,
+}
+
+#[async_trait]
+impl DockerWarmHost for FakeDockerWarmHost {
+    async fn seed_container(&self, spec: &WarmSeedSpec) -> Result<String> {
+        let id = format!("fake-container-{}", spec.seq);
+        self.seeded_ids.lock().unwrap().push(id.clone());
+        Ok(id)
+    }
+
+    async fn claim_container(
+        &self,
+        container_id: &str,
+        sandbox_id: &str,
+    ) -> std::result::Result<ClaimResolved, ClaimFailure> {
+        if self.fail_claim {
+            return Err(ClaimFailure::Unhealthy(
+                "injected claim failure".to_string(),
+            ));
+        }
+        self.claimed_ids
+            .lock()
+            .unwrap()
+            .push(container_id.to_string());
+        Ok(ClaimResolved {
+            sidecar_url: format!("http://127.0.0.1:0/{sandbox_id}"),
+            sidecar_port: 8080,
+            ssh_port: None,
+            extra_ports: HashMap::new(),
+        })
+    }
+
+    async fn reap_container(&self, container_id: &str) {
+        self.reaped_ids
+            .lock()
+            .unwrap()
+            .push(container_id.to_string());
+    }
+}
+
+/// Drive `ensure_seeding` (called per-create in production) until the pool
+/// reaches `target`, matching how the pool fills across successive creates.
+async fn fill_pool(serving: &Arc<DockerWarmServing>, target: usize) -> bool {
+    for _ in 0..400 {
+        serving.ensure_seeding();
+        if serving.ready_count() >= target {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(2)).await;
+    }
+    serving.ready_count() >= target
+}
+
+fn engine(host: Arc<FakeDockerWarmHost>, pool_size: usize) -> Arc<DockerWarmServing> {
+    Arc::new(DockerWarmServing::new(host, test_settings(pool_size)))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shape gate
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn gate(req: DockerWarmClaimRequest) -> Option<DockerWarmMiss> {
+    let serving = engine(Arc::new(FakeDockerWarmHost::default()), 1);
+    serving.shape_gate(&req)
+}
+
+#[test]
+fn shape_gate_accepts_default_shape() {
+    assert!(gate(matching_req()).is_none());
+}
+
+#[test]
+fn shape_gate_accepts_empty_object_base_env() {
+    // "" and "{}" both normalize to an empty object → match.
+    let mut req = matching_req();
+    req.env_json = "{}".to_string();
+    assert!(gate(req).is_none());
+}
+
+#[test]
+fn shape_gate_accepts_exact_cpu_and_memory() {
+    let mut req = matching_req();
+    req.cpu_cores = 2; // == pooled
+    req.memory_mb = 2048; // == pooled
+    assert!(gate(req).is_none());
+}
+
+#[test]
+fn shape_gate_rejects_image_mismatch() {
+    let mut req = matching_req();
+    req.image = "other:latest".to_string();
+    assert!(matches!(
+        gate(req),
+        Some(DockerWarmMiss::ImageMismatch { .. })
+    ));
+}
+
+#[test]
+fn shape_gate_rejects_ssh() {
+    let mut req = matching_req();
+    req.ssh_enabled = true;
+    assert!(matches!(gate(req), Some(DockerWarmMiss::SshRequested)));
+}
+
+#[test]
+fn shape_gate_rejects_user_env() {
+    let mut req = matching_req();
+    req.user_env_json = r#"{"SECRET":"x"}"#.to_string();
+    assert!(matches!(gate(req), Some(DockerWarmMiss::UserEnvPresent)));
+}
+
+#[test]
+fn shape_gate_rejects_extra_ports() {
+    let mut req = matching_req();
+    req.extra_ports_len = 1;
+    assert!(matches!(
+        gate(req),
+        Some(DockerWarmMiss::ExtraPortsRequested)
+    ));
+}
+
+#[test]
+fn shape_gate_rejects_cpu_mismatch() {
+    let mut req = matching_req();
+    req.cpu_cores = 8; // pooled is 2
+    assert!(matches!(
+        gate(req),
+        Some(DockerWarmMiss::CpuMismatch { .. })
+    ));
+}
+
+#[test]
+fn shape_gate_rejects_memory_mismatch() {
+    let mut req = matching_req();
+    req.memory_mb = 4096; // pooled is 2048
+    assert!(matches!(
+        gate(req),
+        Some(DockerWarmMiss::MemoryMismatch { .. })
+    ));
+}
+
+#[test]
+fn shape_gate_rejects_base_env_mismatch() {
+    let mut req = matching_req();
+    req.env_json = r#"{"A":"1"}"#.to_string(); // pooled base is empty
+    assert!(matches!(gate(req), Some(DockerWarmMiss::BaseEnvMismatch)));
+}
+
+#[test]
+fn shape_gate_rejects_capabilities_mismatch() {
+    let mut req = matching_req();
+    req.capabilities_json = r#"["computer_use"]"#.to_string(); // pooled has none
+    assert!(matches!(
+        gate(req),
+        Some(DockerWarmMiss::CapabilitiesMismatch)
+    ));
+}
+
+#[test]
+fn every_miss_variant_has_a_distinct_display() {
+    // Guards against a Display arm silently sharing another's text.
+    let variants = [
+        DockerWarmMiss::Disabled,
+        DockerWarmMiss::NotReady,
+        DockerWarmMiss::Empty,
+        DockerWarmMiss::ImageMismatch {
+            requested: "a".into(),
+            pooled: "b".into(),
+        },
+        DockerWarmMiss::CpuMismatch {
+            requested: 1,
+            pooled: 2,
+        },
+        DockerWarmMiss::MemoryMismatch {
+            requested: 1,
+            pooled: 2,
+        },
+        DockerWarmMiss::SshRequested,
+        DockerWarmMiss::UserEnvPresent,
+        DockerWarmMiss::BaseEnvMismatch,
+        DockerWarmMiss::CapabilitiesMismatch,
+        DockerWarmMiss::ExtraPortsRequested,
+        DockerWarmMiss::RenameFailed("e".into()),
+        DockerWarmMiss::PortResolveFailed("e".into()),
+        DockerWarmMiss::Unhealthy("e".into()),
+    ];
+    let rendered: HashSet<String> = variants.iter().map(|m| m.to_string()).collect();
+    assert_eq!(
+        rendered.len(),
+        variants.len(),
+        "Display strings must be distinct"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Concurrency / claim race — the pop-before-await atomicity guarantee
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_claims_never_double_serve() {
+    let pool_size = 3;
+    let fake = Arc::new(FakeDockerWarmHost::default());
+    let serving = engine(fake.clone(), pool_size);
+
+    assert!(
+        fill_pool(&serving, pool_size).await,
+        "pool never filled to {pool_size}"
+    );
+    // Never over-seeds past pool_size (the seeds_in_flight compare-exchange).
+    assert_eq!(serving.ready_count(), pool_size);
+    assert_eq!(fake.seeded_ids.lock().unwrap().len(), pool_size);
+    assert_eq!(serving.seeds_in_flight(), 0);
+
+    // Fire M > N concurrent claims.
+    let m = 8usize;
+    let mut handles = Vec::new();
+    for i in 0..m {
+        let s = Arc::clone(&serving);
+        handles.push(tokio::spawn(async move {
+            let mut req = matching_req();
+            req.sandbox_id = format!("sb-{i}");
+            s.claim(&req).await
+        }));
+    }
+
+    let mut claimed_ids = Vec::new();
+    let mut misses = 0usize;
+    for h in handles {
+        match h.await.unwrap() {
+            DockerWarmOutcome::Claimed(c) => claimed_ids.push(c.container_id),
+            DockerWarmOutcome::Miss(_) => misses += 1,
+        }
+    }
+
+    assert_eq!(claimed_ids.len(), pool_size, "exactly pool_size claims win");
+    assert_eq!(misses, m - pool_size, "the rest miss");
+    let unique: HashSet<_> = claimed_ids.iter().cloned().collect();
+    assert_eq!(
+        unique.len(),
+        claimed_ids.len(),
+        "no container id was handed to two claims"
+    );
+    assert_eq!(
+        fake.claimed_ids.lock().unwrap().len(),
+        pool_size,
+        "host saw exactly pool_size claim_container calls"
+    );
+    assert_eq!(serving.ready_count(), 0, "pool drained");
+    assert_eq!(serving.claims(), pool_size as u64);
+}
+
+#[tokio::test]
+async fn claim_reuses_the_seeded_container_id() {
+    let fake = Arc::new(FakeDockerWarmHost::default());
+    let serving = engine(fake.clone(), 1);
+    assert!(fill_pool(&serving, 1).await);
+    let seeded = fake.seeded_ids.lock().unwrap().clone();
+    assert_eq!(seeded.len(), 1);
+
+    let out = serving.claim(&matching_req()).await;
+    match out {
+        DockerWarmOutcome::Claimed(claim) => {
+            // The claim reuses the seeded container (rename, not recreate).
+            assert_eq!(claim.container_id, seeded[0]);
+            // The baked token flows through unchanged (it is inside the
+            // container's immutable env; a fresh token would not authenticate).
+            assert!(!claim.token.is_empty());
+        }
+        DockerWarmOutcome::Miss(m) => panic!("expected a claim, got miss: {m}"),
+    }
+    assert_eq!(
+        fake.claimed_ids.lock().unwrap().as_slice(),
+        &[seeded[0].clone()]
+    );
+}
+
+#[tokio::test]
+async fn empty_pool_misses_without_touching_host() {
+    let fake = Arc::new(FakeDockerWarmHost::default());
+    // pool_size 0 would be Disabled at a higher layer; here we exercise the
+    // engine directly with a non-zero size but an unfilled pool.
+    let serving = engine(fake.clone(), 1);
+    let out = serving.claim(&matching_req()).await;
+    // Nothing ready and (in this direct test) nothing seeding yet.
+    assert!(matches!(
+        out,
+        DockerWarmOutcome::Miss(DockerWarmMiss::Empty | DockerWarmMiss::NotReady)
+    ));
+    assert!(fake.claimed_ids.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn claim_failure_reaps_and_misses() {
+    let fake = Arc::new(FakeDockerWarmHost {
+        fail_claim: true,
+        ..Default::default()
+    });
+    let serving = engine(fake.clone(), 1);
+    assert!(fill_pool(&serving, 1).await);
+
+    let out = serving.claim(&matching_req()).await;
+    assert!(
+        matches!(out, DockerWarmOutcome::Miss(DockerWarmMiss::Unhealthy(_))),
+        "a downstream claim failure maps to a typed miss"
+    );
+    assert_eq!(
+        fake.reaped_ids.lock().unwrap().len(),
+        1,
+        "the popped-but-failed container is reaped, not returned to the pool"
+    );
+    assert_eq!(
+        serving.ready_count(),
+        0,
+        "the container was popped, not left"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Restart reconcile — the reap decision (data-loss guard)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn reconcile_reaps_orphans_and_leaves_claimed() {
+    let listings = vec![
+        WarmContainerListing {
+            id: "orphan-1".into(),
+        },
+        WarmContainerListing {
+            id: "claimed".into(),
+        }, // has a live store record
+        WarmContainerListing {
+            id: "orphan-2".into(),
+        },
+    ];
+    // "claimed" is a live sandbox: its id is a store record's container_id.
+    let live: HashSet<String> = ["claimed".to_string()].into_iter().collect();
+
+    let mut reap = containers_to_reap(&listings, &live);
+    reap.sort();
+    assert_eq!(
+        reap,
+        vec!["orphan-1".to_string(), "orphan-2".to_string()],
+        "orphans reaped, the claimed live sandbox left untouched"
+    );
+}
+
+#[test]
+fn reconcile_leaves_everything_when_all_are_live() {
+    let listings = vec![
+        WarmContainerListing { id: "a".into() },
+        WarmContainerListing { id: "b".into() },
+    ];
+    let live: HashSet<String> = ["a".to_string(), "b".to_string()].into_iter().collect();
+    assert!(containers_to_reap(&listings, &live).is_empty());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config parsing + host-memory reservation (env-guarded)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Run `body` with the given warm-pool env applied under the process-wide env
+/// guard, then restore. The config helpers read env live (no caching), so this
+/// is race-free as long as every env-mutating test holds `TEST_ENV_GUARD`.
+fn with_env<F: FnOnce()>(vars: &[(&str, Option<&str>)], body: F) {
+    let _guard = crate::TEST_ENV_GUARD
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let keys = [
+        "SANDBOX_DOCKER_WARM_POOL_SIZE",
+        "SANDBOX_DOCKER_WARM_MEMORY_MB",
+        "SANDBOX_DOCKER_WARM_CPU_CORES",
+        "SANDBOX_DOCKER_WARM_MAX_AGE_SECS",
+    ];
+    // SAFETY: env mutation is serialized by TEST_ENV_GUARD; the config helpers
+    // read env synchronously within `body` while the guard is held.
+    unsafe {
+        for k in keys {
+            std::env::remove_var(k);
+        }
+        for (k, v) in vars {
+            match v {
+                Some(val) => std::env::set_var(k, val),
+                None => std::env::remove_var(k),
+            }
+        }
+    }
+    body();
+    unsafe {
+        for k in keys {
+            std::env::remove_var(k);
+        }
+    }
+}
+
+#[test]
+fn pool_size_absent_or_zero_is_disabled() {
+    with_env(&[("SANDBOX_DOCKER_WARM_POOL_SIZE", None)], || {
+        assert_eq!(configured_pool_size().unwrap(), 0);
+    });
+    with_env(&[("SANDBOX_DOCKER_WARM_POOL_SIZE", Some(""))], || {
+        assert_eq!(configured_pool_size().unwrap(), 0);
+    });
+    with_env(&[("SANDBOX_DOCKER_WARM_POOL_SIZE", Some("0"))], || {
+        assert_eq!(configured_pool_size().unwrap(), 0);
+    });
+}
+
+#[test]
+fn pool_size_parses_and_rejects_garbage() {
+    with_env(&[("SANDBOX_DOCKER_WARM_POOL_SIZE", Some("4"))], || {
+        assert_eq!(configured_pool_size().unwrap(), 4);
+    });
+    with_env(&[("SANDBOX_DOCKER_WARM_POOL_SIZE", Some("x"))], || {
+        assert!(matches!(
+            configured_pool_size(),
+            Err(SandboxError::Validation(_))
+        ));
+    });
+}
+
+#[test]
+fn memory_required_when_enabled() {
+    // Enabled but no memory → hard error (never a silent 0).
+    with_env(
+        &[
+            ("SANDBOX_DOCKER_WARM_POOL_SIZE", Some("2")),
+            ("SANDBOX_DOCKER_WARM_MEMORY_MB", None),
+        ],
+        || {
+            assert!(matches!(
+                configured_warm_memory_mb(2),
+                Err(SandboxError::Validation(_))
+            ));
+        },
+    );
+    // Disabled → 0, no error.
+    with_env(&[], || {
+        assert_eq!(configured_warm_memory_mb(0).unwrap(), 0);
+    });
+    // Enabled + set → parsed.
+    with_env(&[("SANDBOX_DOCKER_WARM_MEMORY_MB", Some("2048"))], || {
+        assert_eq!(configured_warm_memory_mb(2).unwrap(), 2048);
+    });
+    // Enabled + explicit 0 → hard error.
+    with_env(&[("SANDBOX_DOCKER_WARM_MEMORY_MB", Some("0"))], || {
+        assert!(matches!(
+            configured_warm_memory_mb(2),
+            Err(SandboxError::Validation(_))
+        ));
+    });
+}
+
+#[test]
+fn reserved_host_memory_is_pool_times_memory_factor_one() {
+    // Disabled → 0.
+    with_env(&[("SANDBOX_DOCKER_WARM_POOL_SIZE", None)], || {
+        assert_eq!(reserved_host_memory_mb().unwrap(), 0);
+    });
+    // 4 × 2048 = 8192 (factor 1, distinct from Firecracker's factor 2).
+    with_env(
+        &[
+            ("SANDBOX_DOCKER_WARM_POOL_SIZE", Some("4")),
+            ("SANDBOX_DOCKER_WARM_MEMORY_MB", Some("2048")),
+        ],
+        || {
+            assert_eq!(reserved_host_memory_mb().unwrap(), 8192);
+        },
+    );
+    // Enabled without memory → error (fail-closed, never a silent under-reserve).
+    with_env(
+        &[
+            ("SANDBOX_DOCKER_WARM_POOL_SIZE", Some("2")),
+            ("SANDBOX_DOCKER_WARM_MEMORY_MB", None),
+        ],
+        || {
+            assert!(reserved_host_memory_mb().is_err());
+        },
+    );
+}
+
+#[test]
+fn entry_max_age_defaults_and_parses() {
+    with_env(&[("SANDBOX_DOCKER_WARM_MAX_AGE_SECS", None)], || {
+        assert_eq!(
+            configured_entry_max_age().unwrap(),
+            Duration::from_secs(3600)
+        );
+    });
+    with_env(&[("SANDBOX_DOCKER_WARM_MAX_AGE_SECS", Some("60"))], || {
+        assert_eq!(configured_entry_max_age().unwrap(), Duration::from_secs(60));
+    });
+    with_env(
+        &[("SANDBOX_DOCKER_WARM_MAX_AGE_SECS", Some("nope"))],
+        || {
+            assert!(configured_entry_max_age().is_err());
+        },
+    );
+}
+
+#[test]
+fn cpu_defaults_zero_and_parses() {
+    with_env(&[("SANDBOX_DOCKER_WARM_CPU_CORES", None)], || {
+        assert_eq!(configured_warm_cpu_cores().unwrap(), 0);
+    });
+    with_env(&[("SANDBOX_DOCKER_WARM_CPU_CORES", Some("4"))], || {
+        assert_eq!(configured_warm_cpu_cores().unwrap(), 4);
+    });
+}

--- a/sandbox-runtime/src/docker_warm/types.rs
+++ b/sandbox-runtime/src/docker_warm/types.rs
@@ -1,0 +1,178 @@
+//! Warm-serving data types (pooled container, claim request/result, typed
+//! miss/outcome). Mirrors [`crate::firecracker_warm::types`].
+
+/// One pre-created, pre-started, bootstrapped container sitting in the ready
+/// pool. Named `sidecar-warm-<seq>` and labelled `tangle.warm-pool=1` so the
+/// startup reconcile can find it; renamed onto the real `sidecar-<sandbox_id>`
+/// at claim.
+#[derive(Debug, Clone)]
+pub(crate) struct WarmContainer {
+    /// Docker container id (stable across the claim rename; the rename targets
+    /// it by id, not by name).
+    pub container_id: String,
+    /// Auth token baked into the container's env at seed. It is a random
+    /// operator↔sidecar secret (not request-derived), so it is poolable: the
+    /// claim copies it verbatim into the store record — no container mutation.
+    pub token: String,
+    /// Monotonic seed sequence (for logs / label provenance). The pooled image
+    /// is not tracked per-entry: it is fixed for the process's lifetime by the
+    /// settings, and cross-restart staleness is handled by the reap-always
+    /// startup reconcile.
+    pub seq: u64,
+    /// When the container was seeded (unix seconds), for age eviction.
+    pub created_at: u64,
+}
+
+/// The request shape the claim gate evaluates — the subset of
+/// [`CreateSandboxParams`] the pool needs. Env/labels/timeouts are bound by the
+/// caller's record insert, not here.
+#[derive(Debug, Clone)]
+pub(crate) struct DockerWarmClaimRequest {
+    /// Freshly-minted sandbox id the claimed container is renamed onto.
+    pub sandbox_id: String,
+    /// Effective image (request image, or the operator default when empty).
+    pub image: String,
+    pub cpu_cores: u64,
+    pub memory_mb: u64,
+    /// Whether SSH was requested (warm seeds with SSH disabled).
+    pub ssh_enabled: bool,
+    /// Request base env JSON (must match the pooled base env).
+    pub env_json: String,
+    /// Request user env JSON (must be empty — Docker env is immutable).
+    pub user_env_json: String,
+    /// Request capabilities JSON (must match the pooled capabilities).
+    pub capabilities_json: String,
+    /// Number of extra ports requested (must be zero — port bindings are
+    /// create-time immutable on Docker).
+    pub extra_ports_len: usize,
+}
+
+/// Everything the create path needs to finish a warm claim: the reused
+/// container id + baked token, plus the endpoint read back from the
+/// already-started container.
+#[derive(Debug, Clone)]
+pub(crate) struct DockerWarmClaim {
+    pub container_id: String,
+    pub token: String,
+    pub sidecar_url: String,
+    pub sidecar_port: u16,
+    pub ssh_port: Option<u16>,
+    pub extra_ports: std::collections::HashMap<u16, u16>,
+}
+
+/// Resolved endpoint of a claimed (renamed) container, read back from Docker.
+#[derive(Debug, Clone)]
+pub(crate) struct ClaimResolved {
+    pub sidecar_url: String,
+    pub sidecar_port: u16,
+    pub ssh_port: Option<u16>,
+    pub extra_ports: std::collections::HashMap<u16, u16>,
+}
+
+/// A downstream failure of the claim's await stages (after the container was
+/// popped from the pool). Every variant maps to a typed [`DockerWarmMiss`]; the
+/// container is reaped (it may already be renamed and cannot return to the pool)
+/// and the caller cold-falls-back.
+#[derive(Debug)]
+pub(crate) enum ClaimFailure {
+    Rename(String),
+    PortResolve(String),
+    Unhealthy(String),
+}
+
+/// Typed warm-miss reason. Logged by the create path before the designed
+/// fallback to cold boot. Mirrors [`crate::firecracker_warm::WarmMiss`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DockerWarmMiss {
+    /// `SANDBOX_DOCKER_WARM_POOL_SIZE` is 0/unset.
+    Disabled,
+    /// Pool enabled but no container is ready yet (seeding in flight).
+    NotReady,
+    /// Pool enabled, nothing ready and nothing seeding (all seeds failing).
+    Empty,
+    /// Request names an image other than the pooled one.
+    ImageMismatch { requested: String, pooled: String },
+    /// Request asks for cpu cores other than the pooled shape.
+    CpuMismatch { requested: u64, pooled: u64 },
+    /// Request asks for memory other than the pooled shape.
+    MemoryMismatch { requested: u64, pooled: u64 },
+    /// Request enabled SSH; warm seeds with SSH disabled.
+    SshRequested,
+    /// Request carries user env; Docker env is create-time immutable.
+    UserEnvPresent,
+    /// Request's base env differs from the pooled base env.
+    BaseEnvMismatch,
+    /// Request's capabilities differ from the pooled capabilities.
+    CapabilitiesMismatch,
+    /// Request asks for extra ports; Docker port bindings are immutable.
+    ExtraPortsRequested,
+    /// Handoff rename failed; the container was reaped.
+    RenameFailed(String),
+    /// Post-rename port readback failed; the container was reaped.
+    PortResolveFailed(String),
+    /// The pooled sidecar was unhealthy at claim; the container was reaped.
+    Unhealthy(String),
+}
+
+impl DockerWarmMiss {
+    pub(crate) fn from_claim_failure(failure: ClaimFailure) -> Self {
+        match failure {
+            ClaimFailure::Rename(e) => DockerWarmMiss::RenameFailed(e),
+            ClaimFailure::PortResolve(e) => DockerWarmMiss::PortResolveFailed(e),
+            ClaimFailure::Unhealthy(e) => DockerWarmMiss::Unhealthy(e),
+        }
+    }
+}
+
+impl std::fmt::Display for DockerWarmMiss {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DockerWarmMiss::Disabled => {
+                write!(f, "warm pool disabled (SANDBOX_DOCKER_WARM_POOL_SIZE=0)")
+            }
+            DockerWarmMiss::NotReady => write!(f, "no warm container ready (seeding in flight)"),
+            DockerWarmMiss::Empty => {
+                write!(f, "warm pool empty (no ready container, none seeding)")
+            }
+            DockerWarmMiss::ImageMismatch { requested, pooled } => write!(
+                f,
+                "image mismatch (requested {requested:?}, pooled {pooled:?})"
+            ),
+            DockerWarmMiss::CpuMismatch { requested, pooled } => write!(
+                f,
+                "cpu_cores mismatch (requested {requested}, pooled {pooled})"
+            ),
+            DockerWarmMiss::MemoryMismatch { requested, pooled } => write!(
+                f,
+                "memory_mb mismatch (requested {requested}, pooled {pooled})"
+            ),
+            DockerWarmMiss::SshRequested => {
+                write!(f, "ssh requested (warm containers seed with ssh disabled)")
+            }
+            DockerWarmMiss::UserEnvPresent => write!(
+                f,
+                "user env present (Docker container env is create-time immutable)"
+            ),
+            DockerWarmMiss::BaseEnvMismatch => {
+                write!(f, "base env differs from the pooled warm base env")
+            }
+            DockerWarmMiss::CapabilitiesMismatch => {
+                write!(f, "capabilities differ from the pooled warm capabilities")
+            }
+            DockerWarmMiss::ExtraPortsRequested => write!(
+                f,
+                "extra ports requested (Docker port bindings are create-time immutable)"
+            ),
+            DockerWarmMiss::RenameFailed(e) => write!(f, "warm handoff rename failed: {e}"),
+            DockerWarmMiss::PortResolveFailed(e) => write!(f, "warm port readback failed: {e}"),
+            DockerWarmMiss::Unhealthy(e) => write!(f, "warm sidecar unhealthy at claim: {e}"),
+        }
+    }
+}
+
+/// Outcome of a warm-claim attempt.
+#[derive(Debug)]
+pub(crate) enum DockerWarmOutcome {
+    Claimed(DockerWarmClaim),
+    Miss(DockerWarmMiss),
+}

--- a/sandbox-runtime/src/lib.rs
+++ b/sandbox-runtime/src/lib.rs
@@ -9,6 +9,7 @@ pub mod auth;
 pub mod chat_state;
 pub mod circuit_breaker;
 pub mod contracts;
+mod docker_warm;
 pub mod error;
 pub mod firecracker;
 mod firecracker_dnat;

--- a/sandbox-runtime/src/reaper/reconcile.rs
+++ b/sandbox-runtime/src/reaper/reconcile.rs
@@ -17,6 +17,15 @@ pub async fn reconcile_on_startup() {
         }
     };
 
+    // Reap Docker warm-pool containers orphaned by a previous operator process,
+    // BEFORE the records loop / any create that could seed a fresh pool. Warm
+    // containers never enter the store, so the records loop below never sees
+    // them; this label-based sweep is the only thing that reclaims them (and it
+    // leaves any warm container already claimed into a live store record — the
+    // data-loss guard). Mirrors the Firecracker `reconcile_warm_orphans()` call
+    // above, which stays untouched.
+    crate::docker_warm::reconcile_docker_warm_orphans(&builder).await;
+
     let records = match sandboxes().and_then(|s| s.values()) {
         Ok(v) => v,
         Err(err) => {

--- a/sandbox-runtime/src/runtime/admission.rs
+++ b/sandbox-runtime/src/runtime/admission.rs
@@ -123,12 +123,15 @@ pub(crate) fn enforce_store_admission(
     let scan = scan_records_for_admission(&records, reused_sandbox_id);
 
     if memory_budget_enabled {
-        // The warm pool's standing footprint (templates + pre-restored
-        // entries) never enters the store, so reserve it here or an enabled
-        // pool silently over-commits host RAM. Only read when the budget is
-        // on — zero-cost otherwise, as before. (No CPU analogue: warm VMs
-        // pin host RAM but time-share CPU.)
-        let reserved_mb = crate::firecracker_warm::reserved_host_memory_mb()?;
+        // The warm pools' standing footprint (Firecracker templates +
+        // pre-restored entries, and Docker warm containers) never enters the
+        // store, so reserve it here or an enabled pool silently over-commits
+        // host RAM. Only read when the budget is on — zero-cost otherwise, as
+        // before. On any given host only one backend's pool is enabled, so
+        // exactly one term is nonzero; summing both stays fail-closed. (No CPU
+        // analogue: warm inventory pins host RAM but time-shares CPU.)
+        let reserved_mb = crate::firecracker_warm::reserved_host_memory_mb()?
+            .saturating_add(crate::docker_warm::reserved_host_memory_mb()?);
         check_host_memory_budget(
             scan.running_memory_mb,
             incoming_memory_mb,

--- a/sandbox-runtime/src/runtime/docker_create.rs
+++ b/sandbox-runtime/src/runtime/docker_create.rs
@@ -29,10 +29,228 @@ pub(crate) const WORKSPACE_BOOTSTRAP_ROOT_CMD: &str = "mkdir -p /home/agent/.ope
 pub(crate) const WORKSPACE_BOOTSTRAP_AGENT_FALLBACK_CMD: &str =
     "mkdir -p /home/agent/.opencode-home/.config";
 
-/// Docker-backed create with per-stage [`CreateTimings`]. The shared entry
-/// point (`create_sidecar_with_token`) fills the permit/admission/total
-/// fields; this function fills every Docker stage it passes through.
+/// Post-start workspace bootstrap, shared by the cold create path and the warm
+/// pool's seed.
+///
+/// Two jobs, historically two exec round-trips (each also rebuilding a Docker
+/// client — connect + ping — via `docker_exec_as_user`):
+///   1. as root:  chown -R agent:agent /home/agent — repair image builds that
+///      leave workspace dirs root-owned, so the sidecar's demoted (uid 1000)
+///      process doesn't crash with EACCES on mkdir .local;
+///   2. as agent: mkdir -p ~/.opencode-home/.config — pre-create dirs the
+///      sidecar's root process cannot create itself (cap_drop=ALL leaves root
+///      without DAC_OVERRIDE, so it cannot write into agent-owned directories).
+///
+/// Merged into ONE root exec on the already-connected client (see
+/// [`WORKSPACE_BOOTSTRAP_ROOT_CMD`] for why mkdir-then-chown covers the repair
+/// path). When its `test -d` verification fails — an image that ships an
+/// agent-owned /home/agent without the dirs — fall back to the pre-merge
+/// agent-user mkdir. Net round-trips: 1 on the repair path and on images with
+/// the dirs baked in; 2 otherwise. Failures stay warn-and-continue.
+pub(crate) async fn run_workspace_bootstrap(
+    exec_client: &docktopus::bollard::Docker,
+    container_id: &str,
+    sandbox_id: &str,
+) {
+    let bootstrap_verified = match docker_exec_as_user_with_client(
+        exec_client,
+        container_id,
+        "root",
+        WORKSPACE_BOOTSTRAP_ROOT_CMD,
+    )
+    .await
+    {
+        Ok(r) if r.exit_code == 0 => true,
+        Ok(r) => {
+            tracing::info!(
+                sandbox_id,
+                exit_code = r.exit_code,
+                stderr = %r.stderr,
+                "merged workspace bootstrap could not verify dirs; falling back to agent-user mkdir"
+            );
+            false
+        }
+        Err(e) => {
+            tracing::warn!(
+                sandbox_id,
+                error = %e,
+                "merged workspace bootstrap failed; falling back to agent-user mkdir"
+            );
+            false
+        }
+    };
+    if !bootstrap_verified {
+        match docker_exec_as_user_with_client(
+            exec_client,
+            container_id,
+            "agent",
+            WORKSPACE_BOOTSTRAP_AGENT_FALLBACK_CMD,
+        )
+        .await
+        {
+            Ok(r) if r.exit_code != 0 => {
+                tracing::warn!(
+                    sandbox_id,
+                    exit_code = r.exit_code,
+                    stderr = %r.stderr,
+                    "opencode-home pre-creation returned non-zero (continuing)"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    sandbox_id,
+                    error = %e,
+                    "opencode-home pre-creation failed (continuing)"
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Docker-backed create: try the warm pool first, then cold.
+///
+/// The warm claim only applies to a fresh create — both `token_override` and
+/// `sandbox_id_override` are `None`. Recreate, image-upgrade, and
+/// snapshot-restore paths pass an override (they need a specific token/id and
+/// their own store-rollback semantics) and go straight to
+/// [`cold_create_sidecar_docker`].
 pub(crate) async fn create_sidecar_docker(
+    request: &CreateSandboxParams,
+    token_override: Option<&str>,
+    sandbox_id_override: Option<&str>,
+) -> Result<(SandboxRecord, CreateTimings)> {
+    if token_override.is_none() && sandbox_id_override.is_none() {
+        let sandbox_id = next_sandbox_id();
+        let claim_stage = std::time::Instant::now();
+        let outcome = crate::docker_warm::claim_docker_warm(request, &sandbox_id).await?;
+        let warm_claim_elapsed = claim_stage.elapsed();
+        match outcome {
+            crate::docker_warm::DockerWarmOutcome::Claimed(claim) => {
+                return finish_warm_claim_docker(request, claim, sandbox_id, warm_claim_elapsed)
+                    .await;
+            }
+            crate::docker_warm::DockerWarmOutcome::Miss(miss) => {
+                tracing::debug!(
+                    sandbox_id = %sandbox_id,
+                    reason = %miss,
+                    "docker warm-pool miss; falling back to cold create"
+                );
+            }
+        }
+    }
+    cold_create_sidecar_docker(request, token_override, sandbox_id_override).await
+}
+
+/// Finish a warm claim: build the store record binding all per-request state
+/// (owner/name/agent_identifier/service_id/metadata/timeouts) onto the reused
+/// warm container id + baked warm token + resolved endpoint, insert it Running,
+/// and record metrics. Mirrors the record-build + insert tail of
+/// [`cold_create_sidecar_docker`]. The token MUST be the baked warm token
+/// (`claim.token`): it is inside the container's immutable env, so a fresh token
+/// would not match what the sidecar authenticates against.
+async fn finish_warm_claim_docker(
+    request: &CreateSandboxParams,
+    claim: crate::docker_warm::DockerWarmClaim,
+    sandbox_id: String,
+    warm_claim_elapsed: std::time::Duration,
+) -> Result<(SandboxRecord, CreateTimings)> {
+    let config = SidecarRuntimeConfig::load();
+    let mut timings = CreateTimings {
+        warm_claim: Some(warm_claim_elapsed),
+        ..Default::default()
+    };
+
+    // Shape gate guarantees the request's image equals the pooled image; resolve
+    // it the same way the cold path does for `original_image`.
+    let original_image = if request.image.is_empty() {
+        config.image.clone()
+    } else {
+        request.image.clone()
+    };
+
+    let metadata = parse_json_object(&request.metadata_json, "metadata_json")?;
+    let snapshot_destination = metadata
+        .as_ref()
+        .and_then(|v| v.get("snapshot_destination"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    let now = crate::util::now_ts();
+    let idle_timeout = config.effective_idle_timeout(request.idle_timeout_seconds);
+    let max_lifetime = config.effective_max_lifetime(request.max_lifetime_seconds);
+    let container_id = claim.container_id.clone();
+
+    let record = SandboxRecord {
+        id: sandbox_id.clone(),
+        container_id: claim.container_id,
+        sidecar_url: claim.sidecar_url,
+        sidecar_port: claim.sidecar_port,
+        ssh_port: claim.ssh_port,
+        token: claim.token,
+        created_at: now,
+        cpu_cores: request.cpu_cores,
+        memory_mb: request.memory_mb,
+        state: SandboxState::Running,
+        idle_timeout_seconds: idle_timeout,
+        max_lifetime_seconds: max_lifetime,
+        last_activity_at: now,
+        stopped_at: None,
+        snapshot_image_id: None,
+        snapshot_s3_url: None,
+        container_removed_at: None,
+        image_removed_at: None,
+        original_image,
+        base_env_json: request.env_json.clone(),
+        user_env_json: request.user_env_json.clone(),
+        snapshot_destination,
+        tee_deployment_id: None,
+        tee_metadata_json: None,
+        tee_attestation_json: None,
+        name: request.name.clone(),
+        agent_identifier: request.agent_identifier.clone(),
+        metadata_json: request.metadata_json.clone(),
+        disk_gb: request.disk_gb,
+        stack: request.stack.clone(),
+        owner: request.owner.clone(),
+        service_id: request.service_id,
+        tee_config: None,
+        extra_ports: claim.extra_ports,
+        ssh_login_user: None,
+        ssh_authorized_keys: Vec::new(),
+        capabilities_json: request.capabilities_json.clone(),
+    };
+
+    let insert = async {
+        let stage = std::time::Instant::now();
+        let mut sealed = record.clone();
+        seal_record(&mut sealed)?;
+        sandboxes()?.insert(sandbox_id.clone(), sealed)?;
+        timings.store_insert = Some(stage.elapsed());
+        crate::metrics::metrics().record_sandbox_created(request.cpu_cores, request.memory_mb);
+        Ok::<SandboxRecord, SandboxError>(record.clone())
+    }
+    .await;
+
+    match insert {
+        Ok(ready_record) => Ok((ready_record, timings)),
+        Err(err) => {
+            // The container was already renamed onto sandbox_id and cannot
+            // return to the pool. It still carries the warm label, so the next
+            // restart reconcile would reap it, but reap now to avoid holding
+            // RAM + a host port until then.
+            if let Ok(builder) = docker_builder().await {
+                cleanup_orphaned_container(&builder, &container_id).await;
+            }
+            Err(err)
+        }
+    }
+}
+
+/// Docker-backed cold create with per-stage [`CreateTimings`]. The shared entry
+/// point (`create_sidecar_with_token`) fills the permit/admission/total fields;
+/// this function fills every Docker stage it passes through.
+pub(crate) async fn cold_create_sidecar_docker(
     request: &CreateSandboxParams,
     token_override: Option<&str>,
     sandbox_id_override: Option<&str>,
@@ -162,79 +380,9 @@ pub(crate) async fn create_sidecar_docker(
         timings.port_mapping = Some(stage.elapsed());
 
         let stage = std::time::Instant::now();
-        // ── Workspace bootstrap ────────────────────────────────────────────
-        // Two jobs, historically two exec round-trips (each also rebuilding a
-        // Docker client — connect + ping — via `docker_exec_as_user`):
-        //   1. as root:  chown -R agent:agent /home/agent — repair image
-        //      builds that leave workspace dirs root-owned, so the sidecar's
-        //      demoted (uid 1000) process doesn't crash with EACCES on
-        //      mkdir .local;
-        //   2. as agent: mkdir -p ~/.opencode-home/.config — pre-create dirs
-        //      the sidecar's root process cannot create itself (cap_drop=ALL
-        //      leaves root without DAC_OVERRIDE, so it cannot write into
-        //      agent-owned directories).
-        // Merged into ONE root exec on the already-connected `builder` client
-        // (see WORKSPACE_BOOTSTRAP_ROOT_CMD for why mkdir-then-chown covers
-        // the repair path). When its `test -d` verification fails — an image
-        // that ships an agent-owned /home/agent without the dirs — fall back
-        // to the pre-merge agent-user mkdir. Net round-trips: 1 on the repair
-        // path and on images with the dirs baked in; 2 (unchanged) otherwise.
-        // Failures stay warn-and-continue, exactly as before.
-        let exec_client = builder.client();
-        let bootstrap_verified = match docker_exec_as_user_with_client(
-            &exec_client,
-            &container_id,
-            "root",
-            WORKSPACE_BOOTSTRAP_ROOT_CMD,
-        )
-        .await
-        {
-            Ok(r) if r.exit_code == 0 => true,
-            Ok(r) => {
-                tracing::info!(
-                    sandbox_id,
-                    exit_code = r.exit_code,
-                    stderr = %r.stderr,
-                    "merged workspace bootstrap could not verify dirs; falling back to agent-user mkdir"
-                );
-                false
-            }
-            Err(e) => {
-                tracing::warn!(
-                    sandbox_id,
-                    error = %e,
-                    "merged workspace bootstrap failed; falling back to agent-user mkdir"
-                );
-                false
-            }
-        };
-        if !bootstrap_verified {
-            match docker_exec_as_user_with_client(
-                &exec_client,
-                &container_id,
-                "agent",
-                WORKSPACE_BOOTSTRAP_AGENT_FALLBACK_CMD,
-            )
-            .await
-            {
-                Ok(r) if r.exit_code != 0 => {
-                    tracing::warn!(
-                        sandbox_id,
-                        exit_code = r.exit_code,
-                        stderr = %r.stderr,
-                        "opencode-home pre-creation returned non-zero (continuing)"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        sandbox_id,
-                        error = %e,
-                        "opencode-home pre-creation failed (continuing)"
-                    );
-                }
-                _ => {}
-            }
-        }
+        // Workspace bootstrap (chown + pre-create ~/.opencode-home) on the
+        // already-connected client — see `run_workspace_bootstrap`.
+        run_workspace_bootstrap(&builder.client(), &container_id, &sandbox_id).await;
         timings.bootstrap_exec = Some(stage.elapsed());
 
         let now = crate::util::now_ts();

--- a/sandbox-runtime/src/runtime/timings.rs
+++ b/sandbox-runtime/src/runtime/timings.rs
@@ -41,6 +41,11 @@ pub struct CreateTimings {
     pub bootstrap_exec: Option<Duration>,
     /// Record seal + persistent-store insert.
     pub store_insert: Option<Duration>,
+    /// Docker warm-pool claim overhead (rename + port readback + health
+    /// probe). Present only on a warm hit — the `container_create` /
+    /// `container_start` / `bootstrap_exec` stages it replaces are `None`
+    /// because they were pre-paid by the background refill.
+    pub warm_claim: Option<Duration>,
     /// SSH readiness bootstrap; only present when `ssh_enabled`.
     pub ssh_ready: Option<Duration>,
     /// End-to-end create as observed by the caller, including permit wait.
@@ -70,6 +75,7 @@ impl CreateTimings {
         push_stage(&mut out, "container_start", self.container_start);
         push_stage(&mut out, "port_mapping", self.port_mapping);
         push_stage(&mut out, "bootstrap_exec", self.bootstrap_exec);
+        push_stage(&mut out, "warm_claim", self.warm_claim);
         push_stage(&mut out, "store_insert", self.store_insert);
         push_stage(&mut out, "ssh_ready", self.ssh_ready);
         out

--- a/sandbox-runtime/tests/lifecycle_bench.rs
+++ b/sandbox-runtime/tests/lifecycle_bench.rs
@@ -89,11 +89,26 @@ fn image_present(image: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn setup_env(state_dir: &TempDir, image: &str) {
-    // SAFETY: this is the only test in this binary (own process), and the env
-    // is set before the first `SidecarRuntimeConfig::load()` / store access.
+/// One state dir shared by every bench in this binary, lived for the whole
+/// process. The `SANDBOXES` store is a process-global `OnceCell` bound to
+/// `BLUEPRINT_STATE_DIR` on FIRST access — so a per-test `TempDir` (dropped at
+/// test end) would leave a second bench in the same process writing to a
+/// deleted path (`storage error: No such file or directory`). A single dir that
+/// never drops keeps that OnceCell valid for all benches; each bench uses fresh
+/// sandbox ids, so their records never collide.
+fn bench_state_dir() -> &'static std::path::Path {
+    static DIR: std::sync::OnceLock<TempDir> = std::sync::OnceLock::new();
+    DIR.get_or_init(|| TempDir::new().expect("temp state dir"))
+        .path()
+}
+
+fn setup_env(image: &str) {
+    // SAFETY: every bench in this binary sets the env under `ENV_LOCK` before
+    // the first `SidecarRuntimeConfig::load()` / store access, and they share
+    // one process-lived state dir (`bench_state_dir`) so the store `OnceCell`
+    // stays valid across tests.
     unsafe {
-        std::env::set_var("BLUEPRINT_STATE_DIR", state_dir.path());
+        std::env::set_var("BLUEPRINT_STATE_DIR", bench_state_dir());
         std::env::set_var("SIDECAR_IMAGE", image);
         // Keep registry pulls out of the measured loop: the image must be
         // local (checked above), so `image_pull` measures only the local
@@ -195,7 +210,6 @@ async fn lifecycle_create_ready_delete_bench() {
          (or set LIFECYCLE_BENCH_IMAGE)"
     );
 
-    let state_dir = TempDir::new().expect("temp state dir");
     {
         // Serialize env mutation, matching this dir's convention for
         // env-mutating tests. We use a local static (like ssh_e2e's
@@ -205,12 +219,11 @@ async fn lifecycle_create_ready_delete_bench() {
         //
         // Guard scoped to the env mutation only (NOT held across awaits — a
         // std Mutex guard across an await is a clippy denial and a deadlock
-        // risk): this binary has a single #[ignore] test, so nothing else
-        // reads the env before the first SidecarRuntimeConfig::load() inside
-        // the loop below. A future second test in this binary must acquire the
-        // same lock around its own setup_env to stay race-free.
+        // risk). Both benches in this binary acquire this same lock around
+        // their setup_env, and they share `bench_state_dir()`, so the store
+        // OnceCell stays valid whichever bench runs first.
         let _env_guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-        setup_env(&state_dir, &image);
+        setup_env(&image);
     }
 
     let reps = bench_reps();
@@ -346,12 +359,11 @@ async fn warm_vs_cold_create_ready_bench() {
         "RUN_LIFECYCLE_BENCH=1 but image {image} is not local; run `docker pull {image}`"
     );
 
-    let state_dir = TempDir::new().expect("temp state dir");
     {
         let _env_guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-        setup_env(&state_dir, &image);
+        setup_env(&image);
         // Start with the pool disabled for the cold baseline.
-        // SAFETY: single test in its own binary section, guarded by ENV_LOCK.
+        // SAFETY: env mutation guarded by ENV_LOCK; shared bench state dir.
         unsafe {
             std::env::remove_var("SANDBOX_DOCKER_WARM_POOL_SIZE");
         }

--- a/sandbox-runtime/tests/lifecycle_bench.rs
+++ b/sandbox-runtime/tests/lifecycle_bench.rs
@@ -314,3 +314,165 @@ async fn lifecycle_create_ready_delete_bench() {
         delete,
     ]);
 }
+
+/// The docker warm-pool proof-of-win: measure `create_to_ready` for the cold
+/// path (pool disabled) vs a warm hit (pool pre-seeded), in one process.
+///
+/// A warm hit is identified structurally — `timings.warm_claim.is_some()` and
+/// the `container_create` / `container_start` / `bootstrap_exec` stages are
+/// `None` because they were pre-paid by the background refill. The pool shape is
+/// set to exactly match [`bench_params`] (cpu 2, mem 2048, default image, no
+/// user env, no extra ports, ssh disabled) so the create qualifies.
+///
+/// ```bash
+/// docker pull ghcr.io/tangle-network/blueprint-sidecar:all-harness
+/// RUN_LIFECYCLE_BENCH=1 cargo test -p sandbox-runtime --test lifecycle_bench \
+///     warm_vs_cold -- --ignored --nocapture
+/// ```
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "real-docker warm-pool bench; set RUN_LIFECYCLE_BENCH=1 and run with --ignored on a host with Docker"]
+async fn warm_vs_cold_create_ready_bench() {
+    if !bench_enabled() {
+        eprintln!("SKIP: set RUN_LIFECYCLE_BENCH=1 to run the warm-vs-cold bench");
+        return;
+    }
+    assert!(
+        docker_available(),
+        "RUN_LIFECYCLE_BENCH=1 but no reachable Docker daemon (`docker info` failed)"
+    );
+    let image = bench_image();
+    assert!(
+        image_present(&image),
+        "RUN_LIFECYCLE_BENCH=1 but image {image} is not local; run `docker pull {image}`"
+    );
+
+    let state_dir = TempDir::new().expect("temp state dir");
+    {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        setup_env(&state_dir, &image);
+        // Start with the pool disabled for the cold baseline.
+        // SAFETY: single test in its own binary section, guarded by ENV_LOCK.
+        unsafe {
+            std::env::remove_var("SANDBOX_DOCKER_WARM_POOL_SIZE");
+        }
+    }
+
+    let reps = bench_reps();
+    reap_warm_leftovers();
+
+    // ── Phase A: cold baseline (pool disabled) ──
+    eprintln!("=== warm-vs-cold: image={image} reps={reps} — phase A (cold) ===");
+    let mut cold = StageSeries::new("cold_create_to_ready");
+    for rep in 0..=reps {
+        let warmup = rep == 0;
+        let params = bench_params(&image, 1000 + rep);
+        let rep_start = Instant::now();
+        let (record, _a, timings) = create_sidecar_timed(&params, None)
+            .await
+            .unwrap_or_else(|e| panic!("cold rep {rep}: create failed: {e}"));
+        let ready = wait_for_sidecar_health(&record.sidecar_url, 120).await;
+        let ready_elapsed = rep_start.elapsed();
+        let _ = delete_sidecar(&record, None).await;
+        assert!(ready, "cold rep {rep}: sidecar never healthy");
+        assert!(
+            timings.warm_claim.is_none(),
+            "cold rep {rep}: pool disabled but a warm claim fired"
+        );
+        eprintln!(
+            "cold rep {rep}{}: create_to_ready={:.1}ms [{}]",
+            if warmup { " (warmup, discarded)" } else { "" },
+            ready_elapsed.as_secs_f64() * 1e3,
+            timings.summary(),
+        );
+        if !warmup {
+            cold.push(Some(ready_elapsed));
+        }
+    }
+
+    // ── Phase B: warm hits (pool enabled, shape matches bench_params) ──
+    {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: guarded by ENV_LOCK; the warm-pool config helpers read env
+        // live on the next create.
+        unsafe {
+            std::env::set_var("SANDBOX_DOCKER_WARM_POOL_SIZE", "2");
+            std::env::set_var("SANDBOX_DOCKER_WARM_MEMORY_MB", "2048");
+            std::env::set_var("SANDBOX_DOCKER_WARM_CPU_CORES", "2");
+            std::env::set_var("SANDBOX_DOCKER_WARM_IMAGE", &image);
+        }
+    }
+    eprintln!("=== warm-vs-cold: phase B (warm) — priming pool ===");
+
+    let mut warm = StageSeries::new("warm_create_to_ready");
+    let mut warm_claim = StageSeries::new("warm_claim");
+    let mut warm_total = StageSeries::new("warm_create_total");
+    let mut warm_health = StageSeries::new("warm_health_ready");
+    let mut collected = 0usize;
+    let max_attempts = reps * 6 + 24;
+    for attempt in 0..max_attempts {
+        if collected >= reps {
+            break;
+        }
+        // Let the background refill land (~1s create + bootstrap + health).
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+        let params = bench_params(&image, 2000 + attempt);
+        let rep_start = Instant::now();
+        let (record, _a, timings) = create_sidecar_timed(&params, None)
+            .await
+            .unwrap_or_else(|e| panic!("warm attempt {attempt}: create failed: {e}"));
+        let health_start = Instant::now();
+        let ready = wait_for_sidecar_health(&record.sidecar_url, 120).await;
+        let health_elapsed = health_start.elapsed();
+        let ready_elapsed = rep_start.elapsed();
+        let _ = delete_sidecar(&record, None).await;
+        assert!(ready, "warm attempt {attempt}: sidecar never healthy");
+
+        let hit = timings.warm_claim.is_some();
+        eprintln!(
+            "warm attempt {attempt}: {} create_to_ready={:.1}ms [{}]",
+            if hit { "HIT " } else { "miss" },
+            ready_elapsed.as_secs_f64() * 1e3,
+            timings.summary(),
+        );
+        if hit {
+            warm.push(Some(ready_elapsed));
+            warm_claim.push(timings.warm_claim);
+            warm_total.push(Some(timings.total));
+            warm_health.push(Some(health_elapsed));
+            collected += 1;
+        }
+    }
+
+    reap_warm_leftovers();
+
+    assert!(
+        collected > 0,
+        "no warm hit observed after {max_attempts} attempts — the pool never served a claim"
+    );
+    print_summaries(&[cold, warm, warm_total, warm_claim, warm_health]);
+    eprintln!(
+        "warm hits collected: {collected}/{reps}. A warm hit erases container_create + \
+         container_start + bootstrap_exec from the request path (they are pre-paid by refill)."
+    );
+}
+
+/// Force-remove any warm-pool containers this bench left running (the pool
+/// seeds up to `pool_size` containers that are never claimed). Keyed on the
+/// `tangle.warm-pool` label so it never touches a real sandbox.
+fn reap_warm_leftovers() {
+    let ids = Command::new("docker")
+        .args(["ps", "-aq", "--filter", "label=tangle.warm-pool=1"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .split_whitespace()
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    for id in ids {
+        let _ = Command::new("docker").args(["rm", "-f", &id]).output();
+    }
+}


### PR DESCRIPTION
## What

A **Docker warm-pool** for `sandbox-runtime`: keep `N` pre-created + pre-started + bootstrapped sidecar containers idle and **rename** one onto the real `sandbox_id` per create, instead of cold-booting a container on the request path. It mirrors the existing `firecracker_warm` pool 1:1.

## The measured win

Real Docker, this host, `n=5`, `create_to_ready` end-to-end (the caller-visible number: create returns → sidecar `/health` 200):

| path | p50 | min | max |
|---|---:|---:|---:|
| **cold** (pool off) | **1835 ms** | 1692 | 2005 |
| **warm hit** (pool on) | **41 ms** | 32 | 63 |

That erases **~1794 ms at p50 (~44×)**. A warm hit's stage breakdown is `admission ~0.1ms + warm_claim ~40ms + store_insert ~0.4ms` — the `container_create` / `container_start` / `bootstrap_exec` stages are gone from the request path (pre-paid by the background refill). Post-create `health_ready` is ~0.5ms because the claim already health-probed the sidecar.

(The cold p50 here, ~1.8s, is higher than the ~1.0s reference baseline — Docker `container_create` alone measured ~1.4s on this host at bench time. The relative win is what the pool controls, and it's ≥ the design target of "warm hit < 150ms, delta ≥ 850ms".)

Run it yourself:
```bash
docker pull ghcr.io/tangle-network/blueprint-sidecar:all-harness
RUN_LIFECYCLE_BENCH=1 cargo test -p sandbox-runtime --test lifecycle_bench \
    warm_vs_cold -- --ignored --nocapture
```

## How it stays correct

- **Admission-accounted like a cold boot.** The claim hook sits *inside* the Docker create arm, which the runtime only reaches after `admit_sandbox_resources` (count cap + host memory budget, under the creation permit). So a warm claim counts against `SANDBOX_MAX_COUNT` / the budget identically. The pool's own standing RAM is reserved against `SANDBOX_HOST_MEMORY_BUDGET_MB` as `pool_size × memory_mb` (factor 1), summed alongside the Firecracker reservation.
- **Warm inventory never enters `sandboxes.json`.** Containers are identified by the label `tangle.warm-pool=1` and named `sidecar-warm-<seq>`, so the reaper, GC, `list`, and count-cap all stay correct with **zero changes** — they iterate store records and warm has none.
- **Claim atomicity.** The container is popped out of the ready pool **before any await** (mirrors the FC pool), so two concurrent claims can never receive the same container. Seeding runs in detached tasks **outside** the creation permit so refill never serializes user creates.
- **Restart survival.** `reconcile_docker_warm_orphans` lists warm-labelled containers on startup and reaps every one that is **not** a live store record — the data-loss guard. Wired next to the existing FC `reconcile_warm_orphans` in `reaper::reconcile_on_startup`, and in the pool's lazy init.

## The shape-gate limitation (v1 = default shape only)

Docker bakes container **env and port bindings at `docker create`** and cannot mutate them afterward — the one place Docker breaks the Firecracker analogy (FC injects per-request env over vsock at claim). So v1 serves a warm claim **only** when the request matches the pooled shape; anything else returns a typed miss and falls through to a normal cold create. The gate:

| miss variant | condition |
|---|---|
| `ImageMismatch` | request image ≠ pooled image |
| `CpuMismatch` / `MemoryMismatch` | request cpu/mem ≠ pooled (0 = unset matches) |
| `SshRequested` | ssh enabled (warm seeds ssh-disabled) |
| `UserEnvPresent` | request carries user env |
| `BaseEnvMismatch` | request base env ≠ pooled base env |
| `CapabilitiesMismatch` | request capabilities ≠ pooled |
| `ExtraPortsRequested` | request asks for extra ports |
| `NotReady` / `Empty` / `Disabled` | pool state |
| `RenameFailed` / `PortResolveFailed` / `Unhealthy` | claim-time failure → reap + cold fallback |

The auth **token** is still bound at claim: it's a random operator↔sidecar secret (not request-derived), baked into the container's env at seed and copied verbatim into the store record at claim — **no container mutation**. Widening warm to secret-bearing requests (a sidecar env hot-reload protocol) is an explicit v2 follow-up.

## Deviations from the design (grounded in the real code)

- **bollard is 0.18.1** (via `docktopus 0.4.0-alpha.3`), not 0.20.2 — used the generic `RenameContainerOptions<T>` / `ListContainersOptions<T>` API.
- **No `disk_gb` gate.** The Docker backend never applies `disk_gb` to the container (it's metadata only), so two containers differing only in `disk_gb` are byte-identical — gating on it would only cause needless misses. Omitted and documented.
- **`SANDBOX_DOCKER_WARM_MEMORY_MB` is required when the pool is enabled.** Docker has no default per-container memory (`SANDBOX_MAX_MEMORY_MB` defaults to 0/unlimited), and the budget reservation can't be computed without it — requiring it is the fail-closed choice.
- **Reap-always on restart, not adopt-or-reap.** Matches what the FC pool actually does, is strictly simpler, makes image-staleness a non-issue (stale-image warm containers are reaped and reseeded), and the id-in-store guard also closes FC's crash-mid-claim leak window (label present + renamed + no record → reaped). Re-adopting the pool across a clean same-image restart is a possible follow-up.

## Default OFF

`SANDBOX_DOCKER_WARM_POOL_SIZE` unset/0 disables everything — no engine init, no seeding, no memory reservation — so Firecracker-only and plain-Docker hosts are byte-for-byte unaffected. Knobs documented in `.env.example`.

## Tests / gate (all green locally)

- `cargo test -p sandbox-runtime --features test-utils` — **525 passed, 7 ignored** (24 new docker_warm unit tests: shape-gate table, concurrency/claim-race no-double-serve, reap-on-claim-failure, container-id reuse, reconcile decision, config parsing + reservation).
- `cargo fmt -- --check` clean · `cargo clippy -p sandbox-runtime --all-targets --features test-utils -- -D warnings` clean · `cargo clippy --workspace --tests --examples -- -D warnings` clean · `cargo deny check sources bans advisories` ok.

## Open risks / follow-ups

- **v2 secret injection** (sidecar env hot-reload) to widen warm beyond the default shape — needs a measurement of what fraction of real creates carry user_env / non-default env.
- **Reap-always reseeds the whole pool after every restart** (a few background creates); pool re-adoption would skip that.
- **Pool warm-up latency:** the first few creates after boot/restart see cold misses until the pool fills (each seed ~1s in the background). Acceptable for v1.
