### PR TITLE
fix(deps): use modern AWS TLS client

### DIFF
--- a/sandbox-runtime/Cargo.toml
+++ b/sandbox-runtime/Cargo.toml
@@ -22,8 +22,8 @@ phala-tee-deploy-rs = { version = "0.2.0", optional = true }
 rand = "0.8"
 
 # Cloud TEE backends (optional, gated by features)
-aws-config = { version = "1", features = ["behavior-version-latest"], optional = true }
-aws-sdk-ec2 = { version = "1", optional = true }
+aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "credentials-process", "default-https-client", "rt-tokio", "sso"], optional = true }
+aws-sdk-ec2 = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"], optional = true }
 gcp_auth = { version = "0.12", optional = true }
 
 # TEE quote/attestation verification against hardware roots of trust.


### PR DESCRIPTION
## What changed

Disable the AWS SDK legacy `rustls` feature while retaining its maintained default HTTPS client, Tokio runtime, credentials process, and SSO support. This removes the `rustls 0.21 -> rustls-webpki 0.101.7` path consumed by downstream applications.

## Proof

- `cargo tree -p sandbox-runtime --all-features --target all -e normal,build -i rustls-webpki@0.101.7`: no matching package
- `cargo fmt --all -- --check`: passed
- `cargo check -p sandbox-runtime --all-features --all-targets`: passed
- `cargo test -p sandbox-runtime --all-features --lib`: 562 passed, 0 failed, 2 ignored
- `git merge-tree --write-tree origin/main HEAD`: clean
